### PR TITLE
test(api): build the integration schema from migrations, not sync()

### DIFF
--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -1,8 +1,10 @@
+import { readdir } from 'node:fs/promises';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
 import Redis, { type Redis as RedisClient } from 'ioredis';
 import { pino, type Logger } from 'pino';
+import { Sequelize as SequelizeLib } from 'sequelize';
 
 import { createApp } from '../../src/app.js';
 import { createSequelize } from '../../src/config/mysql.js';
@@ -17,9 +19,9 @@ import type { Server as IoServer } from 'socket.io';
 
 /**
  * A fresh test env. Defaults to a dedicated `livechat_test` database —
- * integration tests `sync({ force: true })`, so pointing them at the shared
- * dev `livechat_db` would wipe whatever you're working on. Override `DB_NAME`
- * to target another database.
+ * integration tests drop every table and re-run the migrations, so pointing
+ * them at the shared dev `livechat_db` would wipe whatever you're working on.
+ * Override `DB_NAME` to target another database.
  * @returns Env for integration testing.
  */
 export function testEnv(): Env {
@@ -55,6 +57,57 @@ export function testEnv(): Env {
     isTest: true,
     isDevelopment: false,
   } as unknown as Env;
+}
+
+/** The shape every migration file in `src/db/migrations` exports. */
+interface Migration {
+  up: (
+    queryInterface: ReturnType<Sequelize['getQueryInterface']>,
+    sequelize: unknown,
+  ) => Promise<void>;
+}
+
+const MIGRATIONS_DIR = new URL('../../src/db/migrations/', import.meta.url);
+
+/**
+ * Rebuild the schema by running the **real migrations**, not `sync()`.
+ *
+ * This is the point of the integration suite: `sync({ force: true })` builds
+ * tables from the models, so the models can never disagree with the schema
+ * under test and migration drift is invisible. Six tables once shipped without
+ * the `deleted_at` column that the global `paranoid: true` default requires,
+ * and every suite stayed green because none of them ever ran a migration.
+ *
+ * Drops every table first so each run starts from nothing and applies the full
+ * migration history in filename order — the same path a real deployment takes.
+ * @param sequelize - Connection to the (dedicated) test database.
+ */
+export async function resetSchemaFromMigrations(sequelize: Sequelize): Promise<void> {
+  const queryInterface = sequelize.getQueryInterface();
+
+  // Pin one connection for the drops: FOREIGN_KEY_CHECKS is session-scoped, so
+  // toggling it on a pooled connection other than the one running the DROPs
+  // would not take effect.
+  await sequelize.transaction(async (transaction) => {
+    const tables = await queryInterface.showAllTables({ transaction });
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
+    for (const table of tables) {
+      await sequelize.query(`DROP TABLE IF EXISTS \`${table}\``, { transaction });
+    }
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+  });
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- module constant, no external input
+  const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
+  for (const file of files) {
+    const loaded = (await import(new URL(file, MIGRATIONS_DIR).href)) as {
+      default?: Migration;
+    } & Migration;
+    const migration = loaded.default ?? loaded;
+    // Migrations receive the Sequelize class itself (for `Sequelize.DATE` etc.),
+    // exactly as sequelize-cli passes it.
+    await migration.up(queryInterface, SequelizeLib);
+  }
 }
 
 export interface TestHarness {
@@ -99,7 +152,7 @@ export async function probeHarness(): Promise<TestHarness | null> {
   }
 
   initModels(sequelize);
-  await sequelize.sync({ force: true });
+  await resetSchemaFromMigrations(sequelize);
   await redis.flushdb();
 
   const services = createServices({ env, logger, redis });

--- a/e2e/setup-and-serve-api.sh
+++ b/e2e/setup-and-serve-api.sh
@@ -13,24 +13,25 @@ ROOT_PASS="${DB_ROOT_PASS:-livechat_root_pass}"
 
 docker compose up -d mysql redis mailhog
 
-# Wait until root auth actually works, not just until the socket answers. On a
-# fresh volume (CI) the entrypoint runs a temporary server during init that
-# replies to `mysqladmin ping` before the root password is applied, so a ping
-# probe races ahead and the next command hits "Access denied". A root SELECT
-# only succeeds once the real, initialised server is up.
-echo "e2e: waiting for MySQL to accept root auth…"
-deadline=$(( SECONDS + 90 ))
-until docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e 'SELECT 1' >/dev/null 2>&1; do
+# Retry the provisioning statement itself rather than probing first and acting
+# after. On a fresh volume (CI) the entrypoint runs a temporary server during
+# init: it answers `mysqladmin ping`, and even a root `SELECT 1`, then shuts
+# down before the real server starts. So a probe that passes is no guarantee
+# the *next* command finds a live socket — that window is how this failed with
+# "ERROR 2002: Can't connect to local MySQL server through socket". Making the
+# idempotent CREATE/GRANT the readiness check closes it.
+echo "e2e: waiting for MySQL and provisioning ${DB_NAME}…"
+deadline=$(( SECONDS + 120 ))
+until docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
+  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
+   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;" >/dev/null 2>&1; do
   if [ "$SECONDS" -ge "$deadline" ]; then
-    echo "e2e: MySQL did not accept root auth within 90s" >&2
+    echo "e2e: MySQL did not become ready within 120s" >&2
+    docker logs --tail 50 livechat-mysql >&2 || true
     exit 1
   fi
   sleep 1
 done
-
-docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
-  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
-   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"
 
 echo "e2e: seeding ${DB_NAME}…"
 node_modules/.bin/tsx e2e/support/seed.ts


### PR DESCRIPTION
Closes the gap that let the `deleted_at` bug (#37) reach a running browser with every suite green.

### The problem
`probeHarness()` built its schema with **`sync({ force: true })`** — i.e. *from the models*. That makes the models the source of truth for both the code under test **and** the schema it runs against, so the two can never disagree. Migration drift was structurally invisible: nothing in the repo ever ran a migration.

That is exactly how six tables shipped without the `deleted_at` column the global `paranoid: true` default requires. Unit, integration, all 8 e2e journeys and CI were green while `POST /visitor/chats` returned a 500 in a browser.

### The change
`probeHarness()` now drops every table and **replays the real migration files** in filename order — the same path a deployment takes.

- Drops run inside a **transaction** so the session-scoped `FOREIGN_KEY_CHECKS` toggle lands on the same pooled connection as the `DROP`s (otherwise the pool could hand the SET to a different connection and the drops would fail on FK constraints).
- Migrations are invoked with the `Sequelize` class as the second argument, exactly as `sequelize-cli` passes it, so `Sequelize.DATE` &co. resolve.
- An explicit runner rather than `umzug`, which is only a transitive dep of `sequelize-cli` here.

### Verified both directions
| | Result |
|---|---|
| With the `deleted_at` migration present | **22/22 pass** |
| With it removed (simulating the original bug) | **7 tests fail** — `SequelizeDatabaseError: Unknown column 'deleted_at' in 'field list'` |

Under the old `sync()` setup, that second row passed. This suite would now have caught the bug on its own, at the DB layer, with the real error.

Lint + typecheck clean.

### Still open
`e2e/support/seed.ts` still uses `sync({ force: true })`, so the e2e stack continues to test a model-built schema. Deliberately left out of scope here to keep this change reviewable — happy to follow up.