### PR TITLE
chore: configure npm auth for the afixt scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  NODE_VERSION: '22'
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+jobs:
+  install:
+    name: Install (verify @afixt auth)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+@afixt:registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+always-auth=true


### PR DESCRIPTION
## Summary
- Wire NPM_TOKEN for @afixt scoped private packages so CI can resolve them.
- Pattern A: committed .npmrc + workflow env

## Test plan
- [ ] CI green (install resolves @afixt/* deps)
- [ ] Local: NPM_TOKEN env var set, install works without WARN about ${NPM_TOKEN}