### PR TITLE
test(e2e): build the e2e schema from migrations, not sync()

### DIFF
--- a/api/src/db/migrator.ts
+++ b/api/src/db/migrator.ts
@@ -1,0 +1,60 @@
+import { readdir } from 'node:fs/promises';
+
+import { Sequelize as SequelizeLib } from 'sequelize';
+
+import type { Sequelize } from 'sequelize';
+
+/** The shape every migration file in `src/db/migrations` exports. */
+interface Migration {
+  up: (
+    queryInterface: ReturnType<Sequelize['getQueryInterface']>,
+    sequelize: unknown,
+  ) => Promise<void>;
+}
+
+const MIGRATIONS_DIR = new URL('./migrations/', import.meta.url);
+
+/**
+ * Rebuild a database's schema by running the **real migrations**, not `sync()`.
+ *
+ * Test harnesses reach for `sequelize.sync({ force: true })` because it is one
+ * line, but it builds tables from the models — so the models become the source
+ * of truth for both the code under test and the schema it runs against, and the
+ * two can never disagree. Migration drift is then structurally invisible: six
+ * tables once shipped without the `deleted_at` column that the global
+ * `paranoid: true` default requires, and every suite stayed green until the
+ * widget returned a 500 in a browser.
+ *
+ * Drops every table, then applies the full migration history in filename order
+ * — the same path a real deployment takes.
+ *
+ * Destructive by design: only point this at a dedicated test/e2e database.
+ * @param sequelize - Connection to the database to rebuild.
+ */
+export async function resetSchemaFromMigrations(sequelize: Sequelize): Promise<void> {
+  const queryInterface = sequelize.getQueryInterface();
+
+  // Pin one connection for the drops: FOREIGN_KEY_CHECKS is session-scoped, so
+  // toggling it on a pooled connection other than the one running the DROPs
+  // would not take effect.
+  await sequelize.transaction(async (transaction) => {
+    const tables = await queryInterface.showAllTables({ transaction });
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
+    for (const table of tables) {
+      await sequelize.query(`DROP TABLE IF EXISTS \`${table}\``, { transaction });
+    }
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+  });
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- module constant, no external input
+  const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
+  for (const file of files) {
+    const loaded = (await import(new URL(file, MIGRATIONS_DIR).href)) as {
+      default?: Migration;
+    } & Migration;
+    const migration = loaded.default ?? loaded;
+    // Migrations receive the Sequelize class itself (for `Sequelize.DATE` etc.),
+    // exactly as sequelize-cli passes it.
+    await migration.up(queryInterface, SequelizeLib);
+  }
+}

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -1,13 +1,12 @@
-import { readdir } from 'node:fs/promises';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
 import Redis, { type Redis as RedisClient } from 'ioredis';
 import { pino, type Logger } from 'pino';
-import { Sequelize as SequelizeLib } from 'sequelize';
 
 import { createApp } from '../../src/app.js';
 import { createSequelize } from '../../src/config/mysql.js';
+import { resetSchemaFromMigrations } from '../../src/db/migrator.js';
 import { attachIo } from '../../src/io/index.js';
 import { initModels } from '../../src/models/index.js';
 import { createServices, type Services } from '../../src/services/index.js';
@@ -57,57 +56,6 @@ export function testEnv(): Env {
     isTest: true,
     isDevelopment: false,
   } as unknown as Env;
-}
-
-/** The shape every migration file in `src/db/migrations` exports. */
-interface Migration {
-  up: (
-    queryInterface: ReturnType<Sequelize['getQueryInterface']>,
-    sequelize: unknown,
-  ) => Promise<void>;
-}
-
-const MIGRATIONS_DIR = new URL('../../src/db/migrations/', import.meta.url);
-
-/**
- * Rebuild the schema by running the **real migrations**, not `sync()`.
- *
- * This is the point of the integration suite: `sync({ force: true })` builds
- * tables from the models, so the models can never disagree with the schema
- * under test and migration drift is invisible. Six tables once shipped without
- * the `deleted_at` column that the global `paranoid: true` default requires,
- * and every suite stayed green because none of them ever ran a migration.
- *
- * Drops every table first so each run starts from nothing and applies the full
- * migration history in filename order — the same path a real deployment takes.
- * @param sequelize - Connection to the (dedicated) test database.
- */
-export async function resetSchemaFromMigrations(sequelize: Sequelize): Promise<void> {
-  const queryInterface = sequelize.getQueryInterface();
-
-  // Pin one connection for the drops: FOREIGN_KEY_CHECKS is session-scoped, so
-  // toggling it on a pooled connection other than the one running the DROPs
-  // would not take effect.
-  await sequelize.transaction(async (transaction) => {
-    const tables = await queryInterface.showAllTables({ transaction });
-    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
-    for (const table of tables) {
-      await sequelize.query(`DROP TABLE IF EXISTS \`${table}\``, { transaction });
-    }
-    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
-  });
-
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- module constant, no external input
-  const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
-  for (const file of files) {
-    const loaded = (await import(new URL(file, MIGRATIONS_DIR).href)) as {
-      default?: Migration;
-    } & Migration;
-    const migration = loaded.default ?? loaded;
-    // Migrations receive the Sequelize class itself (for `Sequelize.DATE` etc.),
-    // exactly as sequelize-cli passes it.
-    await migration.up(queryInterface, SequelizeLib);
-  }
 }
 
 export interface TestHarness {

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
     },
     testTimeout: 10_000,
     // Integration tests share a single MySQL + Redis, so test files must
-    // run sequentially — otherwise `sequelize.sync({ force: true })` in
-    // one file drops tables out from under another.
+    // run sequentially — otherwise one file's schema rebuild
+    // (`resetSchemaFromMigrations`) drops tables out from under another.
     fileParallelism: false,
   },
 });

--- a/e2e/support/seed.ts
+++ b/e2e/support/seed.ts
@@ -1,14 +1,21 @@
 /**
  * Standalone seed entry — invoked by `global-setup.ts` as a `tsx` subprocess
- * against the `livechat_e2e` database. Drops and recreates every table
- * (`sync({ force: true })`) then inserts the {@link fixtures} dataset, so each
- * run starts from an identical, isolated state.
+ * against the `livechat_e2e` database. Drops every table and replays the real
+ * migrations, then inserts the {@link fixtures} dataset, so each run starts
+ * from an identical, isolated state.
+ *
+ * The schema deliberately comes from `api/src/db/migrations` rather than
+ * `sync({ force: true })`: building it from the models would make the models
+ * the source of truth for both the code under test and the schema it runs
+ * against, hiding migration drift from the one suite that drives the real
+ * browser end to end.
  *
  * Run directly: `DB_NAME=livechat_e2e tsx e2e/support/seed.ts`
  */
 import { pino } from 'pino';
 
 import { createSequelize } from '../../api/src/config/mysql.js';
+import { resetSchemaFromMigrations } from '../../api/src/db/migrator.js';
 import { initModels, Invitation, Tenant, User } from '../../api/src/models/index.js';
 
 import { PENDING_INVITATION, TENANTS, USERS } from './fixtures.js';
@@ -28,7 +35,7 @@ const logger = pino({ level: 'error' });
 const sequelize = createSequelize(env, logger);
 initModels(sequelize);
 
-await sequelize.sync({ force: true });
+await resetSchemaFromMigrations(sequelize);
 
 // Tenants first, so users/invitations can resolve their slug → id.
 const tenantIdBySlug = new Map<string, string>();


### PR DESCRIPTION
Follows #38. Converts the last suite that was testing a model-built schema.

### Why this one matters most
While doing this I found that **the integration suite does not actually run in CI**. The `check` job starts no MySQL/Redis, so `probeHarness()` returns null and every integration test returns early — passing without asserting anything. CI reports the same "22 passed" whether infra exists or not.

So #38's improvement only takes effect when someone runs the suite locally with infra up. **The e2e job is different — it brings up real infra via docker compose**, which makes this change the one that actually closes the drift gap in CI.

### The change
- Extracts the migration runner from #38 into **`api/src/db/migrator.ts`** (`e2e/support/seed.ts` already imports from `api/src`, so this is a natural shared home).
- Both consumers now use it: the API integration harness and the e2e seeder.
- `e2e/support/seed.ts` drops every table and replays the real migrations before inserting fixtures, instead of `sync({ force: true })`.
- Fixed a stale comment in `api/vitest.config.ts` that still referenced `sync({ force: true })`.

No `sync({ force: true })` remains in executable code anywhere in the repo.

### Verified both directions
| Scenario | Result |
|---|---|
| `deleted_at` migration present | **8/8 journeys pass**, 22/22 api tests |
| `deleted_at` migration removed | journeys **fail** — `SequelizeDatabaseError: Unknown column 'deleted_at'` at `POST /api/v1/visitor/chats` |

That failing request is the exact one that returned a 500 in the browser. Since e2e runs with real infra in CI, this bug would now be caught before merge.

Lint + typecheck clean.

### Still open (not addressed here)
- The `check` job has no DB, so integration tests silently no-op in CI. Worth either giving that job infra, or making the tests fail loudly instead of returning early when infra is absent.
- The static guard catches missing columns, not type/index/constraint drift.