### PR TITLE
chore(security): replace gitleaks with trufflehog for secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,8 @@ jobs:
           chmod +x osv-scanner
           sudo mv osv-scanner /usr/local/bin/
 
-      - name: Install gitleaks
-        # Release assets embed the version (gitleaks_8.30.1_linux_x64.tar.gz),
-        # so `releases/latest/download/<unversioned>` 404s and curl pipes an
-        # HTML error page into tar. Resolve the tag, then build the real name.
-        run: |
-          set -euo pipefail
-          tag=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)
-          version=${tag#v}
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${tag}/gitleaks_${version}_linux_x64.tar.gz" | tar -xz gitleaks
-          sudo mv gitleaks /usr/local/bin/
+      - name: Install trufflehog
+        run: curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sudo sh -s -- -b /usr/local/bin
 
       - name: Install lychee
         uses: lycheeverse/lychee-action@v2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,15 @@
 npx lint-staged
 npx tsc-files --noEmit
-if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks protect --staged --no-banner
+
+# Secret scan. trufflehog has no staged-diff mode, so scan the working-tree
+# content of the staged files here; the authoritative full-history verified
+# scan runs at pre-push and in CI via `npm run security:secrets`.
+if command -v trufflehog >/dev/null 2>&1; then
+  files=$(git diff --cached --name-only --diff-filter=ACM)
+  if [ -n "$files" ]; then
+    printf '%s\n' "$files" | tr '\n' '\0' \
+      | xargs -0 trufflehog filesystem --results=verified --fail --no-update 2>/dev/null
+  fi
 else
-  echo "warn: gitleaks not installed — run scripts/bootstrap.sh" >&2
+  echo "warn: trufflehog not installed — run scripts/bootstrap.sh" >&2
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ means we adopt the **target** stack without legacy carry-over.
 
 Per issue #1 — the full stack is the mandate, not a suggestion:
 
-- Husky pre-commit (`lint-staged` + `tsc-files --noEmit` +
-  `gitleaks protect --staged`)
+- Husky pre-commit (`lint-staged` + `tsc-files --noEmit` + `trufflehog` secret
+  scan of staged files)
 - Husky commit-msg (`commitlint` / Conventional Commits)
 - Husky pre-push (`npm run check:all`)
 - ESLint flat config (`eslint.config.js`) with `@typescript-eslint`
@@ -114,9 +114,9 @@ Per issue #1 — the full stack is the mandate, not a suggestion:
 - `license-checker-rseidelsohn` (allowlist-only licenses)
 - `size-limit` (build gate)
 - Lighthouse CI (perf/SEO/best-practices; a11y is covered by `a11y-assert`)
-- Security: `npm audit`, `osv-scanner`, `semgrep` (OWASP Top 10), `gitleaks`,
-  `eslint-plugin-no-secrets`, scheduled CodeQL + OWASP Dependency-Check + OWASP
-  ZAP baseline in Actions
+- Security: `npm audit`, `osv-scanner`, `semgrep` (OWASP Top 10), `trufflehog`
+  (secret scanning), `eslint-plugin-no-secrets`, scheduled CodeQL + OWASP
+  Dependency-Check + OWASP ZAP baseline in Actions
 
 **Local gates are preferred over GitHub Actions.** Keep CI as a safety net for
 `--no-verify` / web-UI merges.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ From the repo root:
 - Node 22 (pinned via `.nvmrc` and `engines`)
 - Conventional Commits enforced via Husky `commit-msg`
 - Run `scripts/bootstrap.sh` once to install local tool binaries (semgrep,
-  osv-scanner, gitleaks, lychee) required by pre-push hooks
+  osv-scanner, trufflehog, lychee) required by pre-push hooks
 - All user-facing changes must include a corresponding `.uc.yaml` update
   (enforced by a CI diff gate)

--- a/docs/adr/0001-tooling-stack.md
+++ b/docs/adr/0001-tooling-stack.md
@@ -33,8 +33,9 @@ Adopt the tooling stack described in issue #1 verbatim:
   (HTTP mocking)
 - `@afixt/a11y-assert` at component, E2E, and CI-preview layers
 - `size-limit` and Lighthouse CI budgets
-- Security: `npm audit`, `osv-scanner`, `semgrep` (OWASP Top 10), `gitleaks`,
-  weekly CodeQL, weekly OWASP Dependency-Check
+- Security: `npm audit`, `osv-scanner`, `semgrep` (OWASP Top 10), `trufflehog`
+  (secret scanning — superseded `gitleaks`, see ADR 0008), weekly CodeQL, weekly
+  OWASP Dependency-Check
 - Husky hooks as primary gate (pre-commit, commit-msg, pre-push, post-merge);
   GitHub Actions as safety net only
 - Express hardening: `helmet`, `express-rate-limit`, `express-slow-down`,
@@ -52,7 +53,7 @@ Adopt the tooling stack described in issue #1 verbatim:
 
 **Harder:**
 
-- Contributors need local binaries (semgrep, osv-scanner, gitleaks, lychee) —
+- Contributors need local binaries (semgrep, osv-scanner, trufflehog, lychee) —
   see `scripts/bootstrap.sh`
 - Strict rules (300-line file cap, 75-line function cap, complexity 10) will
   push back early when files sprawl

--- a/docs/adr/0008-trufflehog-secret-scanning.md
+++ b/docs/adr/0008-trufflehog-secret-scanning.md
@@ -1,0 +1,59 @@
+# ADR-0008: Replace gitleaks with trufflehog for secret scanning
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Karl Groves
+
+## Context
+
+ADR-0001 (issue #1) adopted `gitleaks` as the secret scanner at the pre-commit
+hook, in the `security:secrets` npm script (run at pre-push and in CI), and as a
+bootstrap-installed binary. Issue #3 proposes switching to
+[`trufflehog`](https://github.com/trufflesecurity/trufflehog).
+
+ADR-0001 set a ground rule: don't replace an existing tool unless the new one is
+a demonstrably higher-quality outcome, and record the decision as an ADR. This
+is that record.
+
+## Decision
+
+Replace `gitleaks` with `trufflehog` everywhere it was wired:
+
+- **`security:secrets` script (enforced at pre-push + CI):**
+  `trufflehog git file://. --results=verified --fail --no-update` — scans the
+  full local git history and fails (exit 183) only on **verified** secrets.
+- **`.husky/pre-commit`:** trufflehog has no staged-diff mode equivalent to
+  `gitleaks protect --staged`, so the hook scans the working-tree content of the
+  staged files (`git diff --cached --name-only --diff-filter=ACM` →
+  `trufflehog filesystem … --results=verified --fail --no-update`). The
+  authoritative full-history verified scan still runs at pre-push and in CI.
+- **`scripts/bootstrap.sh`:** installs `trufflehog` (brew, else the official
+  install script) instead of `gitleaks`.
+- **`.github/workflows/ci.yml`:** installs the `trufflehog` binary via the
+  official install script so `npm run check:all` → `security:secrets` runs it,
+  matching how `osv-scanner` is installed (local-gates-first architecture).
+
+We use `--results=verified` rather than the issue's suggested `--only-verified`
+because the latter is deprecated in trufflehog v3.95+; both express the same
+"fail only on confirmed-live credentials" intent.
+
+## Rationale
+
+- **Verification cuts false positives.** trufflehog actively verifies detected
+  credentials against live services, so the gate fails on real, live secrets
+  rather than regex look-alikes.
+- **Detector coverage.** 800+ verified detectors vs. gitleaks' regex rules.
+- **Licensing.** The gitleaks GitHub Action requires a paid license for
+  organization use; trufflehog is fully open source (AGPL).
+- **Maintenance.** Frequent detector updates and a larger contributor base.
+
+## Consequences
+
+- Pre-commit protection is slightly different in shape: it scans staged file
+  contents rather than the staged diff. Verified-only means an unverifiable but
+  real secret (e.g. an internal token with no reachable verifier) can pass the
+  gate — accepted, because the full-history scan plus semgrep's `p/secrets`
+  rules and `eslint-plugin-no-secrets` provide defense in depth.
+- CI and contributors no longer need `gitleaks`; `bootstrap.sh` installs
+  `trufflehog`. No `.gitleaks.toml` existed, so none was removed.
+- Supersedes the `gitleaks` choice in ADR-0001 (issue #1). Closes issue #3.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "security:audit": "npm audit --workspaces --include-workspace-root --audit-level=high",
     "security:osv": "osv-scanner --lockfile=package-lock.json",
     "security:semgrep": "bash scripts/semgrep.sh",
-    "security:secrets": "gitleaks detect --no-banner",
+    "security:secrets": "trufflehog git file://. --results=verified --fail --no-update",
     "security": "npm-run-all -p security:audit security:osv security:semgrep security:secrets",
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "license-checker-rseidelsohn --production --csv --out reports/licenses.csv",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -24,10 +24,12 @@ if ! command -v osv-scanner >/dev/null 2>&1; then
   }
 fi
 
-if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "Installing gitleaks..."
-  brew install gitleaks 2>/dev/null || {
-    echo "Install gitleaks from https://github.com/gitleaks/gitleaks/releases"
+if ! command -v trufflehog >/dev/null 2>&1; then
+  echo "Installing trufflehog..."
+  brew install trufflehog 2>/dev/null \
+    || curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin \
+    || {
+    echo "Install trufflehog from https://github.com/trufflesecurity/trufflehog"
     exit 1
   }
 fi


### PR DESCRIPTION
Closes #3.

Swaps the secret scanner from gitleaks to trufflehog everywhere it was wired.

**Why** (per issue #3 / ADR-0008): trufflehog verifies detected credentials against live services so the gate fails only on *verified* secrets, ships 800+ detectors vs. gitleaks' regex rules, and is fully OSS — the gitleaks Action needs a paid org license.

**Changes**
- `security:secrets` → `trufflehog git file://. --results=verified --fail --no-update` (full-history verified scan; runs at pre-push + in CI)
- `.husky/pre-commit` scans the staged files' working-tree content (trufflehog has no staged-diff mode; the authoritative scan stays at pre-push/CI)
- `scripts/bootstrap.sh` and `.github/workflows/ci.yml` install trufflehog instead of gitleaks
- docs updated (README, CLAUDE.md, ADR-0001); **ADR-0008** records the reversal of #1's gitleaks choice

Uses `--results=verified` (not the issue's `--only-verified`, deprecated in trufflehog 3.95+) — same intent.

**Verification:** no functional `gitleaks` references remain (only ADR historical mentions); `npm run security:secrets` scans clean (0 verified secrets).