### PR TITLE
docs: record the @afixt scope / NPM_TOKEN auth gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ npm run dev             # run api, ui, and widget in parallel
 Then `npm run check:all` should pass on a clean clone — it is the same gate
 Husky runs on pre-push.
 
+### `@afixt/*` packages and `NPM_TOKEN`
+
+This repo installs private `@afixt/*` scoped packages (`usecase-runner`,
+`a11y-assert`). In CI, npm authenticates via an **organization-level** GitHub
+Actions secret named `NPM_TOKEN` — `actions/setup-node` writes a runner-local
+`.npmrc` from it, which is why no auth token is committed to this repo's
+`.npmrc` (local installs keep using your own credentials).
+
+If installing an `@afixt/*` package returns **404, that is an authentication
+problem, not a missing package**. The usual cause is a stale **repo-level**
+`NPM_TOKEN` secret shadowing the org-level one — delete the repo-level secret
+rather than overriding it per repository.
+
 ## Scripts
 
 From the repo root:


### PR DESCRIPTION
Salvages the one piece of real content from the abandoned `chore/afixt-npm-token-note` branch before that branch is deleted.

**Why it couldn't just be merged:** that branch was cut from the pre-project `main` (merge-base dated 2022-05-31), so its `CLAUDE.md` is a standalone **8-line file**, not an addition to the current 276-line one — merging it would have clobbered the project instructions. Line 1 was also a stray `gh api` 404 JSON response committed by accident.

**Why README instead of CLAUDE.md:** CLAUDE.md is already 276 lines against its own stated ~200-line budget, and this is setup/troubleshooting knowledge — someone hits it during `npm ci`, which is where the README Setup section already lives.

The guidance itself is live: this repo installs `@afixt/usecase-runner` and `@afixt/a11y-assert`, and it documents that a 404 on those is an **auth** failure (a stale repo-level `NPM_TOKEN` shadowing the org-level secret), not a missing package. It also explains why no auth token is committed to `.npmrc` — matching the existing comment in `ci.yml`.