### PR TITLE
fix(widget): make form-field borders visible (WCAG 1.4.11)

### DIFF
--- a/widget/src/styles.css
+++ b/widget/src/styles.css
@@ -4,6 +4,11 @@
   --afixt-surface: canvas;
   --afixt-text: canvastext;
   --afixt-border: #0000001f;
+
+  /* Form-field borders must stay visible: WCAG 1.4.11 requires 3:1 against
+     the surface, which the faint --afixt-border (decorative, ~1.1:1) fails.
+     #767676 clears 4.5:1 on both white and dark system canvases. */
+  --afixt-field-border: #767676;
   --afixt-danger: #b91c1c;
   --afixt-radius: 8px;
   --afixt-z: 2147483000;
@@ -119,7 +124,7 @@ label.field input,
 label.field textarea {
   font: inherit;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--afixt-border);
+  border: 1px solid var(--afixt-field-border);
   border-radius: 4px;
   background: var(--afixt-surface);
   color: var(--afixt-text);


### PR DESCRIPTION
## What

Restores visible borders on the widget's form fields. They used
`--afixt-border` (`#0000001f`, ~12% opacity), which renders at ~1.1:1 against
the field — effectively invisible, and a WCAG 1.4.11 Non-text Contrast
failure. Adds a dedicated `--afixt-field-border` (`#767676`, ~4.5:1 on both
light and dark system canvas) and points only the field rule at it. The
decorative `--afixt-border` (panel edge, message bubbles) is unchanged.

## Why

Noticed while manually poking the running widget — the fields looked
borderless. For an accessibility-first product this is a real 1.4.11 defect,
not just cosmetic.

## User-facing changes?

- [x] No — purely presentational. No interaction added or changed, no change
      to the accessibility tree or any `getByRole`/`getByLabel` target, so no
      `usecases/` update per ADR-0002.

## Test plan

- [x] `stylelint` clean on the changed file
- [x] widget `eslint` clean
- [x] widget build succeeds; `size-limit` 20.14 kB against the 50 kB budget
- [x] Verified visually in the running widget (Vite dev host, :5175)

https://claude.ai/code/session_01NtPVueNsgGz9xAsNHKuoMW