### PR TITLE
fix(io): untenanted staff watch all tenants in real time

### DIFF
--- a/api/src/io/rooms.ts
+++ b/api/src/io/rooms.ts
@@ -1,0 +1,7 @@
+/**
+ * Socket.IO room used to reach AFixt staff who have no tenant of their own
+ * (`tenant_id` is null) and therefore watch every tenant. Visitor/chat events
+ * are mirrored here in addition to the per-tenant `tenant:{id}` room, so
+ * untenanted staff receive them while tenant-scoped staff stay isolated.
+ */
+export const GLOBAL_STAFF_ROOM = 'staff:global';

--- a/api/src/io/staff-namespace.ts
+++ b/api/src/io/staff-namespace.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 
 import { detach } from './detach.js';
+import { GLOBAL_STAFF_ROOM } from './rooms.js';
 
 import type { ServerToClientEvents, StaffSocketData, StaffToServerEvents } from './types.js';
 import type { Env } from '../config/env.js';
@@ -63,6 +64,11 @@ export function registerStaffNamespace(deps: StaffDeps): StaffNamespace {
       await socket.join(`user:${userId}`);
       if (['super_admin', 'admin', 'staff'].includes(role)) {
         await socket.join('staff');
+        // AFixt staff with no tenant of their own serve every tenant, so they
+        // join the global room that visitor/chat events are mirrored to. Note
+        // the `staff` room is NOT used for that — it holds tenant-scoped staff
+        // too, and broadcasting there would break tenant isolation.
+        if (tenantId === null) await socket.join(GLOBAL_STAFF_ROOM);
       }
       if (tenantId !== null) await socket.join(`tenant:${tenantId}`);
     });
@@ -135,7 +141,7 @@ export function registerStaffNamespace(deps: StaffDeps): StaffNamespace {
           supportUserId: userId,
         });
         await socket.join(`chat:${chat.id}`);
-        nsp.to(`tenant:${chat.tenantId}`).emit('chat:requested', {
+        nsp.to(`tenant:${chat.tenantId}`).to(GLOBAL_STAFF_ROOM).emit('chat:requested', {
           chatId: chat.id,
           tenantId: chat.tenantId,
           customerName: chat.customerName,

--- a/api/src/io/visitor-namespace.ts
+++ b/api/src/io/visitor-namespace.ts
@@ -1,4 +1,5 @@
 import { detach } from './detach.js';
+import { GLOBAL_STAFF_ROOM } from './rooms.js';
 
 import type { ServerToClientEvents, VisitorSocketData, VisitorToServerEvents } from './types.js';
 import type { Services } from '../services/index.js';
@@ -80,7 +81,7 @@ export function registerVisitorNamespace(deps: VisitorDeps): VisitorNamespace {
         connectedAt: Date.now(),
       }),
     );
-    deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).emit('visitor:joined', {
+    deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).to(GLOBAL_STAFF_ROOM).emit('visitor:joined', {
       tenantId,
       visitorSessionId,
     });
@@ -93,7 +94,7 @@ export function registerVisitorNamespace(deps: VisitorDeps): VisitorNamespace {
         // the chat never reaches the console's list. Idempotent: the client
         // upserts, so re-joining (e.g. restart) is harmless.
         const chat = await deps.services.chat.getById(payload.chatId);
-        deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).emit('chat:requested', {
+        deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).to(GLOBAL_STAFF_ROOM).emit('chat:requested', {
           chatId: chat.id,
           tenantId,
           customerName: chat.customerName,
@@ -119,7 +120,11 @@ export function registerVisitorNamespace(deps: VisitorDeps): VisitorNamespace {
         };
         nsp.to(`chat:${payload.chatId}`).emit('chat:message', event);
         deps.io.of(STAFF_NS).to(`chat:${payload.chatId}`).emit('chat:message', event);
-        deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).emit('chat:message', event);
+        deps.io
+          .of(STAFF_NS)
+          .to(`tenant:${tenantId}`)
+          .to(GLOBAL_STAFF_ROOM)
+          .emit('chat:message', event);
       });
     });
 
@@ -152,16 +157,20 @@ export function registerVisitorNamespace(deps: VisitorDeps): VisitorNamespace {
     });
 
     socket.on('visitor:page_changed', (payload) => {
-      deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).emit('visitor:page_changed', {
-        visitorSessionId,
-        currentUrl: payload.currentUrl,
-      });
+      deps.io
+        .of(STAFF_NS)
+        .to(`tenant:${tenantId}`)
+        .to(GLOBAL_STAFF_ROOM)
+        .emit('visitor:page_changed', {
+          visitorSessionId,
+          currentUrl: payload.currentUrl,
+        });
     });
 
     socket.on('disconnect', () => {
       detach(deps.logger, 'visitor disconnect cleanup failed', async () => {
         await deps.services.presence.removeVisitor(tenantId, visitorSessionId);
-        deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).emit('visitor:left', {
+        deps.io.of(STAFF_NS).to(`tenant:${tenantId}`).to(GLOBAL_STAFF_ROOM).emit('visitor:left', {
           tenantId,
           visitorSessionId,
         });

--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -260,4 +260,78 @@ describe('chat flow (integration)', () => {
     staffSocket.disconnect();
     visitorSocket.disconnect();
   }, 30_000);
+
+  test('untenanted staff watch all tenants; scoped staff stay isolated', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    // A visitor in tenant "delta", an untenanted AFixt staff (tenant_id null),
+    // and a staff scoped to an unrelated tenant "omega".
+    await seedTenantAndStaff('delta', 'd-staff@delta.example');
+    await seedTenantAndStaff('omega', 'o-staff@omega.example');
+    await User.create({
+      email: 'global@afixt.example',
+      passwordHash: 'Staff!Password1',
+      firstName: 'Gl',
+      lastName: 'Obal',
+      role: 'staff',
+      tenantId: null,
+      status: 'active',
+      emailVerified: true,
+      emailVerificationToken: null,
+      emailVerificationExpires: null,
+      passwordResetToken: null,
+      passwordResetExpires: null,
+      lockedUntil: null,
+      lastLoginAt: null,
+      phone: null,
+      timezone: null,
+      avatarUrl: null,
+      preferences: null,
+    });
+
+    const globalToken = await loginAs(baseUrl, 'global@afixt.example', 'Staff!Password1');
+    const omegaToken = await loginAs(baseUrl, 'o-staff@omega.example', 'Staff!Password1');
+    const { cookie: visitorCookie } = await initVisitor(baseUrl, 'delta');
+
+    const globalSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: globalToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const omegaSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: omegaToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await Promise.all([waitFor(globalSocket, 'connect'), waitFor(omegaSocket, 'connect')]);
+    // Let the connection handlers finish joining their rooms.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    let leakedToOmega = false;
+    omegaSocket.on('visitor:joined', () => {
+      leakedToOmega = true;
+    });
+    const globalSeesVisitor = waitFor<{ visitorSessionId: string }>(globalSocket, 'visitor:joined');
+
+    // The delta visitor connects → visitor:joined fans out to tenant:delta and
+    // the global room, but not to omega's tenant room.
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(visitorSocket, 'connect');
+
+    const joined = await globalSeesVisitor;
+    expect(joined.visitorSessionId).toBeTruthy();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(leakedToOmega).toBe(false);
+
+    globalSocket.disconnect();
+    omegaSocket.disconnect();
+    visitorSocket.disconnect();
+  }, 30_000);
 });

--- a/e2e/journeys/untenanted-staff-presence.spec.ts
+++ b/e2e/journeys/untenanted-staff-presence.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+import { openAdmin, openVisitor } from '../support/actors.js';
+
+/**
+ * Issue #19: an AFixt super-admin with no tenant of their own must still see
+ * real-time visitor presence across every tenant. Before the fix the console
+ * sat silent — untenanted staff joined no `tenant:{id}` room, and every visitor
+ * event targeted only that room. Now untenanted staff join the global staff
+ * room those events are mirrored to.
+ */
+test('untenanted super-admin sees a visitor arrive in the console', async ({ browser }) => {
+  // The seeded super-admin has tenant_id = null (fixtures: USERS.superAdmin).
+  const admin = await openAdmin(browser);
+  await expect(admin.page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await expect(admin.page.getByText('No visitors are currently on the site.')).toBeVisible();
+  // Let the staff socket connect and join the global room before the visitor.
+  await admin.page.waitForTimeout(1000);
+
+  // A visitor loads the widget in tenant "acme"; their presence must reach the
+  // untenanted admin, who has no tenant room of their own.
+  const visitor = await openVisitor(browser);
+
+  const visitorRow = admin.page
+    .getByRole('list', { name: 'Visitors on site' })
+    .getByRole('button', { name: /start a chat with visitor/i })
+    .first();
+  await expect(visitorRow).toBeVisible();
+
+  await visitor.close();
+  await admin.close();
+});


### PR DESCRIPTION
Closes #19.

A support-console user whose `tenant_id` is null joined no `tenant:{id}` room, while every visitor/chat event targeted only that room — so AFixt staff who serve every tenant received nothing and the dashboard sat silent.

### Fix (issue #19 decision — option 2, "staff watch all tenants")
- Untenanted `super_admin`/`admin`/`staff` now join a dedicated **`staff:global`** room on connect (new `api/src/io/rooms.ts`).
- `visitor:joined`, `chat:requested`, `chat:message`, `visitor:page_changed`, and `visitor:left` are mirrored to `staff:global` in addition to `tenant:{id}`.
- Socket.IO dedupes the multi-room emit. The global room is **separate** from the shared `staff` room (which also holds tenant-scoped agents), so tenant-scoped staff stay isolated to their own tenant.

### Isolation preserved
Tenant-scoped agents (`tenant_id` set) still join only their `tenant:{id}` room and are unaffected — verified below.

### Tests
- **Integration**: an untenanted staff receives a delta-tenant visitor's `visitor:joined`, while a staff scoped to a different tenant (omega) does **not**.
- **e2e journey**: an untenanted super-admin (`USERS.superAdmin`, `tenant_id` null) sees a visitor arrive in the console's presence list — the exact scenario that sat silent before.
- All 8 journeys pass locally; no UI changed, so the usecase mandate isn't triggered.

Note: `StaffTenant` subset-scoping isn't wired into socket rooms today (the socket model uses a single `tenantId` from the JWT); this fix doesn't change that — it only routes the null-tenant case.