### PR TITLE
ci: run the integration tests for real instead of silently skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,31 @@ jobs:
         with:
           args: --no-progress '**/*.md'
 
+      # The integration tests return early on a null harness, so without a
+      # database they pass while asserting nothing — a green check that means
+      # nothing. Bring the real stack up and set REQUIRE_DB=1 below so an
+      # unreachable stack fails loudly instead of silently skipping.
+      - name: Start integration infrastructure
+        run: |
+          set -euo pipefail
+          docker compose up -d mysql redis
+          # Retry the readiness query itself: on a fresh volume the entrypoint
+          # runs a temporary server that answers before the real one is up.
+          deadline=$(( SECONDS + 120 ))
+          until docker exec livechat-mysql mysql -ulivechat_user -plivechat_pass \
+            -e 'SELECT 1' livechat_test >/dev/null 2>&1; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "MySQL did not become ready within 120s" >&2
+              docker logs --tail 50 livechat-mysql >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          docker exec livechat-redis redis-cli ping
+
       - run: npm run check:all
+        env:
+          REQUIRE_DB: "1"
 
   usecases-diff-gate:
     runs-on: ubuntu-latest

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -93,9 +93,23 @@ export async function probeHarness(): Promise<TestHarness | null> {
   try {
     await sequelize.authenticate();
     await redis.connect();
-  } catch {
+  } catch (error) {
     await sequelize.close().catch(() => undefined);
     await redis.quit().catch(() => undefined);
+    if (process.env['REQUIRE_DB'] === '1') {
+      // Every integration test returns early on a null harness, so absent
+      // infrastructure otherwise reads as a pass — a green run that asserted
+      // nothing. CI sets REQUIRE_DB=1 so that can never be mistaken for
+      // coverage; locally the null path still skips so `npm test` works
+      // without docker.
+      throw new Error(
+        'REQUIRE_DB=1 but the integration stack is unreachable — ' +
+          `MySQL ${env.DB_HOST}:${String(env.DB_PORT)}/${env.DB_NAME}, ` +
+          `Redis ${env.REDIS_HOST}:${String(env.REDIS_PORT)}. ` +
+          'Start it with `docker compose up -d mysql redis`. ' +
+          `Cause: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
Closes the gap found while doing #39: **the integration tests never actually ran in CI.**

The `check` job started no MySQL or Redis, so `probeHarness()` returned null and every integration test returned early — passing without asserting anything. CI printed the same **"22 passed"** whether a database existed or not. A green light that meant nothing, and precisely why the `deleted_at` migration drift (#37) reached a browser with CI fully green.

### Changes
- **`check` job brings up real infra** — `docker compose up -d mysql redis`, waiting by retrying the readiness query itself (a fresh volume runs a temporary server that answers before the real one is up — the same race fixed in the e2e script).
- **`check:all` runs with `REQUIRE_DB=1`** — `probeHarness()` now throws on an unreachable stack instead of returning null, naming the host, port, and the exact command to fix it.
- **Local runs are unaffected**: without `REQUIRE_DB`, the skip path remains, so `npm test` still works with no Docker.

The test database needs no extra setup — `scripts/mysql-init` creates `livechat_test` on first init, and CI runners are always fresh.

### Verified by exit code (what CI actually keys on)
| Scenario | Exit | Meaning |
|---|---|---|
| unreachable + `REQUIRE_DB=1` | **1** | fails loudly — was silently 0 before |
| reachable + `REQUIRE_DB=1` | **0** | 22/22 genuinely executed |
| unreachable, no flag | **0** | local convenience preserved |

The failure message is actionable rather than a bare stack trace:
> `REQUIRE_DB=1 but the integration stack is unreachable — MySQL localhost:59999/livechat_test, Redis localhost:26380. Start it with 'docker compose up -d mysql redis'.`

### Effect
Combined with #38 and #39, all three suites now run against a migration-built schema, and the integration suite can no longer report success without a database behind it.

Remaining known gap: the guards are column-level, so type/index/constraint drift still isn't caught.