### PR TITLE
docs: close out the tooling epic (#1) — SEO scope, README, license

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -4,14 +4,13 @@
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop",
-        "onlyCategories": ["performance", "seo", "best-practices"],
+        "onlyCategories": ["performance", "best-practices"],
         "skipAudits": ["uses-http2", "bf-cache"]
       }
     },
     "assert": {
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.9 }],
-        "categories:seo": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "first-contentful-paint": ["error", { "maxNumericValue": 1800 }],
         "largest-contentful-paint": ["error", { "maxNumericValue": 2500 }],

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ GitHub issues.
 - `docs/adr/` — architecture decisions
 - `usecases/` — every user-facing interaction as `.uc.yaml`, per ADR-0002
 
+## Setup
+
+```sh
+nvm use                 # Node 22, per .nvmrc
+bash scripts/bootstrap.sh   # install local tool binaries (semgrep, osv-scanner, trufflehog, lychee)
+npm ci                  # install workspace dependencies
+docker compose up -d    # MySQL + Redis + MailHog + MinIO
+npm run dev             # run api, ui, and widget in parallel
+```
+
+Then `npm run check:all` should pass on a clean clone — it is the same gate
+Husky runs on pre-push.
+
 ## Scripts
 
 From the repo root:
@@ -42,3 +55,8 @@ From the repo root:
   osv-scanner, trufflehog, lychee) required by pre-push hooks
 - All user-facing changes must include a corresponding `.uc.yaml` update
   (enforced by a CI diff gate)
+
+## License
+
+Proprietary. © AFixt. This is a private product (`"private": true`); it is not
+licensed for external use or redistribution.

--- a/docs/adr/0009-seo-aieo-not-applicable.md
+++ b/docs/adr/0009-seo-aieo-not-applicable.md
@@ -33,10 +33,11 @@ never indexed if it is ever exposed — is handled directly: `ui/index.html`
 carries `<meta name="robots" content="noindex, nofollow">`.
 
 Lighthouse CI is still run (`.lighthouserc.json` / `lhci.yml`) for
-**performance** and **best-practices** budgets; only the SEO _category_ is
-treated as not-applicable, consistent with issue #1 already scoping Lighthouse
-to "performance, seo, and best-practices" with a11y covered by
-`@afixt/a11y-assert`.
+**performance** and **best-practices** budgets, but the **SEO category is
+removed** from `onlyCategories` and its assertion dropped: the console's
+deliberate `noindex` fails Lighthouse's `is-crawlable` SEO audit, which is the
+correct outcome for a private app, not a regression to gate on. (a11y is covered
+separately by `@afixt/a11y-assert`.)
 
 ## Consequences
 

--- a/docs/adr/0009-seo-aieo-not-applicable.md
+++ b/docs/adr/0009-seo-aieo-not-applicable.md
@@ -1,0 +1,48 @@
+# ADR-0009: SEO/AIEO tooling is out of scope for this product's surfaces
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Karl Groves
+
+## Context
+
+Issue #1's tooling stack lists an SEO/AIEO section: `react-helmet-async` for
+per-page meta, JSON-LD via `schema-dts`, a build-time sitemap + `robots.txt`, an
+`llms.txt` for AI crawlers, the Lighthouse SEO category, and SSR/SSG for
+content-heavy surfaces. Those items assume a public, crawlable web surface.
+
+This product has none:
+
+- **Customer widget (`widget/`)** is injected into arbitrary client sites via a
+  JS snippet and rendered inside a Shadow DOM. It has no standalone page or URL
+  of its own to index; its host page owns all SEO.
+- **Support/admin console (`ui/`)** is a single-page app that lives entirely
+  behind authentication. There is no anonymous content to rank, and it should
+  never appear in a search index.
+- The **API (`api/`)** serves JSON, not documents.
+
+## Decision
+
+Do **not** adopt the SEO/AIEO tooling from issue #1 (`react-helmet-async`,
+`schema-dts` JSON-LD, sitemap/`robots.txt` generation, `llms.txt`, the
+Lighthouse SEO category as a content gate, SSR/SSG). None of it has a surface to
+act on here.
+
+The one concrete measure that does apply — making sure the private console is
+never indexed if it is ever exposed — is handled directly: `ui/index.html`
+carries `<meta name="robots" content="noindex, nofollow">`.
+
+Lighthouse CI is still run (`.lighthouserc.json` / `lhci.yml`) for
+**performance** and **best-practices** budgets; only the SEO _category_ is
+treated as not-applicable, consistent with issue #1 already scoping Lighthouse
+to "performance, seo, and best-practices" with a11y covered by
+`@afixt/a11y-assert`.
+
+## Consequences
+
+- No `llms.txt`, `sitemap.xml`, `robots.txt`, JSON-LD, or head-management
+  library is added. The corresponding acceptance items in issue #1 are closed as
+  not-applicable rather than done.
+- If a public, crawlable surface is ever introduced (a marketing site, public
+  docs, a status page), revisit this ADR — the tooling in issue #1 becomes
+  relevant again for that surface only.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "livechat-root",
   "version": "0.0.0",
   "private": true,
+  "license": "UNLICENSED",
   "type": "module",
   "description": "Root tooling for the AFixt livechat monorepo (api, ui, widget, shared, usecases).",
   "engines": {

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <!-- Private authenticated console — never index it. See ADR-0009. -->
+    <meta name="robots" content="noindex, nofollow" />
     <title>AFixt livechat — support console</title>
   </head>
   <body>


### PR DESCRIPTION
Closes #1.

A full audit of issue #1's acceptance checklist against `develop` found the entire tooling stack already in place (strict tsconfig + ts-reset, the full ESLint flat config, Prettier/Stylelint/markdownlint/jscpd configs, all four Husky hooks, commitlint, size-limit, Lighthouse CI, `@afixt/a11y-assert`, the security scanners, `docs/templates/`, `bootstrap.sh`, and the safety-net + scheduled workflows). Some choices were deliberately superseded by ADRs this session (trufflehog over gitleaks — ADR-0008; jsx-a11y removed — axe-core ban; Dependabot disabled). This PR closes the only real remaining gaps:

- **ADR-0009** — records that the **SEO/AIEO** items (llms.txt, sitemap, robots.txt, JSON-LD, react-helmet, SSR/SSG, Lighthouse SEO gate) are **not-applicable**: the widget is embedded in host pages (no own SEO surface) and the console is a private authed SPA. Documented per the issue's "when in doubt, ADR" ground rule rather than silently skipped.
- **`ui/index.html`** — `noindex, nofollow` on the console so it's never indexed if exposed.
- **README** — explicit **Setup** steps and a **License** section.
- **package.json** — `license: UNLICENSED`, matching `private: true`.

No `ui/src`/`widget/src` changes, so the usecase mandate isn't triggered. I'll post the full item-by-item audit on the issue.