### PR TITLE
chore(security): keep mutable action tags, drop OWASP Dependency-Check (#7)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,18 +18,3 @@ jobs:
           languages: javascript-typescript
           queries: security-extended
       - uses: github/codeql-action/analyze@v3
-
-  dependency-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dependency-check/Dependency-Check_Action@main
-        with:
-          project: ${{ github.event.repository.name }}
-          path: "."
-          format: "HTML"
-          out: "reports/dep-check"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dependency-check-report
-          path: reports/dep-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,8 @@ Per issue #1 — the full stack is the mandate, not a suggestion:
 - `size-limit` (build gate)
 - Lighthouse CI (perf/SEO/best-practices; a11y is covered by `a11y-assert`)
 - Security: `npm audit`, `osv-scanner`, `semgrep` (OWASP Top 10), `trufflehog`
-  (secret scanning), `eslint-plugin-no-secrets`, scheduled CodeQL + OWASP
-  Dependency-Check + OWASP ZAP baseline in Actions
+  (secret scanning), `eslint-plugin-no-secrets`, scheduled CodeQL + OWASP ZAP
+  baseline in Actions
 
 **Local gates are preferred over GitHub Actions.** Keep CI as a safety net for
 `--no-verify` / web-UI merges.

--- a/docs/adr/0001-tooling-stack.md
+++ b/docs/adr/0001-tooling-stack.md
@@ -34,8 +34,8 @@ Adopt the tooling stack described in issue #1 verbatim:
 - `@afixt/a11y-assert` at component, E2E, and CI-preview layers
 - `size-limit` and Lighthouse CI budgets
 - Security: `npm audit`, `osv-scanner`, `semgrep` (OWASP Top 10), `trufflehog`
-  (secret scanning — superseded `gitleaks`, see ADR 0008), weekly CodeQL, weekly
-  OWASP Dependency-Check
+  (secret scanning — superseded `gitleaks`, see ADR 0008), weekly CodeQL.
+  (Weekly OWASP Dependency-Check was later dropped — see ADR 0010.)
 - Husky hooks as primary gate (pre-commit, commit-msg, pre-push, post-merge);
   GitHub Actions as safety net only
 - Express hardening: `helmet`, `express-rate-limit`, `express-slow-down`,

--- a/docs/adr/0010-github-actions-mutable-tags.md
+++ b/docs/adr/0010-github-actions-mutable-tags.md
@@ -1,0 +1,61 @@
+# ADR-0010: Keep mutable major tags for GitHub Actions; drop OWASP Dependency-Check
+
+- **Status:** Accepted
+- **Date:** 2026-07-22
+- **Deciders:** Karl Groves
+
+## Context
+
+Semgrep's `github-actions-mutable-action-tag` rule flags every `uses:` reference
+that points at a mutable tag (`actions/checkout@v4`, `github/codeql-action@v3`,
+…) — 19 findings across the workflows. A tag can be repointed by the action
+owner, or by anyone who compromises that account, so a pinned tag is not a
+pinned artifact. The standard mitigation is to pin every action to a full commit
+SHA.
+
+That mitigation assumes something keeps the pins current. **Dependabot is
+disabled in this repo and will stay disabled** (PR #22). Without a bumper, SHA
+pinning has a cost the rule doesn't account for:
+
+- Every action freezes at the commit pinned on the day of the change.
+- Security and bug fixes published by the action author never arrive.
+- Bumping is a manual chore that, realistically, will not happen on a schedule.
+
+Weighed against that, the actions in use are all from GitHub itself
+(`actions/*`, `github/codeql-action/*`) or established organisations
+(`lycheeverse`, `zaproxy`). For those publishers, a mutable **major** tag is the
+channel through which patches are delivered.
+
+One reference was different in kind:
+`dependency-check/Dependency-Check_Action@main` pointed at a **branch**, not a
+version — it moved with every upstream commit, with no release discipline at
+all. That action's most recent release is 1.1.0 (April 2021).
+
+## Decision
+
+1. **Keep mutable major tags** for GitHub Actions. Do not pin to commit SHAs
+   while there is no automated bumper. Receiving upstream security fixes is
+   judged the larger benefit; the residual tag-repointing risk from
+   GitHub-official and established publishers is accepted.
+2. **Drop the OWASP Dependency-Check job** from `.github/workflows/security.yml`
+   rather than pinning it. It was the only branch (`@main`) reference, it is
+   effectively unmaintained (last release 2021), and for a pure npm/TypeScript
+   monorepo it adds little over the `npm audit`, `osv-scanner`, and CodeQL scans
+   already running — Dependency-Check is primarily a Java/native CVE tool.
+3. The `github-actions-mutable-action-tag` exclusion in `scripts/semgrep.sh`
+   therefore stays, and is justified by this ADR rather than left as an
+   undecided suppression.
+
+## Consequences
+
+- The semgrep secret/SAST gate stays green without re-litigating 19 findings
+  each run; the exclusion now carries a documented rationale.
+- Action versions track their major tags, so upstream fixes land automatically
+  and CI breakage from a bad upstream release is possible — acceptable, since CI
+  failures are visible immediately and the blast radius is the build, not
+  production.
+- Dependency scanning coverage is unchanged in practice: `npm audit`
+  (`--audit-level=high`), `osv-scanner` against `package-lock.json`, and weekly
+  CodeQL all remain.
+- **Revisit if Dependabot is ever re-enabled** — with a bumper in place, SHA
+  pinning becomes the better trade and this ADR should be superseded.

--- a/scripts/semgrep.sh
+++ b/scripts/semgrep.sh
@@ -47,18 +47,18 @@ EXCLUDES=(
   # add_header, repeat the server-block headers in it.
   --exclude-rule=generic.nginx.security.header-redefinition.header-redefinition
 
-  # SHA-pinning of GitHub Actions vs. mutable tags (19 findings). Still a
-  # policy decision tracked in https://github.com/AFixt/livechat/issues/7 —
-  # pinning needs a bumper (Dependabot) to stay current, and Dependabot is
-  # currently disabled. Remove this exclusion if/when actions are pinned.
+  # SHA-pinning of GitHub Actions vs. mutable tags (19 findings). Decided in
+  # ADR-0010: keep mutable major tags. Pinning needs a bumper to stay current
+  # and Dependabot is disabled by choice, so pinning would freeze the actions
+  # and stop upstream security fixes. Revisit if Dependabot is re-enabled.
   --exclude-rule=yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
 
   # TLS on the DB connection is now implemented but env-driven (DB_SSL /
   # DB_SSL_CA in api/src/config/{env,mysql}.ts + db/config.cjs), because it
   # must stay off for local docker-compose. The rule matches the whole
   # Sequelize construction and cannot see that TLS is enabled at runtime via
-  # env, so it can't be satisfied without forcing TLS unconditionally. See
-  # https://github.com/AFixt/livechat/issues/7 — production sets DB_SSL=true.
+  # env, so it can't be satisfied without forcing TLS unconditionally.
+  # Production sets DB_SSL=true.
   --exclude-rule=ajinabraham.njsscan.database.sequelize_tls.sequelize_tls
 )
 


### PR DESCRIPTION
Closes #7 — the last open item (GitHub Actions SHA-pinning).

**Decision: don't pin.** Dependabot is disabled by choice, and SHA-pinning without a bumper freezes every action at today's commit and cuts off the upstream security fixes those publishers ship — a worse outcome than the residual tag-repointing risk from GitHub-official (`actions/*`, `github/codeql-action/*`) and established (`lycheeverse`, `zaproxy`) orgs. Mutable **major** tags are how those fixes arrive.

**The one reference that was genuinely a problem is removed.** `dependency-check/Dependency-Check_Action@main` pointed at a *branch*, not a version — moving on every upstream commit with no release discipline. That action's last release is 1.1.0 (April 2021), and for a pure npm/TypeScript monorepo it adds little over `npm audit` + `osv-scanner` + CodeQL (it's primarily a Java/native CVE tool). Dropped rather than pinned.

- **ADR-0010** records the accepted risk, so the `github-actions-mutable-action-tag` semgrep exclusion is a documented decision rather than an undecided suppression. It also flags the revisit condition: if Dependabot is ever re-enabled, SHA pinning becomes the better trade.
- `scripts/semgrep.sh` comments now cite ADR-0010 instead of the (closing) issue; the `sequelize_tls` comment likewise.
- `CLAUDE.md` and ADR-0001 updated to drop the stale Dependency-Check mention.

**Verification:** `security.yml` is down to the CodeQL job and parses clean; `npm run security:semgrep` → 0 findings, 0 blocking; markdownlint + prettier clean. Dependency-scanning coverage is unchanged in practice (npm audit, osv-scanner, weekly CodeQL all remain).