### PR TITLE
Release v0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,31 @@ jobs:
         with:
           args: --no-progress '**/*.md'
 
+      # The integration tests return early on a null harness, so without a
+      # database they pass while asserting nothing — a green check that means
+      # nothing. Bring the real stack up and set REQUIRE_DB=1 below so an
+      # unreachable stack fails loudly instead of silently skipping.
+      - name: Start integration infrastructure
+        run: |
+          set -euo pipefail
+          docker compose up -d mysql redis
+          # Retry the readiness query itself: on a fresh volume the entrypoint
+          # runs a temporary server that answers before the real one is up.
+          deadline=$(( SECONDS + 120 ))
+          until docker exec livechat-mysql mysql -ulivechat_user -plivechat_pass \
+            -e 'SELECT 1' livechat_test >/dev/null 2>&1; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "MySQL did not become ready within 120s" >&2
+              docker logs --tail 50 livechat-mysql >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          docker exec livechat-redis redis-cli ping
+
       - run: npm run check:all
+        env:
+          REQUIRE_DB: "1"
 
   usecases-diff-gate:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
 _Nothing yet._
 
+## [0.1.1] - 2026-07-22
+
+A correctness release. v0.1.0 shipped a database schema the ORM could not read
+on six tables; this fixes that and closes the testing gap that let it through.
+
+### Fixed
+
+- **The widget could not start a chat.** `POST /api/v1/visitor/chats` returned
+  500 with `Unknown column 'deleted_at' in 'field list'`. `paranoid: true` is a
+  global Sequelize `define` default, so every model selects `deleted_at` and
+  filters on it, but six `createTable` migrations never created the column —
+  `visitor_sessions`, `chat_events`, `user_sessions`, `jwt_blacklist`,
+  `audit_logs`, `staff_tenants`. Any read against those tables failed on a
+  migration-created database. ([#37])
+- **e2e stack failed to start on a fresh MySQL volume.** The readiness probe
+  passed against the entrypoint's temporary init server, which then shut down
+  before the real server started, so the next statement hit a dead socket and
+  took the api webServer down with it. ([#38])
+
+### Changed
+
+- **Test schemas are built from the real migrations, not `sync({ force: true })`.**
+  Both the API integration harness and the e2e seeder now drop every table and
+  replay `api/src/db/migrations` via the new `api/src/db/migrator.ts`. Building
+  from the models made the models the source of truth for both the code under
+  test and the schema it ran against, so migration drift was structurally
+  invisible — which is how the bug above shipped with every suite green.
+  ([#38], [#39])
+- **Integration tests actually run in CI.** The `check` job starts MySQL and
+  Redis and runs with `REQUIRE_DB=1`, so an unreachable stack fails loudly.
+  Previously the job had no database, every integration test returned early,
+  and CI reported the same "22 passed" whether or not one existed. Local runs
+  without the flag still skip, so `npm test` works with no Docker. ([#40])
+
+### Added
+
+- A static migration-drift guard (`api/tests/unit/migration-schema-drift.test.ts`)
+  that replays the migrations and asserts each table ends up with the columns
+  the global define defaults require. Needs no database. ([#37])
+- `CHANGELOG.md`, and a README note on `@afixt/*` scoped packages and
+  `NPM_TOKEN` (a 404 there is an auth failure, not a missing package).
+  ([#35], [#36])
+
 ## [0.1.0] - 2026-07-22
 
 First tagged release. Everything below had accumulated on `develop`; `master`
@@ -73,7 +116,8 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
   ships with Node 22, and effective on toolchain upgrade.
 - `body-parser` bumped to 2.3.0, clearing OSV `GHSA-v422-hmwv-36x6`.
 
-[Unreleased]: https://github.com/AFixt/livechat/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/AFixt/livechat/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/AFixt/livechat/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/AFixt/livechat/releases/tag/v0.1.0
 [#1]: https://github.com/AFixt/livechat/issues/1
 [#3]: https://github.com/AFixt/livechat/issues/3
@@ -89,3 +133,9 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
 [#31]: https://github.com/AFixt/livechat/pull/31
 [#32]: https://github.com/AFixt/livechat/pull/32
 [#33]: https://github.com/AFixt/livechat/pull/33
+[#35]: https://github.com/AFixt/livechat/pull/35
+[#36]: https://github.com/AFixt/livechat/pull/36
+[#37]: https://github.com/AFixt/livechat/pull/37
+[#38]: https://github.com/AFixt/livechat/pull/38
+[#39]: https://github.com/AFixt/livechat/pull/39
+[#40]: https://github.com/AFixt/livechat/pull/40

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ npm run dev             # run api, ui, and widget in parallel
 Then `npm run check:all` should pass on a clean clone — it is the same gate
 Husky runs on pre-push.
 
+### `@afixt/*` packages and `NPM_TOKEN`
+
+This repo installs private `@afixt/*` scoped packages (`usecase-runner`,
+`a11y-assert`). In CI, npm authenticates via an **organization-level** GitHub
+Actions secret named `NPM_TOKEN` — `actions/setup-node` writes a runner-local
+`.npmrc` from it, which is why no auth token is committed to this repo's
+`.npmrc` (local installs keep using your own credentials).
+
+If installing an `@afixt/*` package returns **404, that is an authentication
+problem, not a missing package**. The usual cause is a stale **repo-level**
+`NPM_TOKEN` secret shadowing the org-level one — delete the repo-level secret
+rather than overriding it per repository.
+
 ## Scripts
 
 From the repo root:

--- a/api/src/db/migrations/20260722000001-add-missing-deleted-at.cjs
+++ b/api/src/db/migrations/20260722000001-add-missing-deleted-at.cjs
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * Adds the `deleted_at` column that six tables were missing.
+ *
+ * `createSequelize` sets `paranoid: true` as a global `define` default, so
+ * every model emits `deleted_at` in its SELECT field list and appends
+ * `deleted_at IS NULL` to every WHERE. Six create-table migrations omitted the
+ * column, so any read against those tables failed on a migration-created
+ * database with `ER_BAD_FIELD_ERROR: Unknown column 'deleted_at'`.
+ *
+ * This went unnoticed because both the e2e seeder and the API integration
+ * tests build their schema with `sync({ force: true })` — i.e. from the models,
+ * which always include the column — so nothing exercised the migrated schema.
+ */
+const TABLES = [
+  'visitor_sessions',
+  'chat_events',
+  'user_sessions',
+  'jwt_blacklist',
+  'audit_logs',
+  'staff_tenants',
+];
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    for (const table of TABLES) {
+      const columns = await queryInterface.describeTable(table);
+      if (columns.deleted_at !== undefined) continue;
+      await queryInterface.addColumn(table, 'deleted_at', {
+        type: Sequelize.DATE,
+        allowNull: true,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    for (const table of TABLES) {
+      const columns = await queryInterface.describeTable(table);
+      if (columns.deleted_at === undefined) continue;
+      await queryInterface.removeColumn(table, 'deleted_at');
+    }
+  },
+};

--- a/api/src/db/migrator.ts
+++ b/api/src/db/migrator.ts
@@ -1,0 +1,60 @@
+import { readdir } from 'node:fs/promises';
+
+import { Sequelize as SequelizeLib } from 'sequelize';
+
+import type { Sequelize } from 'sequelize';
+
+/** The shape every migration file in `src/db/migrations` exports. */
+interface Migration {
+  up: (
+    queryInterface: ReturnType<Sequelize['getQueryInterface']>,
+    sequelize: unknown,
+  ) => Promise<void>;
+}
+
+const MIGRATIONS_DIR = new URL('./migrations/', import.meta.url);
+
+/**
+ * Rebuild a database's schema by running the **real migrations**, not `sync()`.
+ *
+ * Test harnesses reach for `sequelize.sync({ force: true })` because it is one
+ * line, but it builds tables from the models — so the models become the source
+ * of truth for both the code under test and the schema it runs against, and the
+ * two can never disagree. Migration drift is then structurally invisible: six
+ * tables once shipped without the `deleted_at` column that the global
+ * `paranoid: true` default requires, and every suite stayed green until the
+ * widget returned a 500 in a browser.
+ *
+ * Drops every table, then applies the full migration history in filename order
+ * — the same path a real deployment takes.
+ *
+ * Destructive by design: only point this at a dedicated test/e2e database.
+ * @param sequelize - Connection to the database to rebuild.
+ */
+export async function resetSchemaFromMigrations(sequelize: Sequelize): Promise<void> {
+  const queryInterface = sequelize.getQueryInterface();
+
+  // Pin one connection for the drops: FOREIGN_KEY_CHECKS is session-scoped, so
+  // toggling it on a pooled connection other than the one running the DROPs
+  // would not take effect.
+  await sequelize.transaction(async (transaction) => {
+    const tables = await queryInterface.showAllTables({ transaction });
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
+    for (const table of tables) {
+      await sequelize.query(`DROP TABLE IF EXISTS \`${table}\``, { transaction });
+    }
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+  });
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- module constant, no external input
+  const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
+  for (const file of files) {
+    const loaded = (await import(new URL(file, MIGRATIONS_DIR).href)) as {
+      default?: Migration;
+    } & Migration;
+    const migration = loaded.default ?? loaded;
+    // Migrations receive the Sequelize class itself (for `Sequelize.DATE` etc.),
+    // exactly as sequelize-cli passes it.
+    await migration.up(queryInterface, SequelizeLib);
+  }
+}

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -1,13 +1,12 @@
-import { readdir } from 'node:fs/promises';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
 import Redis, { type Redis as RedisClient } from 'ioredis';
 import { pino, type Logger } from 'pino';
-import { Sequelize as SequelizeLib } from 'sequelize';
 
 import { createApp } from '../../src/app.js';
 import { createSequelize } from '../../src/config/mysql.js';
+import { resetSchemaFromMigrations } from '../../src/db/migrator.js';
 import { attachIo } from '../../src/io/index.js';
 import { initModels } from '../../src/models/index.js';
 import { createServices, type Services } from '../../src/services/index.js';
@@ -57,57 +56,6 @@ export function testEnv(): Env {
     isTest: true,
     isDevelopment: false,
   } as unknown as Env;
-}
-
-/** The shape every migration file in `src/db/migrations` exports. */
-interface Migration {
-  up: (
-    queryInterface: ReturnType<Sequelize['getQueryInterface']>,
-    sequelize: unknown,
-  ) => Promise<void>;
-}
-
-const MIGRATIONS_DIR = new URL('../../src/db/migrations/', import.meta.url);
-
-/**
- * Rebuild the schema by running the **real migrations**, not `sync()`.
- *
- * This is the point of the integration suite: `sync({ force: true })` builds
- * tables from the models, so the models can never disagree with the schema
- * under test and migration drift is invisible. Six tables once shipped without
- * the `deleted_at` column that the global `paranoid: true` default requires,
- * and every suite stayed green because none of them ever ran a migration.
- *
- * Drops every table first so each run starts from nothing and applies the full
- * migration history in filename order — the same path a real deployment takes.
- * @param sequelize - Connection to the (dedicated) test database.
- */
-export async function resetSchemaFromMigrations(sequelize: Sequelize): Promise<void> {
-  const queryInterface = sequelize.getQueryInterface();
-
-  // Pin one connection for the drops: FOREIGN_KEY_CHECKS is session-scoped, so
-  // toggling it on a pooled connection other than the one running the DROPs
-  // would not take effect.
-  await sequelize.transaction(async (transaction) => {
-    const tables = await queryInterface.showAllTables({ transaction });
-    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
-    for (const table of tables) {
-      await sequelize.query(`DROP TABLE IF EXISTS \`${table}\``, { transaction });
-    }
-    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
-  });
-
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- module constant, no external input
-  const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
-  for (const file of files) {
-    const loaded = (await import(new URL(file, MIGRATIONS_DIR).href)) as {
-      default?: Migration;
-    } & Migration;
-    const migration = loaded.default ?? loaded;
-    // Migrations receive the Sequelize class itself (for `Sequelize.DATE` etc.),
-    // exactly as sequelize-cli passes it.
-    await migration.up(queryInterface, SequelizeLib);
-  }
 }
 
 export interface TestHarness {

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -1,8 +1,10 @@
+import { readdir } from 'node:fs/promises';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
 import Redis, { type Redis as RedisClient } from 'ioredis';
 import { pino, type Logger } from 'pino';
+import { Sequelize as SequelizeLib } from 'sequelize';
 
 import { createApp } from '../../src/app.js';
 import { createSequelize } from '../../src/config/mysql.js';
@@ -17,9 +19,9 @@ import type { Server as IoServer } from 'socket.io';
 
 /**
  * A fresh test env. Defaults to a dedicated `livechat_test` database —
- * integration tests `sync({ force: true })`, so pointing them at the shared
- * dev `livechat_db` would wipe whatever you're working on. Override `DB_NAME`
- * to target another database.
+ * integration tests drop every table and re-run the migrations, so pointing
+ * them at the shared dev `livechat_db` would wipe whatever you're working on.
+ * Override `DB_NAME` to target another database.
  * @returns Env for integration testing.
  */
 export function testEnv(): Env {
@@ -55,6 +57,57 @@ export function testEnv(): Env {
     isTest: true,
     isDevelopment: false,
   } as unknown as Env;
+}
+
+/** The shape every migration file in `src/db/migrations` exports. */
+interface Migration {
+  up: (
+    queryInterface: ReturnType<Sequelize['getQueryInterface']>,
+    sequelize: unknown,
+  ) => Promise<void>;
+}
+
+const MIGRATIONS_DIR = new URL('../../src/db/migrations/', import.meta.url);
+
+/**
+ * Rebuild the schema by running the **real migrations**, not `sync()`.
+ *
+ * This is the point of the integration suite: `sync({ force: true })` builds
+ * tables from the models, so the models can never disagree with the schema
+ * under test and migration drift is invisible. Six tables once shipped without
+ * the `deleted_at` column that the global `paranoid: true` default requires,
+ * and every suite stayed green because none of them ever ran a migration.
+ *
+ * Drops every table first so each run starts from nothing and applies the full
+ * migration history in filename order — the same path a real deployment takes.
+ * @param sequelize - Connection to the (dedicated) test database.
+ */
+export async function resetSchemaFromMigrations(sequelize: Sequelize): Promise<void> {
+  const queryInterface = sequelize.getQueryInterface();
+
+  // Pin one connection for the drops: FOREIGN_KEY_CHECKS is session-scoped, so
+  // toggling it on a pooled connection other than the one running the DROPs
+  // would not take effect.
+  await sequelize.transaction(async (transaction) => {
+    const tables = await queryInterface.showAllTables({ transaction });
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
+    for (const table of tables) {
+      await sequelize.query(`DROP TABLE IF EXISTS \`${table}\``, { transaction });
+    }
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+  });
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- module constant, no external input
+  const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
+  for (const file of files) {
+    const loaded = (await import(new URL(file, MIGRATIONS_DIR).href)) as {
+      default?: Migration;
+    } & Migration;
+    const migration = loaded.default ?? loaded;
+    // Migrations receive the Sequelize class itself (for `Sequelize.DATE` etc.),
+    // exactly as sequelize-cli passes it.
+    await migration.up(queryInterface, SequelizeLib);
+  }
 }
 
 export interface TestHarness {
@@ -99,7 +152,7 @@ export async function probeHarness(): Promise<TestHarness | null> {
   }
 
   initModels(sequelize);
-  await sequelize.sync({ force: true });
+  await resetSchemaFromMigrations(sequelize);
   await redis.flushdb();
 
   const services = createServices({ env, logger, redis });

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -93,9 +93,23 @@ export async function probeHarness(): Promise<TestHarness | null> {
   try {
     await sequelize.authenticate();
     await redis.connect();
-  } catch {
+  } catch (error) {
     await sequelize.close().catch(() => undefined);
     await redis.quit().catch(() => undefined);
+    if (process.env['REQUIRE_DB'] === '1') {
+      // Every integration test returns early on a null harness, so absent
+      // infrastructure otherwise reads as a pass — a green run that asserted
+      // nothing. CI sets REQUIRE_DB=1 so that can never be mistaken for
+      // coverage; locally the null path still skips so `npm test` works
+      // without docker.
+      throw new Error(
+        'REQUIRE_DB=1 but the integration stack is unreachable — ' +
+          `MySQL ${env.DB_HOST}:${String(env.DB_PORT)}/${env.DB_NAME}, ` +
+          `Redis ${env.REDIS_HOST}:${String(env.REDIS_PORT)}. ` +
+          'Start it with `docker compose up -d mysql redis`. ' +
+          `Cause: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     return null;
   }
 

--- a/api/tests/unit/migration-schema-drift.test.ts
+++ b/api/tests/unit/migration-schema-drift.test.ts
@@ -1,0 +1,130 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards against schema/model drift in the migrations.
+ *
+ * `createSequelize` sets `paranoid: true`, `timestamps: true` as global
+ * `define` defaults, so every model emits `deleted_at` in its SELECT field list
+ * and appends `deleted_at IS NULL` to every WHERE. A table whose migrations
+ * never produce the column yields a database the ORM cannot read —
+ * `ER_BAD_FIELD_ERROR: Unknown column 'deleted_at'` on the first query.
+ *
+ * Six tables shipped that way (visitor_sessions, chat_events, user_sessions,
+ * jwt_blacklist, audit_logs, staff_tenants) and it reached a running stack,
+ * because the e2e seeder and the integration suite both build their schema with
+ * `sync({ force: true })` — from the models, which always include the column —
+ * so nothing exercised the migrated schema. This test closes that gap
+ * statically, without needing a database.
+ *
+ * It replays the migrations in filename order and accumulates each table's
+ * effective column set, so a column introduced by a later `addColumn` counts
+ * just as much as one declared in the original `createTable`.
+ */
+
+const MIGRATIONS_DIR = join(import.meta.dirname, '../../src/db/migrations');
+
+/**
+ * Columns every table must end up with.
+ *
+ * Only `deleted_at` is universal: `paranoid: true` is a global define default
+ * and no model overrides it to `false`, so every table is read with a
+ * `deleted_at IS NULL` predicate. `updated_at` is deliberately NOT asserted —
+ * append-only models (audit_logs, chat_events, jwt_blacklist, staff_tenants,
+ * chat_attachments) legitimately set `updatedAt: false`.
+ */
+const REQUIRED_COLUMNS = ['created_at', 'deleted_at'] as const;
+
+/**
+ * Find the matching close brace for the `{` that begins at `from`.
+ * @param source - Text to scan.
+ * @param from - Index just past the opening brace.
+ * @returns Index just past the matching close brace.
+ */
+function matchBrace(source: string, from: number): number {
+  let depth = 1;
+  let i = from;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    i += 1;
+  }
+  return i;
+}
+
+/**
+ * Replay every migration and build each table's effective column set.
+ * @param sources - Migration file contents, in filename order.
+ * @returns Map of table name to the columns its migrations produce.
+ */
+function effectiveColumns(sources: string[]): Map<string, Set<string>> {
+  const tables = new Map<string, Set<string>>();
+
+  for (const source of sources) {
+    const creates = /createTable\(\s*['"`]([a-z_]+)['"`]\s*,\s*\{/g;
+    let m: RegExpExecArray | null;
+    while ((m = creates.exec(source)) !== null) {
+      const table = m[1];
+      if (table === undefined) continue;
+      const end = matchBrace(source, creates.lastIndex);
+      const body = source.slice(creates.lastIndex, end);
+      const cols = new Set<string>();
+      for (const c of body.matchAll(/^\s*([a-z_]+)\s*:/gm)) {
+        if (c[1] !== undefined) cols.add(c[1]);
+      }
+      tables.set(table, cols);
+    }
+
+    // addColumn('table', 'column', …) — including loops over a table list,
+    // which is how the corrective migration backfills several tables at once.
+    for (const a of source.matchAll(
+      /addColumn\(\s*(?:['"`]([a-z_]+)['"`]|[A-Za-z_$][\w$]*)\s*,\s*['"`]([a-z_]+)['"`]/g,
+    )) {
+      const [, literalTable, column] = a;
+      if (column === undefined) continue;
+      if (literalTable !== undefined) {
+        (tables.get(literalTable) ?? tables.set(literalTable, new Set()).get(literalTable))?.add(
+          column,
+        );
+        continue;
+      }
+      // Variable table name: applies to every table named in the file, which
+      // for our loop-style migrations is the declared TABLES array.
+      for (const t of source.matchAll(/['"`]([a-z_]+)['"`]\s*,?\s*$/gm)) {
+        const name = t[1];
+        if (name !== undefined && tables.has(name)) tables.get(name)?.add(column);
+      }
+    }
+  }
+  return tables;
+}
+
+describe('migration schema drift', () => {
+  it('every migrated table ends up with the columns the define defaults require', async () => {
+    // Both paths derive from MIGRATIONS_DIR, a module constant resolved from
+    // import.meta.dirname — no external input reaches them, so the non-literal
+    // filename rule is a false positive here.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.cjs')).sort();
+    expect(files.length).toBeGreaterThan(0);
+
+    const sources = await Promise.all(
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      files.map(async (f) => readFile(join(MIGRATIONS_DIR, f), 'utf8')),
+    );
+    const tables = effectiveColumns(sources);
+    expect(tables.size).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const [table, columns] of tables) {
+      for (const required of REQUIRED_COLUMNS) {
+        if (!columns.has(required)) offenders.push(`${table} is missing ${required}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
     },
     testTimeout: 10_000,
     // Integration tests share a single MySQL + Redis, so test files must
-    // run sequentially — otherwise `sequelize.sync({ force: true })` in
-    // one file drops tables out from under another.
+    // run sequentially — otherwise one file's schema rebuild
+    // (`resetSchemaFromMigrations`) drops tables out from under another.
     fileParallelism: false,
   },
 });

--- a/e2e/setup-and-serve-api.sh
+++ b/e2e/setup-and-serve-api.sh
@@ -13,24 +13,25 @@ ROOT_PASS="${DB_ROOT_PASS:-livechat_root_pass}"
 
 docker compose up -d mysql redis mailhog
 
-# Wait until root auth actually works, not just until the socket answers. On a
-# fresh volume (CI) the entrypoint runs a temporary server during init that
-# replies to `mysqladmin ping` before the root password is applied, so a ping
-# probe races ahead and the next command hits "Access denied". A root SELECT
-# only succeeds once the real, initialised server is up.
-echo "e2e: waiting for MySQL to accept root auth…"
-deadline=$(( SECONDS + 90 ))
-until docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e 'SELECT 1' >/dev/null 2>&1; do
+# Retry the provisioning statement itself rather than probing first and acting
+# after. On a fresh volume (CI) the entrypoint runs a temporary server during
+# init: it answers `mysqladmin ping`, and even a root `SELECT 1`, then shuts
+# down before the real server starts. So a probe that passes is no guarantee
+# the *next* command finds a live socket — that window is how this failed with
+# "ERROR 2002: Can't connect to local MySQL server through socket". Making the
+# idempotent CREATE/GRANT the readiness check closes it.
+echo "e2e: waiting for MySQL and provisioning ${DB_NAME}…"
+deadline=$(( SECONDS + 120 ))
+until docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
+  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
+   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;" >/dev/null 2>&1; do
   if [ "$SECONDS" -ge "$deadline" ]; then
-    echo "e2e: MySQL did not accept root auth within 90s" >&2
+    echo "e2e: MySQL did not become ready within 120s" >&2
+    docker logs --tail 50 livechat-mysql >&2 || true
     exit 1
   fi
   sleep 1
 done
-
-docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
-  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
-   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"
 
 echo "e2e: seeding ${DB_NAME}…"
 node_modules/.bin/tsx e2e/support/seed.ts

--- a/e2e/support/seed.ts
+++ b/e2e/support/seed.ts
@@ -1,14 +1,21 @@
 /**
  * Standalone seed entry — invoked by `global-setup.ts` as a `tsx` subprocess
- * against the `livechat_e2e` database. Drops and recreates every table
- * (`sync({ force: true })`) then inserts the {@link fixtures} dataset, so each
- * run starts from an identical, isolated state.
+ * against the `livechat_e2e` database. Drops every table and replays the real
+ * migrations, then inserts the {@link fixtures} dataset, so each run starts
+ * from an identical, isolated state.
+ *
+ * The schema deliberately comes from `api/src/db/migrations` rather than
+ * `sync({ force: true })`: building it from the models would make the models
+ * the source of truth for both the code under test and the schema it runs
+ * against, hiding migration drift from the one suite that drives the real
+ * browser end to end.
  *
  * Run directly: `DB_NAME=livechat_e2e tsx e2e/support/seed.ts`
  */
 import { pino } from 'pino';
 
 import { createSequelize } from '../../api/src/config/mysql.js';
+import { resetSchemaFromMigrations } from '../../api/src/db/migrator.js';
 import { initModels, Invitation, Tenant, User } from '../../api/src/models/index.js';
 
 import { PENDING_INVITATION, TENANTS, USERS } from './fixtures.js';
@@ -28,7 +35,7 @@ const logger = pino({ level: 'error' });
 const sequelize = createSequelize(env, logger);
 initModels(sequelize);
 
-await sequelize.sync({ force: true });
+await resetSchemaFromMigrations(sequelize);
 
 // Tenants first, so users/invitations can resolve their slug → id.
 const tenantIdBySlug = new Map<string, string>();

--- a/lychee.toml
+++ b/lychee.toml
@@ -31,6 +31,11 @@ exclude = [
   # subdomain is unreliable and answers 503 to the checker (fine in a browser).
   # Not our content to fix — exclude the host rather than block every PR on it.
   "^https?://output\\.jsbin\\.com",
+  # CHANGELOG "compare" links name the tag being released, which does not exist
+  # until the release is tagged — so they 404 on the pre-push that ships the
+  # release commit itself. Only the compare form is excluded; the per-version
+  # releases/tag links are still checked.
+  "^https://github\\.com/AFixt/livechat/compare/",
 ]
 
 # Sites that block automated checkers answer 403/429 to lychee but are fine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "workspaces": [
         "shared",
         "api",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",


### PR DESCRIPTION
Patch release. No `feat`, no breaking changes.

**This is the release that matters** — `main` currently carries a schema the ORM cannot read on six tables, so a visitor cannot start a chat at all in production.

### Fixed
- **The widget could not start a chat** ([#37]) — `POST /api/v1/visitor/chats` returned 500 with `Unknown column 'deleted_at' in 'field list'`. `paranoid: true` is a global Sequelize default, so every model selects and filters on `deleted_at`, but six `createTable` migrations never created it: `visitor_sessions`, `chat_events`, `user_sessions`, `jwt_blacklist`, `audit_logs`, `staff_tenants`.
- **e2e stack failed to start on a fresh MySQL volume** ([#38]) — the readiness probe passed against the entrypoint's temporary init server, which shut down before the real one started.

### Changed — the testing gap that let it ship
The bug reached a browser with **every suite green**, because nothing ever ran a migration:
- Integration harness and e2e seeder now build schema from the **real migrations** instead of `sync({ force: true })` ([#38], [#39]).
- Integration tests **actually run in CI** — the `check` job now starts MySQL/Redis and sets `REQUIRE_DB=1`, so an unreachable stack fails loudly. Previously they returned early and CI printed "22 passed" with no database at all ([#40]).

### Added
- Static migration-drift guard test (needs no DB) ([#37]).
- `CHANGELOG.md` ([#35]) and a README note on `@afixt/*` + `NPM_TOKEN` ([#36]).

Verified: removing the `deleted_at` migration now fails both the e2e journeys and the integration suite with the real `Unknown column 'deleted_at'` error.

https://github.com/AFixt/livechat/compare/v0.1.0...develop

[#35]: https://github.com/AFixt/livechat/pull/35
[#36]: https://github.com/AFixt/livechat/pull/36
[#37]: https://github.com/AFixt/livechat/pull/37
[#38]: https://github.com/AFixt/livechat/pull/38
[#39]: https://github.com/AFixt/livechat/pull/39
[#40]: https://github.com/AFixt/livechat/pull/40