### PR TITLE
test(api): enforce coverage thresholds in check:all and fill the gaps

### DIFF
--- a/api/src/config/env.test.ts
+++ b/api/src/config/env.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const REQUIRED_ENV: Record<string, string> = {
+  DB_HOST: 'localhost',
+  DB_NAME: 'livechat',
+  DB_USER: 'livechat_user',
+  DB_PASS: 'livechat_pass',
+  REDIS_HOST: 'localhost',
+  JWT_ACCESS_SECRET: 'access-secret',
+  JWT_REFRESH_SECRET: 'refresh-secret',
+  COOKIE_SECRET: 'cookie-secret',
+  APP_URL: 'http://localhost:3000',
+  API_URL: 'http://localhost:3001',
+  WIDGET_URL: 'http://localhost:3002',
+  SMTP_HOST: 'localhost',
+  S3_ACCESS_KEY: 'access-key',
+  S3_SECRET_KEY: 'secret-key',
+  S3_BUCKET: 'bucket',
+};
+
+const REQUIRED_KEYS = Object.keys(REQUIRED_ENV);
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of REQUIRED_KEYS) savedEnv[key] = process.env[key];
+  savedEnv['NODE_ENV'] = process.env['NODE_ENV'];
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) Reflect.deleteProperty(process.env, key);
+    else process.env[key] = value;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('loadEnv', () => {
+  it('accepts a fully-populated, valid environment', async () => {
+    for (const [key, value] of Object.entries(REQUIRED_ENV)) process.env[key] = value;
+    process.env['NODE_ENV'] = 'test';
+
+    const { loadEnv } = await import('./env.js');
+    const env = loadEnv();
+
+    expect(env.DB_HOST).toBe('localhost');
+    expect(env.NODE_ENV).toBe('test');
+    // Defaulted values prove the schema actually ran rather than passing
+    // through untouched input.
+    expect(env.PORT).toBe(3000);
+    expect(env.DB_SSL).toBe(false);
+    expect(env.LOG_LEVEL).toBe('info');
+  });
+
+  it('exits the process (via the envalid default reporter) when required vars are missing', async () => {
+    for (const key of REQUIRED_KEYS) Reflect.deleteProperty(process.env, key);
+    process.env['NODE_ENV'] = 'test';
+
+    // envalid's default reporter binds `console.error` once, at module load
+    // (`var defaultLogger = console.error.bind(console)`), before this test
+    // gets a chance to spy on it — so only `process.exit` is observable here.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    const { loadEnv } = await import('./env.js');
+    loadEnv();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/api/src/config/logger.test.ts
+++ b/api/src/config/logger.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LoggerOptions } from 'pino';
+
+const { pinoMock } = vi.hoisted(() => ({
+  pinoMock: vi.fn((options: LoggerOptions) => ({ __options: options })),
+}));
+
+vi.mock('pino', () => ({
+  pino: (options: LoggerOptions) => pinoMock(options),
+}));
+
+describe('createLogger', () => {
+  it('sets the level from env.LOG_LEVEL', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'production', LOG_LEVEL: 'warn' });
+    expect(pinoMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ level: 'warn' }));
+  });
+
+  it('redacts sensitive fields and removes them entirely', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'test', LOG_LEVEL: 'error' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.redact).toEqual({
+      paths: [
+        'req.headers.authorization',
+        'req.headers.cookie',
+        'req.headers["x-xsrf-token"]',
+        'password',
+        'password_hash',
+        'token',
+        'refreshToken',
+        'accessToken',
+      ],
+      remove: true,
+    });
+  });
+
+  it('does not attach a pretty-print transport outside development', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'production', LOG_LEVEL: 'info' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.transport).toBeUndefined();
+  });
+
+  it('attaches the pino-pretty transport in development', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'development', LOG_LEVEL: 'debug' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.transport).toEqual({
+      target: 'pino-pretty',
+      options: { translateTime: 'HH:MM:ss.l', ignore: 'pid,hostname,env' },
+    });
+  });
+
+  it('carries NODE_ENV through as base.env', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'test', LOG_LEVEL: 'info' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.base).toEqual({ env: 'test' });
+  });
+});

--- a/api/src/config/mysql.test.ts
+++ b/api/src/config/mysql.test.ts
@@ -1,9 +1,10 @@
 import { pino } from 'pino';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createSequelize } from './mysql.js';
 
 import type { Env } from './env.js';
+import type { Logger } from 'pino';
 import type { Sequelize } from 'sequelize';
 
 const logger = pino({ level: 'silent' });
@@ -34,6 +35,39 @@ function sslOf(sequelize: Sequelize): Ssl | undefined {
   };
   return withOptions.options.dialectOptions?.ssl;
 }
+
+/**
+ * Read the resolved `logging` function off a built Sequelize instance, the
+ * same narrow-cast approach as {@link sslOf}.
+ * @param sequelize - The instance built by createSequelize.
+ * @returns The logging option, either `false` or a `(sql: string) => void`.
+ */
+function loggingOf(sequelize: Sequelize): false | ((sql: string) => void) {
+  const withOptions = sequelize as unknown as {
+    options: { logging: false | ((sql: string) => void) };
+  };
+  return withOptions.options.logging;
+}
+
+describe('createSequelize SQL logging', () => {
+  it('disables query logging outside development', () => {
+    const sequelize = createSequelize({ ...baseEnv, DB_SSL: false, DB_SSL_CA: '' }, logger);
+    expect(loggingOf(sequelize)).toBe(false);
+  });
+
+  it('logs each query at debug level in development', () => {
+    const debugSpy = vi.fn();
+    const devLogger = { debug: debugSpy } as unknown as Logger;
+    const sequelize = createSequelize(
+      { ...baseEnv, NODE_ENV: 'development', DB_SSL: false, DB_SSL_CA: '' },
+      devLogger,
+    );
+    const logging = loggingOf(sequelize);
+    expect(typeof logging).toBe('function');
+    if (typeof logging === 'function') logging('SELECT 1');
+    expect(debugSpy).toHaveBeenCalledExactlyOnceWith({ sql: 'SELECT 1' }, 'sql');
+  });
+});
 
 describe('createSequelize DB TLS', () => {
   it('omits ssl when DB_SSL is false (local docker-compose stays plaintext)', () => {

--- a/api/src/config/redis.test.ts
+++ b/api/src/config/redis.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'pino';
+
+interface CapturedRedisOptions {
+  host: string;
+  port: number;
+  lazyConnect: boolean;
+  maxRetriesPerRequest: number;
+  enableReadyCheck: boolean;
+}
+
+type ErrorHandler = (error: Error) => void;
+
+const { FakeRedis, constructed } = vi.hoisted(() => {
+  const instances: {
+    options: CapturedRedisOptions;
+    triggerError: (error: Error) => void;
+  }[] = [];
+
+  class FakeRedisImpl {
+    public readonly options: CapturedRedisOptions;
+    private errorHandler: ErrorHandler | undefined;
+
+    public constructor(options: CapturedRedisOptions) {
+      this.options = options;
+      instances.push(this);
+    }
+
+    public on(event: string, handler: ErrorHandler): this {
+      if (event === 'error') this.errorHandler = handler;
+      return this;
+    }
+
+    public triggerError(error: Error): void {
+      this.errorHandler?.(error);
+    }
+  }
+
+  return { FakeRedis: FakeRedisImpl, constructed: instances };
+});
+
+vi.mock('ioredis', () => ({ default: FakeRedis }));
+
+function fakeLogger(): Logger {
+  return { error: vi.fn() } as unknown as Logger;
+}
+
+describe('createRedis', () => {
+  beforeEach(() => {
+    constructed.length = 0;
+  });
+
+  it('builds a lazy-connect client from the given host and port', async () => {
+    const { createRedis } = await import('./redis.js');
+    const logger = fakeLogger();
+    createRedis({ REDIS_HOST: 'redis.internal', REDIS_PORT: 6380 }, logger);
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0]?.options).toEqual({
+      host: 'redis.internal',
+      port: 6380,
+      lazyConnect: true,
+      maxRetriesPerRequest: 3,
+      enableReadyCheck: true,
+    });
+  });
+
+  it('logs redis errors through the provided logger', async () => {
+    const { createRedis } = await import('./redis.js');
+    const logger = fakeLogger();
+    createRedis({ REDIS_HOST: 'localhost', REDIS_PORT: 6379 }, logger);
+    const instance = constructed[0];
+    expect(instance).toBeDefined();
+    const boom = new Error('connection refused');
+    instance?.triggerError(boom);
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith({ err: boom }, 'redis error');
+  });
+});

--- a/api/src/middlewares/authorize.test.ts
+++ b/api/src/middlewares/authorize.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { requireRole, requireStaffOrAdmin, requireTenantAccess } from './authorize.js';
+
+import type { User } from '../models/index.js';
+import type { Request, Response } from 'express';
+
+/**
+ * Build a minimal fake User for a given role/tenant, cast to the real type so
+ * call sites see the shape they expect without standing up Sequelize.
+ * @param role - Role to assign.
+ * @param tenantId - Tenant id, or null for tenantless accounts.
+ * @returns A fake User.
+ */
+function fakeUser(role: User['role'], tenantId: string | null = null): User {
+  return { role, tenantId } as unknown as User;
+}
+
+/**
+ * Build a fake Express Request carrying only what these middlewares read.
+ * @param overrides - Partial fields to set on the request.
+ * @returns A fake Request.
+ */
+function fakeReq(overrides: {
+  user?: User;
+  params?: Record<string, unknown>;
+  body?: unknown;
+  query?: Record<string, unknown>;
+}): Request {
+  return {
+    user: overrides.user,
+    params: overrides.params ?? {},
+    body: overrides.body ?? {},
+    query: overrides.query ?? {},
+  } as unknown as Request;
+}
+
+const res = {} as Response;
+
+describe('requireRole', () => {
+  it('calls next with 401 when no user is authenticated', () => {
+    const next = vi.fn();
+    const req = fakeReq({});
+    requireRole('admin')(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+  });
+
+  it('calls next with 403 when the user role is not in the allowed list', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('client') });
+    requireRole('admin', 'staff')(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Insufficient permissions');
+  });
+
+  it('calls next with no argument when the user role is allowed', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('admin') });
+    requireRole('admin', 'staff')(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+});
+
+describe('requireStaffOrAdmin', () => {
+  it.each(['super_admin', 'admin', 'staff'] as const)('allows role %s through', (role) => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser(role) });
+    requireStaffOrAdmin()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('rejects a client', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('client') });
+    requireStaffOrAdmin()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.status).toBe(403);
+  });
+});
+
+describe('requireTenantAccess', () => {
+  it('calls next with 401 when no user is authenticated', () => {
+    const next = vi.fn();
+    const req = fakeReq({});
+    requireTenantAccess()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+  });
+
+  it.each(['super_admin', 'admin', 'staff'] as const)(
+    'lets %s through regardless of tenant mismatch',
+    (role) => {
+      const next = vi.fn();
+      const req = fakeReq({
+        user: fakeUser(role, 'tenant-a'),
+        params: { tenantId: 'tenant-b' },
+      });
+      requireTenantAccess()(req, res, next);
+      expect(next).toHaveBeenCalledExactlyOnceWith();
+    },
+  );
+
+  it('allows a client through when no tenantId is present anywhere on the request', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('client', 'tenant-a') });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('allows a client whose params.tenantId matches their own tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      params: { tenantId: 'tenant-a' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('allows a client whose body.tenantId matches their own tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      body: { tenantId: 'tenant-a' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('allows a client whose query.tenantId matches their own tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      query: { tenantId: 'tenant-a' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('prefers params.tenantId over body/query when present', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      params: { tenantId: 'tenant-a' },
+      body: { tenantId: 'tenant-b' },
+      query: { tenantId: 'tenant-c' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('calls next with 403 when the resolved tenantId does not match the user tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      params: { tenantId: 'tenant-b' },
+    });
+    requireTenantAccess()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Access denied to this tenant');
+  });
+});

--- a/api/src/middlewares/error-handler.test.ts
+++ b/api/src/middlewares/error-handler.test.ts
@@ -1,0 +1,121 @@
+import { pino } from 'pino';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { errorHandler } from './error-handler.js';
+
+import type { Request, Response } from 'express';
+import type { Logger } from 'pino';
+import type { ZodError } from 'zod';
+
+/**
+ * A logger that records `error` calls instead of writing them.
+ * @returns The stub logger and the recorded calls.
+ */
+function stubLogger(): { logger: Logger; errors: { err: unknown; msg: string }[] } {
+  const errors: { err: unknown; msg: string }[] = [];
+  const base = pino({ level: 'silent' });
+  const logger = Object.create(base) as Logger;
+  logger.error = ((obj: { err: unknown }, msg: string) => {
+    errors.push({ err: obj.err, msg });
+  }) as Logger['error'];
+  return { logger, errors };
+}
+
+/**
+ * Build a fake response that records `status` and `json` calls.
+ * @returns The fake response plus the captured status/body.
+ */
+function fakeRes(): { res: Response; captured: { status?: number; body?: unknown } } {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status: vi.fn((code: number) => {
+      captured.status = code;
+      return res;
+    }),
+    json: vi.fn((body: unknown) => {
+      captured.body = body;
+      return res;
+    }),
+  } as unknown as Response;
+  return { res, captured };
+}
+
+const req = { correlationId: 'corr-1', path: '/api/v1/thing' } as unknown as Request;
+
+describe('errorHandler', () => {
+  it('serializes an ApiError with its own status and message', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)(ApiError.forbidden('nope'), req, res, next);
+    expect(captured.status).toBe(403);
+    expect(captured.body).toEqual({ success: false, message: 'nope' });
+    expect(errors).toEqual([]);
+  });
+
+  it('includes details on the payload when the ApiError carries them', () => {
+    const { logger } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)(ApiError.badRequest('bad', { field: 'name' }), req, res, next);
+    expect(captured.status).toBe(400);
+    expect(captured.body).toEqual({
+      success: false,
+      message: 'bad',
+      details: { field: 'name' },
+    });
+  });
+
+  it('omits details when the ApiError has none', () => {
+    const { logger } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)(ApiError.notFound(), req, res, next);
+    expect(captured.body).toEqual({ success: false, message: 'Not found' });
+    expect(captured.body).not.toHaveProperty('details');
+  });
+
+  it('serializes a bare ZodError as a 400 validation failure', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    const schema = z.object({ name: z.string() });
+    const zodError = schema.safeParse({ name: 42 }).error as ZodError;
+    errorHandler(logger)(zodError, req, res, next);
+    expect(captured.status).toBe(400);
+    expect(captured.body).toEqual({
+      success: false,
+      message: 'Validation failed',
+      details: zodError.issues,
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('logs and returns a generic 500 for an unrecognized Error', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    const boom = new Error('kaboom');
+    errorHandler(logger)(boom, req, res, next);
+    expect(captured.status).toBe(500);
+    expect(captured.body).toEqual({ success: false, message: 'Internal server error' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.err).toBe(boom);
+    expect(errors[0]?.msg).toBe('unhandled error');
+  });
+
+  it('logs and returns a generic 500 for a non-Error throw', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)('a string was thrown', req, res, next);
+    expect(captured.status).toBe(500);
+    expect(captured.body).toEqual({ success: false, message: 'Internal server error' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.err).toBe('a string was thrown');
+    expect(errors[0]?.msg).toBe('unhandled non-error throw');
+  });
+});

--- a/api/src/middlewares/not-found-handler.test.ts
+++ b/api/src/middlewares/not-found-handler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { notFoundHandler } from './not-found-handler.js';
+
+import type { Request, Response } from 'express';
+
+describe('notFoundHandler', () => {
+  it('calls next with a 404 ApiError describing the missing route', () => {
+    const next = vi.fn();
+    const req = { method: 'GET', path: '/api/v1/nope' } as unknown as Request;
+    const res = {} as Response;
+    notFoundHandler()(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Route not found: GET /api/v1/nope');
+  });
+
+  it('reflects the actual method and path for a different route', () => {
+    const next = vi.fn();
+    const req = { method: 'POST', path: '/widgets' } as unknown as Request;
+    const res = {} as Response;
+    notFoundHandler()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.message).toBe('Route not found: POST /widgets');
+  });
+});

--- a/api/src/middlewares/origin-allowed.test.ts
+++ b/api/src/middlewares/origin-allowed.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Tenant } from '../models/index.js';
+import { ApiError } from '../utils/api-error.js';
+
+import { originAllowed } from './origin-allowed.js';
+
+import type { Request, Response } from 'express';
+
+/**
+ * Build a fake Express Request with a header lookup, query, and body.
+ * @param overrides - Partial fields to set on the request.
+ * @returns A fake Request.
+ */
+function fakeReq(overrides: {
+  origin?: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+}): Request {
+  return {
+    header: (name: string) => (name === 'origin' ? overrides.origin : undefined),
+    query: overrides.query ?? {},
+    body: overrides.body,
+  } as unknown as Request;
+}
+
+const res = {} as Response;
+
+/** Wait for the microtask queue to flush so the async IIFE inside the middleware settles. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('originAllowed', () => {
+  it('lets the request through when there is no Origin header', async () => {
+    const findOne = vi.spyOn(Tenant, 'findOne');
+    const next = vi.fn();
+    const req = fakeReq({});
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('lets the request through when the tenant key cannot be resolved', async () => {
+    const findOne = vi.spyOn(Tenant, 'findOne');
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com' });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('resolves the tenant key from the query string', async () => {
+    const findOne = vi
+      .spyOn(Tenant, 'findOne')
+      .mockResolvedValue({ allowedOrigins: [] } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(findOne).toHaveBeenCalledExactlyOnceWith({
+      where: { slug: 'acme' },
+      attributes: ['id', 'allowedOrigins'],
+    });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('resolves the tenant key from the body when absent from the query', async () => {
+    const findOne = vi
+      .spyOn(Tenant, 'findOne')
+      .mockResolvedValue({ allowedOrigins: [] } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', body: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(findOne).toHaveBeenCalledExactlyOnceWith({
+      where: { slug: 'acme' },
+      attributes: ['id', 'allowedOrigins'],
+    });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when the tenant cannot be found', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue(null);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'ghost' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when allowedOrigins is null (no restriction)', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({ allowedOrigins: null } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when allowedOrigins is an empty array', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({ allowedOrigins: [] } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when the origin is in the allowed list', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({
+      allowedOrigins: ['https://example.com', 'https://other.com'],
+    } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('calls next with a 403 ApiError when the origin is not in the allowed list', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({
+      allowedOrigins: ['https://other.com'],
+    } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Origin not allowed for this tenant');
+  });
+
+  it('calls next with the rejection reason when the tenant lookup throws', async () => {
+    const boom = new Error('db unreachable');
+    vi.spyOn(Tenant, 'findOne').mockRejectedValue(boom);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith(boom);
+  });
+});

--- a/api/src/middlewares/rate-limit.test.ts
+++ b/api/src/middlewares/rate-limit.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RequestHandler } from 'express';
+import type { Redis } from 'ioredis';
+
+/**
+ * Options captured from the real `rateLimit()` call so tests can assert on
+ * them without pulling in express or a live Redis connection.
+ */
+interface CapturedRateLimitOptions {
+  windowMs: number;
+  limit: number;
+  standardHeaders: string;
+  legacyHeaders: boolean;
+  store: unknown;
+}
+
+const noopHandler: RequestHandler = (_req, _res, next) => {
+  next();
+};
+
+const rateLimitMock = vi.fn((_options: CapturedRateLimitOptions): RequestHandler => noopHandler);
+
+/**
+ * Options captured from the real `RedisStore` constructor.
+ */
+interface CapturedStoreOptions {
+  sendCommand: (command: string, ...args: (string | number | Buffer)[]) => Promise<unknown>;
+  prefix: string;
+}
+
+let lastStoreOptions: CapturedStoreOptions | undefined;
+
+class FakeRedisStore {
+  public readonly options: CapturedStoreOptions;
+
+  public constructor(options: CapturedStoreOptions) {
+    this.options = options;
+    lastStoreOptions = options;
+  }
+}
+
+vi.mock('express-rate-limit', () => ({
+  rateLimit: (options: CapturedRateLimitOptions): RequestHandler => rateLimitMock(options),
+}));
+
+vi.mock('rate-limit-redis', () => ({
+  RedisStore: FakeRedisStore,
+}));
+
+const { createAuthLimiter, createGlobalLimiter, createRateLimiter } = await import(
+  './rate-limit.js'
+);
+
+/**
+ * Build a fake ioredis client that just records `call` invocations.
+ * @returns The fake client and the list of recorded calls.
+ */
+function fakeRedis(): { redis: Redis; calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  const redis = {
+    call: (...args: unknown[]) => {
+      calls.push(args);
+      return Promise.resolve('OK');
+    },
+  } as unknown as Redis;
+  return { redis, calls };
+}
+
+describe('createRateLimiter', () => {
+  it('builds a rate limiter with the given window, max, and Redis-backed store', () => {
+    rateLimitMock.mockClear();
+    const { redis } = fakeRedis();
+    createRateLimiter({ redis, windowMs: 1000, max: 10, prefix: 'rl:test:' });
+    expect(rateLimitMock).toHaveBeenCalledTimes(1);
+    const options = rateLimitMock.mock.calls[0]?.[0];
+    expect(options?.windowMs).toBe(1000);
+    expect(options?.limit).toBe(10);
+    expect(options?.standardHeaders).toBe('draft-7');
+    expect(options?.legacyHeaders).toBe(false);
+    expect(options?.store).toBeInstanceOf(FakeRedisStore);
+  });
+
+  it('wires the store prefix through to RedisStore', () => {
+    const { redis } = fakeRedis();
+    createRateLimiter({ redis, windowMs: 1000, max: 10, prefix: 'rl:custom:' });
+    expect(lastStoreOptions?.prefix).toBe('rl:custom:');
+  });
+
+  it('forwards sendCommand calls to redis.call with the command and args', async () => {
+    const { redis, calls } = fakeRedis();
+    createRateLimiter({ redis, windowMs: 1000, max: 10, prefix: 'rl:test:' });
+    await lastStoreOptions?.sendCommand('EVALSHA', 'abc123', 1, 'key');
+    expect(calls).toEqual([['EVALSHA', 'abc123', 1, 'key']]);
+  });
+});
+
+describe('createGlobalLimiter', () => {
+  it('configures a 300-per-15-minutes limiter under the rl:global: prefix', () => {
+    rateLimitMock.mockClear();
+    const { redis } = fakeRedis();
+    createGlobalLimiter(redis);
+    const options = rateLimitMock.mock.calls[0]?.[0];
+    expect(options?.windowMs).toBe(15 * 60 * 1000);
+    expect(options?.limit).toBe(300);
+    expect(lastStoreOptions?.prefix).toBe('rl:global:');
+  });
+});
+
+describe('createAuthLimiter', () => {
+  it('configures a 5-per-15-minutes limiter under the rl:auth: prefix', () => {
+    rateLimitMock.mockClear();
+    const { redis } = fakeRedis();
+    createAuthLimiter(redis);
+    const options = rateLimitMock.mock.calls[0]?.[0];
+    expect(options?.windowMs).toBe(15 * 60 * 1000);
+    expect(options?.limit).toBe(5);
+    expect(lastStoreOptions?.prefix).toBe('rl:auth:');
+  });
+});

--- a/api/src/middlewares/validate.test.ts
+++ b/api/src/middlewares/validate.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { parsedBody, validate } from './validate.js';
+
+import type { Request, Response } from 'express';
+
+/**
+ * Build a fake Express Request carrying only body/query/params.
+ * @param overrides - Partial fields to set on the request.
+ * @returns A fake Request.
+ */
+function fakeReq(overrides: {
+  body?: unknown;
+  query?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+}): Request {
+  return {
+    body: overrides.body ?? {},
+    query: overrides.query ?? {},
+    params: overrides.params ?? {},
+  } as unknown as Request;
+}
+
+const res = {} as Response;
+
+describe('validate', () => {
+  it('parses and replaces req.body when a body schema is given', () => {
+    const next = vi.fn();
+    const schema = z.object({ name: z.string() });
+    const req = fakeReq({ body: { name: 'ada' } });
+    validate({ body: schema })(req, res, next);
+    expect(req.body).toEqual({ name: 'ada' });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('parses and merges req.query when a query schema is given', () => {
+    const next = vi.fn();
+    const schema = z.object({ page: z.coerce.number() });
+    const req = fakeReq({ query: { page: '2' } });
+    validate({ query: schema })(req, res, next);
+    expect(req.query).toEqual({ page: 2 });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('parses and merges req.params when a params schema is given', () => {
+    const next = vi.fn();
+    const schema = z.object({ id: z.uuid() });
+    const id = '123e4567-e89b-12d3-a456-426614174000';
+    const req = fakeReq({ params: { id } });
+    validate({ params: schema })(req, res, next);
+    expect(req.params).toEqual({ id });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('applies body, query, and params schemas together', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      body: { name: 'ada' },
+      query: { page: '1' },
+      params: { id: 'abc' },
+    });
+    validate({
+      body: z.object({ name: z.string() }),
+      query: z.object({ page: z.coerce.number() }),
+      params: z.object({ id: z.string() }),
+    })(req, res, next);
+    expect(req.body).toEqual({ name: 'ada' });
+    expect(req.query).toEqual({ page: 1 });
+    expect(req.params).toEqual({ id: 'abc' });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('skips validation entirely when no schemas are given', () => {
+    const next = vi.fn();
+    const req = fakeReq({ body: { anything: true } });
+    validate({})(req, res, next);
+    expect(req.body).toEqual({ anything: true });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('calls next with a 400 ApiError carrying Zod issues when body fails validation', () => {
+    const next = vi.fn();
+    const schema = z.object({ name: z.string() });
+    const req = fakeReq({ body: { name: 42 } });
+    validate({ body: schema })(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('Validation failed');
+    expect(Array.isArray(err.details)).toBe(true);
+  });
+
+  it('calls next with a 400 ApiError when query fails validation', () => {
+    const next = vi.fn();
+    const schema = z.object({ page: z.coerce.number() });
+    const req = fakeReq({ query: { page: 'not-a-number' } });
+    validate({ query: schema })(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.status).toBe(400);
+  });
+
+  it('calls next with a 400 ApiError when params fails validation', () => {
+    const next = vi.fn();
+    const schema = z.object({ id: z.uuid() });
+    const req = fakeReq({ params: { id: 'not-a-uuid' } });
+    validate({ params: schema })(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.status).toBe(400);
+  });
+
+  it('propagates a non-Zod error thrown by a schema untouched', () => {
+    const next = vi.fn();
+    const boom = new Error('schema exploded');
+    const schema = {
+      parse: () => {
+        throw boom;
+      },
+    } as unknown as z.ZodType;
+    const req = fakeReq({ body: {} });
+    validate({ body: schema })(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith(boom);
+  });
+});
+
+describe('parsedBody', () => {
+  it('returns req.body typed to the schema without re-parsing', () => {
+    const schema = z.object({ name: z.string() });
+    const req = { body: { name: 'ada' } };
+    expect(parsedBody(req, schema)).toEqual({ name: 'ada' });
+  });
+});

--- a/api/src/services/invitation-service.test.ts
+++ b/api/src/services/invitation-service.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Invitation, Tenant } from '../models/index.js';
+import { ApiError } from '../utils/api-error.js';
+
+import { createInvitationService } from './invitation-service.js';
+
+import type { EmailService } from './email-service.js';
+import type { CreateInvitationInput } from '@livechat/shared';
+
+function fakeEmail(): EmailService {
+  return {
+    sendInvitationEmail: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EmailService;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('invitation-service', () => {
+  describe('create', () => {
+    it('creates a tenant-scoped invitation and emails the recipient', async () => {
+      vi.spyOn(Tenant, 'findByPk').mockResolvedValue({ id: 'tenant-1' } as Tenant);
+      const created = { id: 'inv-1' } as Invitation;
+      const createSpy = vi.spyOn(Invitation, 'create').mockResolvedValue(created);
+      const email = fakeEmail();
+      const service = createInvitationService({ email });
+
+      const input: CreateInvitationInput = {
+        tenantId: 'tenant-1',
+        email: 'new@example.com',
+        name: 'New Person',
+        role: 'staff',
+        expiresInDays: 7,
+      };
+      const result = await service.create(input, 'inviter-1');
+
+      expect(result).toBe(created);
+      expect(createSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          tenantId: 'tenant-1',
+          email: 'new@example.com',
+          name: 'New Person',
+          role: 'staff',
+          invitedBy: 'inviter-1',
+        }),
+      );
+      expect(email.sendInvitationEmail).toHaveBeenCalledExactlyOnceWith(
+        'new@example.com',
+        'New Person',
+        expect.any(String),
+      );
+    });
+
+    it('creates an untenanted invitation without checking the tenant', async () => {
+      const findByPk = vi.spyOn(Tenant, 'findByPk');
+      const created = { id: 'inv-2' } as Invitation;
+      vi.spyOn(Invitation, 'create').mockResolvedValue(created);
+      const email = fakeEmail();
+      const service = createInvitationService({ email });
+
+      const input: CreateInvitationInput = {
+        tenantId: null,
+        email: 'global@example.com',
+        role: 'staff',
+        expiresInDays: 3,
+      };
+      const result = await service.create(input, 'inviter-1');
+
+      expect(result).toBe(created);
+      expect(findByPk).not.toHaveBeenCalled();
+      expect(email.sendInvitationEmail).toHaveBeenCalledExactlyOnceWith(
+        'global@example.com',
+        null,
+        expect.any(String),
+      );
+    });
+
+    it('throws 400 when the given tenantId does not exist', async () => {
+      vi.spyOn(Tenant, 'findByPk').mockResolvedValue(null);
+      const createSpy = vi.spyOn(Invitation, 'create');
+      const email = fakeEmail();
+      const service = createInvitationService({ email });
+
+      const input: CreateInvitationInput = {
+        tenantId: 'ghost-tenant',
+        email: 'x@example.com',
+        role: 'staff',
+        expiresInDays: 7,
+      };
+
+      await expect(service.create(input, 'inviter-1')).rejects.toMatchObject({
+        status: 400,
+        message: 'Tenant not found',
+      });
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(email.sendInvitationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('list', () => {
+    it('lists all invitations when no tenant filter is given', async () => {
+      const findAll = vi.spyOn(Invitation, 'findAll').mockResolvedValue([]);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await service.list();
+
+      expect(findAll).toHaveBeenCalledExactlyOnceWith({
+        where: {},
+        order: [['createdAt', 'DESC']],
+      });
+    });
+
+    it('filters by tenant when a tenantId is given', async () => {
+      const findAll = vi.spyOn(Invitation, 'findAll').mockResolvedValue([]);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await service.list('tenant-9');
+
+      expect(findAll).toHaveBeenCalledExactlyOnceWith({
+        where: { tenantId: 'tenant-9' },
+        order: [['createdAt', 'DESC']],
+      });
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes a pending invitation', async () => {
+      const update = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(Invitation, 'findByPk').mockResolvedValue({
+        status: 'pending',
+        update,
+      } as unknown as Invitation);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await service.revoke('inv-1');
+
+      expect(update).toHaveBeenCalledExactlyOnceWith({ status: 'revoked' });
+    });
+
+    it('throws 404 when the invitation does not exist', async () => {
+      vi.spyOn(Invitation, 'findByPk').mockResolvedValue(null);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await expect(service.revoke('missing')).rejects.toMatchObject({
+        status: 404,
+        message: 'Invitation not found',
+      });
+    });
+
+    it('throws 400 when the invitation is not pending', async () => {
+      const update = vi.fn();
+      vi.spyOn(Invitation, 'findByPk').mockResolvedValue({
+        status: 'accepted',
+        update,
+      } as unknown as Invitation);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await expect(service.revoke('inv-2')).rejects.toBeInstanceOf(ApiError);
+      await expect(service.revoke('inv-2')).rejects.toMatchObject({
+        status: 400,
+        message: 'Cannot revoke a accepted invitation',
+      });
+      expect(update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/utils/api-error.test.ts
+++ b/api/src/utils/api-error.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './api-error.js';
+
+describe('ApiError', () => {
+  it('sets status, message, name, and details from the constructor', () => {
+    const err = new ApiError(418, "I'm a teapot", { hint: 'brew' });
+    expect(err.status).toBe(418);
+    expect(err.message).toBe("I'm a teapot");
+    expect(err.name).toBe('ApiError');
+    expect(err.details).toEqual({ hint: 'brew' });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('leaves details undefined when not supplied', () => {
+    const err = new ApiError(500, 'boom');
+    expect(err.details).toBeUndefined();
+  });
+
+  it('badRequest defaults status 400 and accepts details', () => {
+    const err = ApiError.badRequest('bad input', { field: 'email' });
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('bad input');
+    expect(err.details).toEqual({ field: 'email' });
+  });
+
+  it('unauthorized defaults its message', () => {
+    const err = ApiError.unauthorized();
+    expect(err.status).toBe(401);
+    expect(err.message).toBe('Authentication required');
+  });
+
+  it('unauthorized accepts a custom message', () => {
+    const err = ApiError.unauthorized('Token expired');
+    expect(err.status).toBe(401);
+    expect(err.message).toBe('Token expired');
+  });
+
+  it('forbidden defaults its message', () => {
+    const err = ApiError.forbidden();
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Insufficient permissions');
+  });
+
+  it('forbidden accepts a custom message', () => {
+    const err = ApiError.forbidden('Access denied to this tenant');
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Access denied to this tenant');
+  });
+
+  it('notFound defaults its message', () => {
+    const err = ApiError.notFound();
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Not found');
+  });
+
+  it('notFound accepts a custom message', () => {
+    const err = ApiError.notFound('Route not found: GET /nope');
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Route not found: GET /nope');
+  });
+
+  it('conflict requires and sets a message', () => {
+    const err = ApiError.conflict('Email already in use');
+    expect(err.status).toBe(409);
+    expect(err.message).toBe('Email already in use');
+  });
+
+  it('tooManyRequests defaults its message', () => {
+    const err = ApiError.tooManyRequests();
+    expect(err.status).toBe(429);
+    expect(err.message).toBe('Too many requests');
+  });
+
+  it('tooManyRequests accepts a custom message', () => {
+    const err = ApiError.tooManyRequests('Slow down');
+    expect(err.status).toBe(429);
+    expect(err.message).toBe('Slow down');
+  });
+});

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -1,0 +1,683 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { Tenant, User } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { Role } from '@livechat/shared';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+let harness: Harness;
+
+/**
+ * Create a tenant with sane defaults for the fields the model requires.
+ * @param overrides - Partial field overrides.
+ * @returns The created tenant.
+ */
+async function seedTenant(
+  overrides: Partial<{ name: string; slug: string }> = {},
+): Promise<Tenant> {
+  return Tenant.create({
+    name: overrides.name ?? 'Acme Corp',
+    slug: overrides.slug ?? `acme-${Math.random().toString(36).slice(2, 8)}`,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+}
+
+/**
+ * Create a user with a given role/tenant and return its plaintext password
+ * for login. `passwordHash` is set to plaintext — the model's `beforeCreate`
+ * hook bcrypt-hashes it.
+ * @param role - Role to assign.
+ * @param tenantId - Tenant id, or `null` for untenanted roles.
+ * @param overrides - Optional email override so callers can avoid collisions.
+ * @returns The created user and its plaintext password.
+ */
+async function seedUser(
+  role: Role,
+  tenantId: string | null,
+  overrides: Partial<{ email: string }> = {},
+): Promise<{ user: User; password: string }> {
+  const password = 'Sup3r!Secret1';
+  const user = await User.create({
+    email: overrides.email ?? `${role}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    passwordHash: password,
+    firstName: 'Test',
+    lastName: role,
+    role,
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { user, password };
+}
+
+/**
+ * Log a seeded user in and return an access token.
+ * @param email - Login email.
+ * @param password - Plaintext password.
+ * @returns Bearer access token.
+ */
+async function login(email: string, password: string): Promise<string> {
+  if (harness === null) throw new Error('harness not initialized');
+  const res = await request(harness.app).post('/api/v1/auth/login').send({ email, password });
+  expect(res.status).toBe(200);
+  return res.body.data.accessToken as string;
+}
+
+describe('admin routes (integration)', () => {
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  describe('authentication and authorization guards', () => {
+    test.runIf(() => harness !== null)(
+      'unauthenticated requests are rejected with 401',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+
+        const getTenants = await request(app).get('/api/v1/tenants');
+        expect(getTenants.status).toBe(401);
+        expect(getTenants.body.success).toBe(false);
+
+        const postTenants = await request(app).post('/api/v1/tenants').send({});
+        expect(postTenants.status).toBe(401);
+
+        const tenant = await seedTenant();
+        const patchTenant = await request(app).patch(`/api/v1/tenants/${tenant.id}`).send({});
+        expect(patchTenant.status).toBe(401);
+
+        const deleteTenant = await request(app).delete(`/api/v1/tenants/${tenant.id}`);
+        expect(deleteTenant.status).toBe(401);
+
+        const rotate = await request(app).post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`);
+        expect(rotate.status).toBe(401);
+
+        const origins = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .send({});
+        expect(origins.status).toBe(401);
+
+        const getUsers = await request(app).get('/api/v1/users');
+        expect(getUsers.status).toBe(401);
+
+        const patchUser = await request(app).patch('/api/v1/users/some-id').send({});
+        expect(patchUser.status).toBe(401);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'a malformed bearer token is rejected with 401',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const res = await request(app)
+          .get('/api/v1/tenants')
+          .set('authorization', 'Bearer not-a-real-token');
+        expect(res.status).toBe(401);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'staff cannot reach any /tenants or /users route (403 — admin-router base guard)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('staff', null);
+        const token = await login(user.email, password);
+        const tenant = await seedTenant();
+
+        const list = await request(app)
+          .get('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`);
+        expect(list.status).toBe(403);
+        expect(list.body.message).toMatch(/permission/i);
+
+        const create = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Nope', slug: 'nope' });
+        expect(create.status).toBe(403);
+
+        const getOne = await request(app)
+          .get(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(getOne.status).toBe(403);
+
+        const patchOne = await request(app)
+          .patch(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Nope' });
+        expect(patchOne.status).toBe(403);
+
+        const deleteOne = await request(app)
+          .delete(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(deleteOne.status).toBe(403);
+
+        const rotate = await request(app)
+          .post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`)
+          .set('authorization', `Bearer ${token}`);
+        expect(rotate.status).toBe(403);
+
+        const origins = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: ['https://example.com'] });
+        expect(origins.status).toBe(403);
+
+        const listUsers = await request(app)
+          .get('/api/v1/users')
+          .set('authorization', `Bearer ${token}`);
+        expect(listUsers.status).toBe(403);
+
+        const patchUser = await request(app)
+          .patch(`/api/v1/users/${user.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ firstName: 'X' });
+        expect(patchUser.status).toBe(403);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'client role cannot reach any /tenants or /users route (403)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('client', tenant.id);
+        const token = await login(user.email, password);
+
+        const list = await request(app)
+          .get('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`);
+        expect(list.status).toBe(403);
+
+        const listUsers = await request(app)
+          .get('/api/v1/users')
+          .set('authorization', `Bearer ${token}`);
+        expect(listUsers.status).toBe(403);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'tenant-scoped admin is forbidden from super_admin-only tenant mutations (403)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const ownTenant = await seedTenant();
+        const otherTenant = await seedTenant();
+        const { user, password } = await seedUser('admin', ownTenant.id);
+        const token = await login(user.email, password);
+
+        const create = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Blocked', slug: `blocked-${Math.random().toString(36).slice(2, 8)}` });
+        expect(create.status).toBe(403);
+
+        const patchOwn = await request(app)
+          .patch(`/api/v1/tenants/${ownTenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Renamed' });
+        expect(patchOwn.status).toBe(403);
+
+        const patchOther = await request(app)
+          .patch(`/api/v1/tenants/${otherTenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Renamed' });
+        expect(patchOther.status).toBe(403);
+
+        const deleteOther = await request(app)
+          .delete(`/api/v1/tenants/${otherTenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(deleteOther.status).toBe(403);
+
+        const rotate = await request(app)
+          .post(`/api/v1/tenants/${otherTenant.id}/rotate-embed-secret`)
+          .set('authorization', `Bearer ${token}`);
+        expect(rotate.status).toBe(403);
+
+        const origins = await request(app)
+          .put(`/api/v1/tenants/${otherTenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: ['https://example.com'] });
+        expect(origins.status).toBe(403);
+
+        // Read-only tenant routes have no super_admin guard, so admin CAN
+        // read any tenant (including one it is not scoped to) — the admin
+        // console's whole point is cross-tenant visibility for AFixt staff.
+        const readOther = await request(app)
+          .get(`/api/v1/tenants/${otherTenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(readOther.status).toBe(200);
+        expect(readOther.body.data.id).toBe(otherTenant.id);
+      },
+    );
+  });
+
+  describe('/tenants CRUD', () => {
+    test.runIf(() => harness !== null)('list returns all tenants for an admin', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await seedTenant();
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app).get('/api/v1/tenants').set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThan(0);
+    });
+
+    test.runIf(() => harness !== null)(
+      'create succeeds for super_admin with a valid payload',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({
+            name: 'Brand New Co',
+            slug: `brand-new-${Math.random().toString(36).slice(2, 8)}`,
+          });
+        expect(res.status).toBe(201);
+        expect(res.body.data.name).toBe('Brand New Co');
+        expect(res.body.data.status).toBe('active');
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'create rejects an invalid slug with 400 (zod validation branch)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Bad Slug Co', slug: 'not a valid slug!' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.details).toBeDefined();
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'create rejects a missing required field with 400',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ slug: 'no-name-here' });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('create rejects a duplicate slug with 409', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+      const slug = `dupe-${Math.random().toString(36).slice(2, 8)}`;
+
+      const first = await request(app)
+        .post('/api/v1/tenants')
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'First', slug });
+      expect(first.status).toBe(201);
+
+      const second = await request(app)
+        .post('/api/v1/tenants')
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'Second', slug });
+      expect(second.status).toBe(409);
+      expect(second.body.message).toMatch(/slug/i);
+    });
+
+    test.runIf(() => harness !== null)('get by id 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .get('/api/v1/tenants/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)('get by id returns the tenant when it exists', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenant = await seedTenant();
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .get(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.id).toBe(tenant.id);
+    });
+
+    test.runIf(() => harness !== null)('update applies fields and persists them', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenant = await seedTenant();
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .patch(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'Updated Name', status: 'suspended' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.name).toBe('Updated Name');
+      expect(res.body.data.status).toBe('suspended');
+    });
+
+    test.runIf(() => harness !== null)('update 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .patch('/api/v1/tenants/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'Ghost' });
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'update rejects an invalid status enum with 400',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .patch(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ status: 'not-a-real-status' });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('delete soft-deletes the tenant, then 404s', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenant = await seedTenant();
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const del = await request(app)
+        .delete(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(del.status).toBe(200);
+      expect(del.body.success).toBe(true);
+
+      const after = await request(app)
+        .get(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(after.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)('delete 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .delete('/api/v1/tenants/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'rotate-embed-secret returns a fresh secret different from the original',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const originalSecret = tenant.embedSecret;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`)
+          .set('authorization', `Bearer ${token}`);
+        expect(res.status).toBe(200);
+        expect(res.body.data.embedSecret).toBeTypeOf('string');
+        expect(res.body.data.embedSecret).not.toBe(originalSecret);
+      },
+    );
+
+    test.runIf(() => harness !== null)('rotate-embed-secret 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .post('/api/v1/tenants/00000000-0000-4000-8000-000000000000/rotate-embed-secret')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'allowed-origins sets the list when given a valid array',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: ['https://example.com', 'https://foo.example.com'] });
+        expect(res.status).toBe(200);
+        expect(res.body.data.allowedOrigins).toEqual([
+          'https://example.com',
+          'https://foo.example.com',
+        ]);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'allowed-origins clears to null when origins is not an array (branch coverage)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: 'not-an-array' });
+        expect(res.status).toBe(200);
+        expect(res.body.data.allowedOrigins).toBeNull();
+      },
+    );
+
+    test.runIf(() => harness !== null)('allowed-origins 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .put('/api/v1/tenants/00000000-0000-4000-8000-000000000000/allowed-origins')
+        .set('authorization', `Bearer ${token}`)
+        .send({ origins: ['https://example.com'] });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('/users', () => {
+    test.runIf(() => harness !== null)('list returns all users for an admin', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app).get('/api/v1/users').set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThan(0);
+      expect(res.body.data[0].passwordHash).toBeUndefined();
+    });
+
+    test.runIf(() => harness !== null)('list filters by tenantId query when provided', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenantA = await seedTenant();
+      const tenantB = await seedTenant();
+      await seedUser('client', tenantA.id);
+      await seedUser('client', tenantB.id);
+      const { user: admin, password } = await seedUser('admin', null);
+      const token = await login(admin.email, password);
+
+      const res = await request(app)
+        .get(`/api/v1/users?tenantId=${tenantA.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBeGreaterThan(0);
+      for (const returned of res.body.data as { tenantId: string | null }[]) {
+        expect(returned.tenantId).toBe(tenantA.id);
+      }
+    });
+
+    test.runIf(() => harness !== null)('get by id 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .get('/api/v1/users/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)('get by id returns the user when it exists', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user: target } = await seedUser('client', null);
+      const { user: admin, password } = await seedUser('admin', null);
+      const token = await login(admin.email, password);
+
+      const res = await request(app)
+        .get(`/api/v1/users/${target.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.id).toBe(target.id);
+      expect(res.body.data.passwordHash).toBeUndefined();
+    });
+
+    test.runIf(() => harness !== null)('update applies fields and persists them', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user: target } = await seedUser('client', null);
+      const { user: admin, password } = await seedUser('admin', null);
+      const token = await login(admin.email, password);
+
+      const res = await request(app)
+        .patch(`/api/v1/users/${target.id}`)
+        .set('authorization', `Bearer ${token}`)
+        .send({ firstName: 'Renamed', status: 'suspended' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.firstName).toBe('Renamed');
+      expect(res.body.data.status).toBe('suspended');
+    });
+
+    test.runIf(() => harness !== null)('update 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .patch('/api/v1/users/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`)
+        .send({ firstName: 'Ghost' });
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'update rejects an invalid role enum with 400 (zod branch)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user: target } = await seedUser('client', null);
+        const { user: admin, password } = await seedUser('admin', null);
+        const token = await login(admin.email, password);
+
+        const res = await request(app)
+          .patch(`/api/v1/users/${target.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ role: 'not-a-real-role' });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'update rejects an invalid status enum with 400 (zod branch)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user: target } = await seedUser('client', null);
+        const { user: admin, password } = await seedUser('admin', null);
+        const token = await login(admin.email, password);
+
+        const res = await request(app)
+          .patch(`/api/v1/users/${target.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ status: 'not-a-real-status' });
+        expect(res.status).toBe(400);
+      },
+    );
+  });
+});

--- a/api/tests/integration/auth-lifecycle.test.ts
+++ b/api/tests/integration/auth-lifecycle.test.ts
@@ -1,0 +1,874 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { AuditLog, Invitation, Tenant, User, UserSession } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { Role, UserStatus } from '@livechat/shared';
+import type { Express } from 'express';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+interface UserOverrides {
+  email: string;
+  password: string;
+  role?: Role;
+  tenantId?: string | null;
+  status?: UserStatus;
+  emailVerified?: boolean;
+  emailVerificationToken?: string | null;
+  emailVerificationExpires?: Date | null;
+  passwordResetToken?: string | null;
+  passwordResetExpires?: Date | null;
+  lockedUntil?: Date | null;
+  failedLoginAttempts?: number;
+}
+
+/**
+ * Create a fully-specified test user. Mirrors the field list required by
+ * `InferCreationAttributes<User>` — every plain-nullable field must be
+ * passed explicitly.
+ * @param overrides - Per-test field overrides.
+ * @returns The created user.
+ */
+async function createUser(overrides: UserOverrides): Promise<User> {
+  return User.create({
+    email: overrides.email,
+    passwordHash: overrides.password,
+    firstName: 'Test',
+    lastName: 'User',
+    role: overrides.role ?? 'client',
+    tenantId: overrides.tenantId ?? null,
+    status: overrides.status ?? 'active',
+    emailVerified: overrides.emailVerified ?? true,
+    emailVerificationToken: overrides.emailVerificationToken ?? null,
+    emailVerificationExpires: overrides.emailVerificationExpires ?? null,
+    passwordResetToken: overrides.passwordResetToken ?? null,
+    passwordResetExpires: overrides.passwordResetExpires ?? null,
+    failedLoginAttempts: overrides.failedLoginAttempts ?? 0,
+    lockedUntil: overrides.lockedUntil ?? null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+}
+
+/**
+ * Create a super_admin user and log in, returning the bearer access token.
+ * @param app - The Express app under test.
+ * @param email - Unique email for this admin.
+ * @returns The bearer access token.
+ */
+async function loginAsSuperAdmin(app: Express, email: string): Promise<string> {
+  const password = 'Admin!Password1';
+  await createUser({ email, password, role: 'super_admin' });
+  const res = await request(app).post('/api/v1/auth/login').send({ email, password });
+  return res.body.data.accessToken as string;
+}
+
+describe('auth lifecycle (integration)', () => {
+  let harness: Harness;
+
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  describe('forgot-password', () => {
+    test.runIf(() => harness !== null)('known email issues a reset token', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'forgot-known@example.com', password: 'Original!Pass1' });
+
+      const res = await request(app)
+        .post('/api/v1/auth/forgot-password')
+        .send({ email: 'forgot-known@example.com' });
+      expect(res.status).toBe(200);
+
+      const user = await User.findOne({ where: { email: 'forgot-known@example.com' } });
+      expect(user?.passwordResetToken).toBeTypeOf('string');
+      expect(user?.passwordResetExpires).not.toBeNull();
+    });
+
+    test.runIf(() => harness !== null)(
+      'unknown email returns the same response without leaking existence',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const res = await request(app)
+          .post('/api/v1/auth/forgot-password')
+          .send({ email: 'never-registered@example.com' });
+        expect(res.status).toBe(200);
+        expect(res.body.message).toMatch(/if the email exists/i);
+
+        const user = await User.findOne({ where: { email: 'never-registered@example.com' } });
+        expect(user).toBeNull();
+      },
+    );
+  });
+
+  describe('reset-password', () => {
+    test.runIf(() => harness !== null)(
+      'valid token resets the password, is single-use, and destroys sessions',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'reset-valid@example.com', password: 'Original!Pass1' });
+
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'reset-valid@example.com',
+          password: 'Original!Pass1',
+        });
+        expect(loginRes.status).toBe(200);
+        const preResetRefresh = loginRes.body.data.refreshToken as string;
+
+        await request(app)
+          .post('/api/v1/auth/forgot-password')
+          .send({ email: 'reset-valid@example.com' });
+        const user = await User.findOne({ where: { email: 'reset-valid@example.com' } });
+        const token = user?.passwordResetToken;
+        expect(token).toBeTypeOf('string');
+
+        const resetRes = await request(app)
+          .post('/api/v1/auth/reset-password')
+          .send({ token, password: 'BrandNew!Pass1' });
+        expect(resetRes.status).toBe(200);
+
+        const loginOld = await request(app).post('/api/v1/auth/login').send({
+          email: 'reset-valid@example.com',
+          password: 'Original!Pass1',
+        });
+        expect(loginOld.status).toBe(401);
+
+        const loginNew = await request(app).post('/api/v1/auth/login').send({
+          email: 'reset-valid@example.com',
+          password: 'BrandNew!Pass1',
+        });
+        expect(loginNew.status).toBe(200);
+
+        // Sessions destroyed by the reset — the pre-reset refresh token is dead.
+        const refreshAfterReset = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: preResetRefresh });
+        expect(refreshAfterReset.status).toBe(401);
+
+        // Token is single-use — replaying it fails even with a fresh password.
+        const replay = await request(app)
+          .post('/api/v1/auth/reset-password')
+          .send({ token, password: 'AnotherNew!Pass1' });
+        expect(replay.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('invalid token is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token: 'not-a-real-token', password: 'Whatever!Pass1' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/invalid/i);
+    });
+
+    test.runIf(() => harness !== null)('expired token is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const token = randomBytes(32).toString('hex');
+      await createUser({
+        email: 'reset-expired@example.com',
+        password: 'Original!Pass1',
+        passwordResetToken: token,
+        passwordResetExpires: new Date(Date.now() - HOUR_MS),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token, password: 'Whatever!Pass1' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/expired/i);
+    });
+  });
+
+  describe('change-password', () => {
+    test.runIf(() => harness !== null)('correct current password succeeds', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'change-ok@example.com', password: 'Original!Pass1' });
+      const loginRes = await request(app).post('/api/v1/auth/login').send({
+        email: 'change-ok@example.com',
+        password: 'Original!Pass1',
+      });
+      const access = loginRes.body.data.accessToken as string;
+
+      const changeRes = await request(app)
+        .put('/api/v1/auth/change-password')
+        .set('authorization', `Bearer ${access}`)
+        .send({ currentPassword: 'Original!Pass1', newPassword: 'Updated!Pass1' });
+      expect(changeRes.status).toBe(200);
+
+      const relogin = await request(app).post('/api/v1/auth/login').send({
+        email: 'change-ok@example.com',
+        password: 'Updated!Pass1',
+      });
+      expect(relogin.status).toBe(200);
+    });
+
+    test.runIf(() => harness !== null)('wrong current password is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'change-wrong@example.com', password: 'Original!Pass1' });
+      const loginRes = await request(app).post('/api/v1/auth/login').send({
+        email: 'change-wrong@example.com',
+        password: 'Original!Pass1',
+      });
+      const access = loginRes.body.data.accessToken as string;
+
+      const changeRes = await request(app)
+        .put('/api/v1/auth/change-password')
+        .set('authorization', `Bearer ${access}`)
+        .send({ currentPassword: 'NotItAtAll1', newPassword: 'Updated!Pass1' });
+      expect(changeRes.status).toBe(400);
+      expect(changeRes.body.message).toMatch(/incorrect/i);
+    });
+
+    test.runIf(() => harness !== null)('requires authentication', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .put('/api/v1/auth/change-password')
+        .send({ currentPassword: 'Whatever1', newPassword: 'Updated!Pass1' });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('verify-email/:token', () => {
+    test.runIf(() => harness !== null)('valid token verifies the account', async () => {
+      if (harness === null) return;
+      const token = randomBytes(32).toString('hex');
+      await createUser({
+        email: 'verify-valid@example.com',
+        password: 'Original!Pass1',
+        emailVerified: false,
+        emailVerificationToken: token,
+        emailVerificationExpires: new Date(Date.now() + DAY_MS),
+      });
+      const { app } = harness;
+
+      const res = await request(app).get(`/api/v1/auth/verify-email/${token}`);
+      expect(res.status).toBe(200);
+
+      const user = await User.findOne({ where: { email: 'verify-valid@example.com' } });
+      expect(user?.emailVerified).toBe(true);
+      expect(user?.emailVerificationToken).toBeNull();
+    });
+
+    test.runIf(() => harness !== null)('invalid token is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app).get('/api/v1/auth/verify-email/not-a-real-token');
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)('expired token is rejected', async () => {
+      if (harness === null) return;
+      const token = randomBytes(32).toString('hex');
+      await createUser({
+        email: 'verify-expired@example.com',
+        password: 'Original!Pass1',
+        emailVerified: false,
+        emailVerificationToken: token,
+        emailVerificationExpires: new Date(Date.now() - HOUR_MS),
+      });
+      const { app } = harness;
+
+      const res = await request(app).get(`/api/v1/auth/verify-email/${token}`);
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/expired/i);
+    });
+  });
+
+  describe('login edge branches', () => {
+    test.runIf(() => harness !== null)('failed attempts increment the counter', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'login-fail-count@example.com', password: 'Real!Password1' });
+
+      const res = await request(app).post('/api/v1/auth/login').send({
+        email: 'login-fail-count@example.com',
+        password: 'wrong-password',
+      });
+      expect(res.status).toBe(401);
+
+      const user = await User.findOne({ where: { email: 'login-fail-count@example.com' } });
+      expect(user?.failedLoginAttempts).toBe(1);
+      expect(user?.lockedUntil).toBeNull();
+    });
+
+    test.runIf(() => harness !== null)(
+      'locked account rejects login even with correct password',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({
+          email: 'login-locked@example.com',
+          password: 'Real!Password1',
+          lockedUntil: new Date(Date.now() + HOUR_MS),
+          failedLoginAttempts: 5,
+        });
+
+        const res = await request(app).post('/api/v1/auth/login').send({
+          email: 'login-locked@example.com',
+          password: 'Real!Password1',
+        });
+        expect(res.status).toBe(403);
+        expect(res.body.message).toMatch(/locked/i);
+      },
+    );
+
+    test.runIf(() => harness !== null)('suspended account is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({
+        email: 'login-suspended@example.com',
+        password: 'Real!Password1',
+        status: 'suspended',
+      });
+
+      const res = await request(app).post('/api/v1/auth/login').send({
+        email: 'login-suspended@example.com',
+        password: 'Real!Password1',
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/not active/i);
+    });
+
+    test.runIf(() => harness !== null)('pending account is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({
+        email: 'login-pending@example.com',
+        password: 'Real!Password1',
+        status: 'pending',
+      });
+
+      const res = await request(app).post('/api/v1/auth/login').send({
+        email: 'login-pending@example.com',
+        password: 'Real!Password1',
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/not active/i);
+    });
+
+    test.runIf(() => harness !== null)(
+      'unknown email is rejected without distinguishing detail',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const res = await request(app).post('/api/v1/auth/login').send({
+          email: 'does-not-exist@example.com',
+          password: 'Whatever!Pass1',
+        });
+        expect(res.status).toBe(401);
+      },
+    );
+  });
+
+  describe('refresh-token / logout', () => {
+    test.runIf(() => harness !== null)(
+      'refresh rotates the token and the old one is rejected',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'refresh-rotate@example.com', password: 'Real!Password1' });
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'refresh-rotate@example.com',
+          password: 'Real!Password1',
+        });
+        const oldRefresh = loginRes.body.data.refreshToken as string;
+
+        const refreshRes = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: oldRefresh });
+        expect(refreshRes.status).toBe(200);
+        const newRefresh = refreshRes.body.data.refreshToken as string;
+        expect(newRefresh).not.toBe(oldRefresh);
+
+        const reuseOld = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: oldRefresh });
+        expect(reuseOld.status).toBe(401);
+
+        const useNew = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: newRefresh });
+        expect(useNew.status).toBe(200);
+      },
+    );
+
+    test.runIf(() => harness !== null)('refresh-token requires a body field', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app).post('/api/v1/auth/refresh-token').send({});
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)('refresh rejects a malformed token', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .post('/api/v1/auth/refresh-token')
+        .send({ refreshToken: 'garbage.not.a.jwt' });
+      expect(res.status).toBe(401);
+    });
+
+    test.runIf(() => harness !== null)('refresh rejects a suspended user', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'refresh-suspend@example.com', password: 'Real!Password1' });
+      const loginRes = await request(app).post('/api/v1/auth/login').send({
+        email: 'refresh-suspend@example.com',
+        password: 'Real!Password1',
+      });
+      const refreshToken = loginRes.body.data.refreshToken as string;
+
+      const user = await User.findOne({ where: { email: 'refresh-suspend@example.com' } });
+      await user?.update({ status: 'suspended' });
+
+      const res = await request(app).post('/api/v1/auth/refresh-token').send({ refreshToken });
+      expect(res.status).toBe(401);
+    });
+
+    test.runIf(() => harness !== null)(
+      'logout destroys the session so refresh stops working',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'logout-destroys@example.com', password: 'Real!Password1' });
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'logout-destroys@example.com',
+          password: 'Real!Password1',
+        });
+        const access = loginRes.body.data.accessToken as string;
+        const refreshToken = loginRes.body.data.refreshToken as string;
+
+        const logoutRes = await request(app)
+          .post('/api/v1/auth/logout')
+          .set('authorization', `Bearer ${access}`);
+        expect(logoutRes.status).toBe(200);
+
+        const meRes = await request(app)
+          .get('/api/v1/auth/me')
+          .set('authorization', `Bearer ${access}`);
+        expect(meRes.status).toBe(401);
+
+        const refreshRes = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken });
+        expect(refreshRes.status).toBe(401);
+      },
+    );
+  });
+
+  describe('invitations', () => {
+    test.runIf(() => harness !== null)(
+      'admin can create, list, and register succeeds with the token',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-1@example.com');
+
+        const createRes = await request(app)
+          .post('/api/v1/invitations')
+          .set('authorization', `Bearer ${adminAccess}`)
+          .send({ email: 'invitee-1@example.com', role: 'client', expiresInDays: 7 });
+        expect(createRes.status).toBe(201);
+
+        const listRes = await request(app)
+          .get('/api/v1/invitations')
+          .set('authorization', `Bearer ${adminAccess}`);
+        expect(listRes.status).toBe(200);
+        expect(Array.isArray(listRes.body.data)).toBe(true);
+
+        const invitation = await Invitation.findOne({ where: { email: 'invitee-1@example.com' } });
+        const token = invitation?.token as string;
+
+        const registerRes = await request(app).post('/api/v1/auth/register').send({
+          email: 'invitee-1@example.com',
+          password: 'NewUser!Pass1',
+          firstName: 'In',
+          lastName: 'Vitee',
+          token,
+        });
+        expect(registerRes.status).toBe(201);
+
+        const accepted = await Invitation.findOne({ where: { email: 'invitee-1@example.com' } });
+        expect(accepted?.status).toBe('accepted');
+
+        // Single-use: the same token cannot register a second account.
+        const replay = await request(app).post('/api/v1/auth/register').send({
+          email: 'invitee-1@example.com',
+          password: 'NewUser!Pass1',
+          firstName: 'In',
+          lastName: 'Vitee',
+          token,
+        });
+        expect(replay.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('create rejects an unknown tenantId', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-2@example.com');
+
+      const res = await request(app)
+        .post('/api/v1/invitations')
+        .set('authorization', `Bearer ${adminAccess}`)
+        .send({ email: 'invitee-2@example.com', role: 'client', tenantId: randomUUID() });
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)(
+      'create succeeds with a real tenantId and list can filter by it',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-3@example.com');
+        const tenant = await Tenant.create({
+          name: 'Filter Co',
+          slug: 'filter-co',
+          status: 'active',
+          domain: null,
+          expiresAt: null,
+          settings: null,
+        });
+
+        const createRes = await request(app)
+          .post('/api/v1/invitations')
+          .set('authorization', `Bearer ${adminAccess}`)
+          .send({ email: 'invitee-3@example.com', role: 'staff', tenantId: tenant.id });
+        expect(createRes.status).toBe(201);
+
+        const filtered = await request(app)
+          .get(`/api/v1/invitations?tenantId=${tenant.id}`)
+          .set('authorization', `Bearer ${adminAccess}`);
+        expect(filtered.status).toBe(200);
+        const data = filtered.body.data as { email: string }[];
+        const emails: string[] = [];
+        for (const invite of data) emails.push(invite.email);
+        expect(emails).toContain('invitee-3@example.com');
+      },
+    );
+
+    test.runIf(() => harness !== null)('register rejects an unknown token', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .post('/api/v1/auth/register')
+        .send({
+          email: 'nobody@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'No',
+          lastName: 'Body',
+          token: randomBytes(16).toString('hex'),
+        });
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)(
+      'register rejects an expired invitation and marks it expired',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await loginAsSuperAdmin(app, 'inv-admin-4@example.com');
+        const admin = await User.findOne({ where: { email: 'inv-admin-4@example.com' } });
+        const invitation = await Invitation.create({
+          email: 'expired-invite@example.com',
+          role: 'client',
+          token: randomBytes(16).toString('hex'),
+          invitedBy: (admin as User).id,
+          expiresAt: new Date(Date.now() - HOUR_MS),
+          tenantId: null,
+          name: null,
+          acceptedAt: null,
+        });
+
+        const res = await request(app).post('/api/v1/auth/register').send({
+          email: 'expired-invite@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'Ex',
+          lastName: 'Pired',
+          token: invitation.token,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/expired/i);
+
+        const reloaded = await Invitation.findByPk(invitation.id);
+        expect(reloaded?.status).toBe('expired');
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'register rejects an already-accepted invitation',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await loginAsSuperAdmin(app, 'inv-admin-5@example.com');
+        const admin = await User.findOne({ where: { email: 'inv-admin-5@example.com' } });
+        const invitation = await Invitation.create({
+          email: 'already-accepted@example.com',
+          role: 'client',
+          token: randomBytes(16).toString('hex'),
+          invitedBy: (admin as User).id,
+          expiresAt: new Date(Date.now() + DAY_MS),
+          tenantId: null,
+          name: null,
+          acceptedAt: new Date(),
+          status: 'accepted',
+        });
+
+        const res = await request(app).post('/api/v1/auth/register').send({
+          email: 'already-accepted@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'Al',
+          lastName: 'Ready',
+          token: invitation.token,
+        });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('register rejects a revoked invitation', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await loginAsSuperAdmin(app, 'inv-admin-6@example.com');
+      const admin = await User.findOne({ where: { email: 'inv-admin-6@example.com' } });
+      const invitation = await Invitation.create({
+        email: 'revoked-invite@example.com',
+        role: 'client',
+        token: randomBytes(16).toString('hex'),
+        invitedBy: (admin as User).id,
+        expiresAt: new Date(Date.now() + DAY_MS),
+        tenantId: null,
+        name: null,
+        acceptedAt: null,
+        status: 'revoked',
+      });
+
+      const res = await request(app).post('/api/v1/auth/register').send({
+        email: 'revoked-invite@example.com',
+        password: 'Whatever!Pass1',
+        firstName: 'Re',
+        lastName: 'Voked',
+        token: invitation.token,
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)(
+      'register rejects an email that no longer matches the invitation',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await loginAsSuperAdmin(app, 'inv-admin-7@example.com');
+        const admin = await User.findOne({ where: { email: 'inv-admin-7@example.com' } });
+        const invitation = await Invitation.create({
+          email: 'target@example.com',
+          role: 'client',
+          token: randomBytes(16).toString('hex'),
+          invitedBy: (admin as User).id,
+          expiresAt: new Date(Date.now() + DAY_MS),
+          tenantId: null,
+          name: null,
+          acceptedAt: null,
+        });
+        await createUser({ email: 'target@example.com', password: 'Existing!Pass1' });
+
+        const res = await request(app).post('/api/v1/auth/register').send({
+          email: 'target@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'Ta',
+          lastName: 'Rget',
+          token: invitation.token,
+        });
+        expect(res.status).toBe(409);
+        expect(res.body.message).toMatch(/already registered/i);
+      },
+    );
+
+    test.runIf(() => harness !== null)('revoke succeeds for a pending invitation', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-8@example.com');
+      const createRes = await request(app)
+        .post('/api/v1/invitations')
+        .set('authorization', `Bearer ${adminAccess}`)
+        .send({ email: 'revoke-me@example.com', role: 'client' });
+      expect(createRes.status).toBe(201);
+      const invitation = await Invitation.findOne({ where: { email: 'revoke-me@example.com' } });
+
+      const revokeRes = await request(app)
+        .post(`/api/v1/invitations/${(invitation as Invitation).id}/revoke`)
+        .set('authorization', `Bearer ${adminAccess}`);
+      expect(revokeRes.status).toBe(200);
+
+      const reloaded = await Invitation.findByPk((invitation as Invitation).id);
+      expect(reloaded?.status).toBe('revoked');
+    });
+
+    test.runIf(() => harness !== null)('revoke rejects a non-pending invitation', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-9@example.com');
+      const admin = await User.findOne({ where: { email: 'inv-admin-9@example.com' } });
+      const invitation = await Invitation.create({
+        email: 'already-revoked@example.com',
+        role: 'client',
+        token: randomBytes(16).toString('hex'),
+        invitedBy: (admin as User).id,
+        expiresAt: new Date(Date.now() + DAY_MS),
+        tenantId: null,
+        name: null,
+        acceptedAt: null,
+        status: 'revoked',
+      });
+
+      const res = await request(app)
+        .post(`/api/v1/invitations/${invitation.id}/revoke`)
+        .set('authorization', `Bearer ${adminAccess}`);
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/revoked/i);
+    });
+
+    test.runIf(() => harness !== null)('revoke of an unknown invitation is 404', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-10@example.com');
+
+      const res = await request(app)
+        .post(`/api/v1/invitations/${randomUUID()}/revoke`)
+        .set('authorization', `Bearer ${adminAccess}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'invitations endpoints require admin/super_admin',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'plain-client@example.com', password: 'Real!Password1' });
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'plain-client@example.com',
+          password: 'Real!Password1',
+        });
+        const clientAccess = loginRes.body.data.accessToken as string;
+
+        const res = await request(app)
+          .post('/api/v1/invitations')
+          .set('authorization', `Bearer ${clientAccess}`)
+          .send({ email: 'someone@example.com', role: 'client' });
+        expect(res.status).toBe(403);
+      },
+    );
+  });
+
+  describe('audit-service', () => {
+    test.runIf(() => harness !== null)('records a login-shaped entry', async () => {
+      if (harness === null) return;
+      const user = await createUser({
+        email: 'audit-login@example.com',
+        password: 'Real!Password1',
+      });
+
+      await harness.services.audit.record({
+        userId: user.id,
+        action: 'auth.login',
+        resourceType: 'user',
+        resourceId: user.id,
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest',
+      });
+
+      const row = await AuditLog.findOne({ where: { userId: user.id, action: 'auth.login' } });
+      expect(row).not.toBeNull();
+      expect(row?.resourceType).toBe('user');
+      expect(row?.ipAddress).toBe('127.0.0.1');
+    });
+
+    test.runIf(() => harness !== null)(
+      'records an admin-action-shaped entry with metadata',
+      async () => {
+        if (harness === null) return;
+        const admin = await createUser({
+          email: 'audit-admin@example.com',
+          password: 'Real!Password1',
+          role: 'super_admin',
+        });
+
+        await harness.services.audit.record({
+          userId: admin.id,
+          action: 'invitation.create',
+          resourceType: 'invitation',
+          resourceId: randomUUID(),
+          metadata: { email: 'invitee@example.com', role: 'client' },
+        });
+
+        const row = await AuditLog.findOne({
+          where: { userId: admin.id, action: 'invitation.create' },
+        });
+        expect(row).not.toBeNull();
+        expect(row?.metadata).toEqual({ email: 'invitee@example.com', role: 'client' });
+      },
+    );
+
+    test.runIf(() => harness !== null)('swallows write failures instead of throwing', async () => {
+      if (harness === null) return;
+      // userId references `users.id` with an FK constraint — a well-formed
+      // but non-existent UUID trips the FK violation inside `AuditLog.create`,
+      // exercising the service's catch branch without ever throwing here.
+      await expect(
+        harness.services.audit.record({
+          userId: randomUUID(),
+          action: 'audit.fk-violation',
+        }),
+      ).resolves.toBeUndefined();
+
+      const row = await AuditLog.findOne({ where: { action: 'audit.fk-violation' } });
+      expect(row).toBeNull();
+    });
+  });
+
+  describe('UserSession bookkeeping sanity', () => {
+    test.runIf(() => harness !== null)(
+      'login creates exactly one session row per login',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'session-count@example.com', password: 'Real!Password1' });
+        const user = await User.findOne({ where: { email: 'session-count@example.com' } });
+
+        await request(app).post('/api/v1/auth/login').send({
+          email: 'session-count@example.com',
+          password: 'Real!Password1',
+        });
+
+        const sessions = await UserSession.findAll({ where: { userId: (user as User).id } });
+        expect(sessions.length).toBe(1);
+      },
+    );
+  });
+});

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -1,0 +1,482 @@
+import { randomUUID } from 'node:crypto';
+
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { Chat, ChatMessage, Tenant, User, VisitorSession } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { ChatStatus } from '@livechat/shared';
+import type { Express } from 'express';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+interface StaffSeed {
+  tenantId: string;
+  email: string;
+  password: string;
+}
+
+const STAFF_PASSWORD = 'Staff!Password1';
+let staffCounter = 0;
+
+/**
+ * Create a staff user attached to an existing tenant (or untenanted, if
+ * `tenantId` is `null`).
+ * @param tenantId - Owning tenant id, or `null` for an untenanted user.
+ * @param label - Unique-ish label folded into the generated email.
+ * @returns The new user's login credentials.
+ */
+async function seedStaff(
+  tenantId: string | null,
+  label: string,
+): Promise<{ email: string; password: string }> {
+  staffCounter += 1;
+  const email = `staff${String(staffCounter)}-${label}@example.com`;
+  await User.create({
+    email,
+    passwordHash: STAFF_PASSWORD,
+    firstName: 'St',
+    lastName: 'Aff',
+    role: 'staff',
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { email, password: STAFF_PASSWORD };
+}
+
+/**
+ * Create a fresh tenant plus one staff member belonging to it.
+ * @param tenantSlug - Unique tenant slug.
+ * @returns Tenant id and the staff member's login credentials.
+ */
+async function seedTenantAndStaff(tenantSlug: string): Promise<StaffSeed> {
+  const tenant = await Tenant.create({
+    name: `Tenant-${tenantSlug}`,
+    slug: tenantSlug,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+  const { email, password } = await seedStaff(tenant.id, tenantSlug);
+  return { tenantId: tenant.id, email, password };
+}
+
+/**
+ * Create a non-staff (`client`) user attached to a tenant.
+ * @param tenantId - Owning tenant id.
+ * @param label - Unique-ish label folded into the generated email.
+ * @returns The new user's login credentials.
+ */
+async function seedClient(
+  tenantId: string,
+  label: string,
+): Promise<{ email: string; password: string }> {
+  staffCounter += 1;
+  const email = `client${String(staffCounter)}-${label}@example.com`;
+  const password = 'Client!Password1';
+  await User.create({
+    email,
+    passwordHash: password,
+    firstName: 'Cl',
+    lastName: 'Ient',
+    role: 'client',
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { email, password };
+}
+
+/**
+ * Log in and return the access token.
+ * @param app - Express app under test.
+ * @param email - Login email.
+ * @param password - Login password.
+ * @returns The bearer access token.
+ */
+async function loginAs(app: Express, email: string, password: string): Promise<string> {
+  const res = await request(app).post('/api/v1/auth/login').send({ email, password });
+  expect(res.status).toBe(200);
+  return res.body.data.accessToken as string;
+}
+
+/**
+ * Create a visitor session directly via the model (bypassing the widget
+ * bootstrap endpoint, which isn't under test here).
+ * @param tenantId - Owning tenant id.
+ * @returns The new visitor session.
+ */
+async function seedVisitorSession(tenantId: string): Promise<VisitorSession> {
+  const now = new Date();
+  return VisitorSession.create({
+    tenantId,
+    sessionCookieHash: `hash-${randomUUID()}`,
+    identityTokenSub: null,
+    userAgent: null,
+    ipAddress: null,
+    country: null,
+    city: null,
+    language: null,
+    currentUrl: null,
+    referrer: null,
+    status: 'active',
+    firstSeenAt: now,
+    lastSeenAt: now,
+  });
+}
+
+interface ChatOverrides {
+  status?: ChatStatus;
+  assignedTo?: string | null;
+  initiatedBy?: 'customer' | 'support';
+  endedAt?: Date | null;
+}
+
+/**
+ * Create a chat directly via the model.
+ * @param tenantId - Owning tenant id.
+ * @param visitorSessionId - Owning visitor session id.
+ * @param overrides - Optional field overrides.
+ * @returns The new chat.
+ */
+async function seedChat(
+  tenantId: string,
+  visitorSessionId: string,
+  overrides: ChatOverrides = {},
+): Promise<Chat> {
+  return Chat.create({
+    tenantId,
+    visitorSessionId,
+    assignedTo: overrides.assignedTo ?? null,
+    initiatedBy: overrides.initiatedBy ?? 'customer',
+    status: overrides.status ?? 'pending',
+    customerName: 'Test Visitor',
+    customerEmail: null,
+    startedAt: new Date(),
+    endedAt: overrides.endedAt ?? null,
+  });
+}
+
+/**
+ * Create a chat message directly via the model, with an explicit
+ * `deliveredAt` so ordering can be tested independently of insertion order.
+ * @param chatId - Owning chat id.
+ * @param body - Message body.
+ * @param deliveredAt - Explicit delivery timestamp.
+ * @returns The new message.
+ */
+async function seedMessage(chatId: string, body: string, deliveredAt: Date): Promise<ChatMessage> {
+  return ChatMessage.create({
+    chatId,
+    senderKind: 'visitor',
+    senderUserId: null,
+    body,
+    deliveredAt,
+    readAt: null,
+  });
+}
+
+describe('chat routes (integration)', () => {
+  let harness: Harness;
+
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  test('unauthenticated request is rejected with 401', async () => {
+    if (harness === null) return;
+    const res = await request(harness.app).get('/api/v1/chats');
+    expect(res.status).toBe(401);
+  });
+
+  test('a non-staff role is forbidden with 403', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const { tenantId } = await seedTenantAndStaff('forbid');
+    const client = await seedClient(tenantId, 'forbid');
+    const token = await loginAs(app, client.email, client.password);
+
+    const res = await request(app).get('/api/v1/chats').set('authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  // NOTE: `buildChatsRouter` (api/src/routes/chats.ts) only gates access on
+  // role via `requireStaffOrAdmin()` — it never compares a chat's tenantId
+  // against `req.user.tenantId`, unlike the tenant-scoped Socket.IO rooms
+  // exercised in chat-flow.test.ts. This test documents that actual, current
+  // REST-layer behavior; it is not an endorsement of it. Flagged separately
+  // as a cross-tenant data-exposure gap worth a follow-up fix.
+  test("current behavior: a tenant-scoped staff member can read another tenant's chat", async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staffA = await seedTenantAndStaff('iso-a');
+    const staffB = await seedTenantAndStaff('iso-b');
+    const visitorB = await seedVisitorSession(staffB.tenantId);
+    const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
+    const tokenA = await loginAs(app, staffA.email, staffA.password);
+
+    const res = await request(app)
+      .get(`/api/v1/chats/${chatB.id}`)
+      .set('authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(chatB.id);
+  });
+
+  test('lists chats, filterable by tenantId and status', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staffA = await seedTenantAndStaff('list-a');
+    const staffB = await seedTenantAndStaff('list-b');
+    const visitorA = await seedVisitorSession(staffA.tenantId);
+    const visitorB = await seedVisitorSession(staffB.tenantId);
+    const pendingChatA = await seedChat(staffA.tenantId, visitorA.id, { status: 'pending' });
+    const activeChatA = await seedChat(staffA.tenantId, visitorA.id, { status: 'active' });
+    const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
+    const token = await loginAs(app, staffA.email, staffA.password);
+
+    const unfiltered = await request(app)
+      .get('/api/v1/chats')
+      .set('authorization', `Bearer ${token}`);
+    expect(unfiltered.status).toBe(200);
+    const unfilteredIds = (unfiltered.body.data as { id: string }[]).map((c) => c.id);
+    expect(unfilteredIds).toEqual(
+      expect.arrayContaining([pendingChatA.id, activeChatA.id, chatB.id]),
+    );
+
+    const byTenant = await request(app)
+      .get('/api/v1/chats')
+      .query({ tenantId: staffA.tenantId })
+      .set('authorization', `Bearer ${token}`);
+    expect(byTenant.status).toBe(200);
+    const tenantIds = (byTenant.body.data as { id: string }[]).map((c) => c.id);
+    expect(tenantIds).toEqual(expect.arrayContaining([pendingChatA.id, activeChatA.id]));
+    expect(tenantIds).not.toContain(chatB.id);
+
+    const byStatus = await request(app)
+      .get('/api/v1/chats')
+      .query({ status: 'pending' })
+      .set('authorization', `Bearer ${token}`);
+    expect(byStatus.status).toBe(200);
+    const statusIds = (byStatus.body.data as { id: string }[]).map((c) => c.id);
+    expect(statusIds).toContain(pendingChatA.id);
+    expect(statusIds).not.toContain(activeChatA.id);
+
+    // An invalid status value fails `chatStatusSchema.safeParse` inside
+    // `parseStatusQuery`, so the filter is silently dropped rather than
+    // rejected — exercises the `parsed.success === false` branch.
+    const invalidStatus = await request(app)
+      .get('/api/v1/chats')
+      .query({ status: 'not-a-real-status' })
+      .set('authorization', `Bearer ${token}`);
+    expect(invalidStatus.status).toBe(200);
+    const invalidStatusIds = (invalidStatus.body.data as { id: string }[]).map((c) => c.id);
+    expect(invalidStatusIds).toEqual(expect.arrayContaining([pendingChatA.id, activeChatA.id]));
+  });
+
+  test('GET /:id returns a chat, and 404s for an unknown id', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('get-one');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id);
+    const token = await loginAs(app, staff.email, staff.password);
+
+    const found = await request(app)
+      .get(`/api/v1/chats/${chat.id}`)
+      .set('authorization', `Bearer ${token}`);
+    expect(found.status).toBe(200);
+    expect(found.body.data.id).toBe(chat.id);
+
+    const missing = await request(app)
+      .get(`/api/v1/chats/${randomUUID()}`)
+      .set('authorization', `Bearer ${token}`);
+    expect(missing.status).toBe(404);
+  });
+
+  test('POST /:id/accept assigns a pending chat and reassigns an already-active one', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('accept');
+    const second = await seedStaff(staff.tenantId, 'accept-second');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id, { status: 'pending' });
+    const token = await loginAs(app, staff.email, staff.password);
+    const secondToken = await loginAs(app, second.email, second.password);
+    const staffUser = await User.findOne({ where: { email: staff.email } });
+    const secondUser = await User.findOne({ where: { email: second.email } });
+
+    const firstAccept = await request(app)
+      .post(`/api/v1/chats/${chat.id}/accept`)
+      .set('authorization', `Bearer ${token}`);
+    expect(firstAccept.status).toBe(200);
+    expect(firstAccept.body.data.status).toBe('active');
+    expect(firstAccept.body.data.assignedTo).toBe(staffUser?.id);
+
+    // Chat is already active: the `status === 'pending'` branch in
+    // `assign()` is NOT retaken, only `assignedTo` changes.
+    const secondAccept = await request(app)
+      .post(`/api/v1/chats/${chat.id}/accept`)
+      .set('authorization', `Bearer ${secondToken}`);
+    expect(secondAccept.status).toBe(200);
+    expect(secondAccept.body.data.status).toBe('active');
+    expect(secondAccept.body.data.assignedTo).toBe(secondUser?.id);
+
+    const missing = await request(app)
+      .post(`/api/v1/chats/${randomUUID()}/accept`)
+      .set('authorization', `Bearer ${token}`);
+    expect(missing.status).toBe(404);
+  });
+
+  test('POST /:id/end transitions status by endedBy and is idempotent once ended', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('end');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const supportEndedChat = await seedChat(staff.tenantId, visitor.id, { status: 'active' });
+    const customerEndedChat = await seedChat(staff.tenantId, visitor.id, { status: 'active' });
+    const token = await loginAs(app, staff.email, staff.password);
+
+    const supportEnd = await request(app)
+      .post(`/api/v1/chats/${supportEndedChat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    expect(supportEnd.status).toBe(200);
+    expect(supportEnd.body.data.status).toBe('ended_by_support');
+    expect(supportEnd.body.data.endedAt).not.toBeNull();
+
+    const customerEnd = await request(app)
+      .post(`/api/v1/chats/${customerEndedChat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'customer' });
+    expect(customerEnd.status).toBe(200);
+    expect(customerEnd.body.data.status).toBe('ended_by_customer');
+
+    // Re-fetch from the DB rather than trusting the first response's
+    // in-memory Date: MySQL's DATETIME column truncates sub-second
+    // precision on write, so the persisted value differs from the
+    // millisecond-precise value the first response echoed back.
+    const persisted = await request(app)
+      .get(`/api/v1/chats/${customerEndedChat.id}`)
+      .set('authorization', `Bearer ${token}`);
+    const endedAtFirst = persisted.body.data.endedAt as string;
+
+    // Already-ended: `endChat()`'s `chat.endedAt !== null` early-return
+    // branch — status and endedAt must stay exactly as they were, even
+    // though this call asks for a different `endedBy`.
+    const secondEnd = await request(app)
+      .post(`/api/v1/chats/${customerEndedChat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    expect(secondEnd.status).toBe(200);
+    expect(secondEnd.body.data.status).toBe('ended_by_customer');
+    expect(secondEnd.body.data.endedAt).toBe(endedAtFirst);
+
+    const missing = await request(app)
+      .post(`/api/v1/chats/${randomUUID()}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    expect(missing.status).toBe(404);
+  });
+
+  test('GET /:id/messages returns the transcript ordered by deliveredAt, not insertion order', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('messages');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id, { status: 'active' });
+    const token = await loginAs(app, staff.email, staff.password);
+    const base = Date.now();
+
+    await seedMessage(chat.id, 'third', new Date(base + 2000));
+    await seedMessage(chat.id, 'first', new Date(base));
+    await seedMessage(chat.id, 'second', new Date(base + 1000));
+
+    const res = await request(app)
+      .get(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const bodies = (res.body.data as { body: string }[]).map((m) => m.body);
+    expect(bodies).toEqual(['first', 'second', 'third']);
+  });
+
+  test('POST /:id/messages activates a pending chat on first reply and assigns the sender', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('activate');
+    const second = await seedStaff(staff.tenantId, 'activate-second');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id, {
+      status: 'pending',
+      assignedTo: null,
+    });
+    const token = await loginAs(app, staff.email, staff.password);
+    const secondToken = await loginAs(app, second.email, second.password);
+    const staffUser = await User.findOne({ where: { email: staff.email } });
+
+    const firstReply = await request(app)
+      .post(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ body: 'how can I help?' });
+    expect(firstReply.status).toBe(201);
+
+    const afterFirst = await Chat.findByPk(chat.id);
+    expect(afterFirst?.status).toBe('active');
+    expect(afterFirst?.assignedTo).toBe(staffUser?.id);
+
+    // Chat is already active: the `status === 'pending'` branch in
+    // `sendMessage()` is NOT retaken, so a second staffer's reply does not
+    // steal the assignment.
+    const secondReply = await request(app)
+      .post(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${secondToken}`)
+      .send({ body: 'still here' });
+    expect(secondReply.status).toBe(201);
+
+    const afterSecond = await Chat.findByPk(chat.id);
+    expect(afterSecond?.status).toBe('active');
+    expect(afterSecond?.assignedTo).toBe(staffUser?.id);
+
+    // Ending the chat then replying hits `sendMessage()`'s
+    // `chat.endedAt !== null` "chat has ended" rejection branch.
+    await request(app)
+      .post(`/api/v1/chats/${chat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    const afterEndReply = await request(app)
+      .post(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ body: 'too late' });
+    expect(afterEndReply.status).toBe(400);
+  });
+});

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -1,0 +1,397 @@
+import { io as ioClient, type Socket } from 'socket.io-client';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { Tenant, User } from '../../src/models/index.js';
+
+import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+
+const STAFF_PASSWORD = 'Staff!Password1';
+
+/**
+ * Create a tenant + one staff user attached to it, and return the tenant id.
+ * @param tenantSlug - Unique tenant slug.
+ * @param email - Staff login email.
+ * @returns The new tenant's id.
+ */
+async function seedTenantAndStaff(
+  tenantSlug: string,
+  email: string,
+): Promise<{ tenantId: string }> {
+  const tenant = await Tenant.create({
+    name: `Tenant-${tenantSlug}`,
+    slug: tenantSlug,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+  await User.create({
+    email,
+    passwordHash: STAFF_PASSWORD,
+    firstName: 'St',
+    lastName: 'Aff',
+    role: 'staff',
+    tenantId: tenant.id,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { tenantId: tenant.id };
+}
+
+/**
+ * Log in a staff user over HTTP and return the access token.
+ * @param baseUrl - Live harness base URL.
+ * @param email - Login email.
+ * @param password - Login password.
+ * @returns The bearer access token.
+ */
+async function loginAs(baseUrl: string, email: string, password: string): Promise<string> {
+  const res = await request(baseUrl).post('/api/v1/auth/login').send({ email, password });
+  expect(res.status).toBe(200);
+  return res.body.data.accessToken as string;
+}
+
+/**
+ * Init a visitor session over HTTP and return the raw cookie value + session id.
+ * @param baseUrl - Live harness base URL.
+ * @param tenantSlug - Tenant to attach the session to.
+ * @returns The raw `livechat_visitor` cookie value plus the session id.
+ */
+async function initVisitor(
+  baseUrl: string,
+  tenantSlug: string,
+): Promise<{ cookie: string; sessionId: string }> {
+  const res = await request(baseUrl)
+    .post('/api/v1/visitor/session')
+    .send({ tenantKey: tenantSlug });
+  expect(res.status).toBe(201);
+  const setCookie = res.headers['set-cookie'] as string | string[] | undefined;
+  const cookies: string[] = Array.isArray(setCookie)
+    ? setCookie
+    : setCookie === undefined
+      ? []
+      : [setCookie];
+  const visitorCookie = cookies.find((c) => c.startsWith('livechat_visitor='));
+  const cookie = visitorCookie?.split(';')[0]?.replace('livechat_visitor=', '') ?? '';
+  return { cookie, sessionId: res.body.data.sessionId as string };
+}
+
+function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`timeout waiting for ${event}`));
+    }, timeoutMs);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timer);
+      resolve(payload);
+    });
+  });
+}
+
+describe('visitor namespace + visitor routes (integration)', () => {
+  let harness: LiveTestHarness | null = null;
+
+  beforeAll(async () => {
+    harness = await probeLiveHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  test('connection is rejected without any cookie', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const socket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const err = await waitFor<Error>(socket, 'connect_error');
+    expect(err.message).toContain('Visitor cookie required');
+    socket.disconnect();
+  }, 10_000);
+
+  test('connection is rejected with a garbage cookie', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const socket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: 'not-a-real-cookie-value' },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const err = await waitFor<Error>(socket, 'connect_error');
+    expect(err.message).toContain('Invalid visitor cookie');
+    socket.disconnect();
+  }, 10_000);
+
+  test('connection accepts the cookie carried on the raw header instead of auth', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('typing-hdr', 'hdr-staff@typing.example');
+    const { cookie } = await initVisitor(baseUrl, 'typing-hdr');
+    const socket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      transports: ['websocket'],
+      forceNew: true,
+      extraHeaders: { cookie: `livechat_visitor=${cookie}` },
+    });
+    await waitFor(socket, 'connect');
+    socket.disconnect();
+  }, 10_000);
+
+  test('chat:typing fans out to the chat room and the staff namespace', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('typing', 'staff@typing.example');
+    const accessToken = await loginAs(baseUrl, 'staff@typing.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie } = await initVisitor(baseUrl, 'typing');
+
+    const initRes = await request(baseUrl)
+      .post('/api/v1/visitor/chats')
+      .set('cookie', `livechat_visitor=${visitorCookie}`)
+      .send({ customerName: 'Typer', body: 'hello' });
+    expect(initRes.status).toBe(201);
+    const chatId = initRes.body.data.chat.id as string;
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await Promise.all([waitFor(staffSocket, 'connect'), waitFor(visitorSocket, 'connect')]);
+    visitorSocket.emit('chat:join', { chatId });
+    // Staff only joins the `chat:{id}` room on accept — chat:typing (unlike
+    // chat:message) is not also mirrored to the tenant room, so without this
+    // the staff socket never sees it.
+    staffSocket.emit('chat:accept', { chatId });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const otherVisitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(otherVisitorSocket, 'connect');
+    otherVisitorSocket.emit('chat:join', { chatId });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const staffSeesTyping = waitFor<{ chatId: string; actor: string; isTyping: boolean }>(
+      staffSocket,
+      'chat:typing',
+    );
+    const roommateSeesTyping = waitFor<{ chatId: string; actor: string; isTyping: boolean }>(
+      otherVisitorSocket,
+      'chat:typing',
+    );
+    visitorSocket.emit('chat:typing', { chatId, isTyping: true });
+    const [staffTyping, roommateTyping] = await Promise.all([staffSeesTyping, roommateSeesTyping]);
+    expect(staffTyping.chatId).toBe(chatId);
+    expect(staffTyping.actor).toBe('visitor');
+    expect(staffTyping.isTyping).toBe(true);
+    expect(roommateTyping.actor).toBe('visitor');
+
+    staffSocket.disconnect();
+    visitorSocket.disconnect();
+    otherVisitorSocket.disconnect();
+  }, 30_000);
+
+  test('visitor chat:end ends the chat as customer and notifies staff', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('vend', 'staff@vend.example');
+    const accessToken = await loginAs(baseUrl, 'staff@vend.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie } = await initVisitor(baseUrl, 'vend');
+
+    const initRes = await request(baseUrl)
+      .post('/api/v1/visitor/chats')
+      .set('cookie', `livechat_visitor=${visitorCookie}`)
+      .send({ customerName: 'Ender', body: 'bye soon' });
+    expect(initRes.status).toBe(201);
+    const chatId = initRes.body.data.chat.id as string;
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await Promise.all([waitFor(staffSocket, 'connect'), waitFor(visitorSocket, 'connect')]);
+    visitorSocket.emit('chat:join', { chatId });
+    staffSocket.emit('chat:accept', { chatId });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const staffSeesEnd = waitFor<{ chatId: string; endedBy: string }>(staffSocket, 'chat:ended');
+    visitorSocket.emit('chat:end', { chatId });
+    const ended = await staffSeesEnd;
+    expect(ended.chatId).toBe(chatId);
+    expect(ended.endedBy).toBe('customer');
+
+    staffSocket.disconnect();
+    visitorSocket.disconnect();
+  }, 30_000);
+
+  test('visitor:page_changed fans out to the tenant staff room', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('pagechange', 'staff@pagechange.example');
+    const accessToken = await loginAs(baseUrl, 'staff@pagechange.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'pagechange');
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(staffSocket, 'connect');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(visitorSocket, 'connect');
+
+    const staffSeesPageChange = waitFor<{ visitorSessionId: string; currentUrl: string }>(
+      staffSocket,
+      'visitor:page_changed',
+    );
+    visitorSocket.emit('visitor:page_changed', { currentUrl: 'https://example.com/pricing' });
+    const evt = await staffSeesPageChange;
+    expect(evt.visitorSessionId).toBe(sessionId);
+    expect(evt.currentUrl).toBe('https://example.com/pricing');
+
+    staffSocket.disconnect();
+    visitorSocket.disconnect();
+  }, 30_000);
+
+  test('visitor disconnect removes presence and notifies staff visitor:left', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('leaving', 'staff@leaving.example');
+    const accessToken = await loginAs(baseUrl, 'staff@leaving.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'leaving');
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(staffSocket, 'connect');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(visitorSocket, 'connect');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const staffSeesLeft = waitFor<{ tenantId: string; visitorSessionId: string }>(
+      staffSocket,
+      'visitor:left',
+    );
+    visitorSocket.disconnect();
+    const evt = await staffSeesLeft;
+    expect(evt.visitorSessionId).toBe(sessionId);
+
+    staffSocket.disconnect();
+  }, 30_000);
+
+  test('POST /visitor/session persists the optional language/currentUrl/referrer fields', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('optfields', 'staff@optfields.example');
+    const res = await request(baseUrl).post('/api/v1/visitor/session').send({
+      tenantKey: 'optfields',
+      language: 'en-US',
+      currentUrl: 'https://example.com/landing',
+      referrer: 'https://google.com/search',
+    });
+    expect(res.status).toBe(201);
+
+    const { VisitorSession } = await import('../../src/models/index.js');
+    const session = await VisitorSession.findByPk(res.body.data.sessionId as string);
+    expect(session?.language).toBe('en-US');
+    expect(session?.currentUrl).toBe('https://example.com/landing');
+    expect(session?.referrer).toBe('https://google.com/search');
+  });
+
+  test('POST /visitor/heartbeat without a cookie is unauthorized', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const res = await request(baseUrl).post('/api/v1/visitor/heartbeat').send({});
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('POST /visitor/heartbeat with a valid cookie updates the session and returns 200', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('heartbeat', 'staff@heartbeat.example');
+    const { cookie } = await initVisitor(baseUrl, 'heartbeat');
+
+    const res = await request(baseUrl)
+      .post('/api/v1/visitor/heartbeat')
+      .set('cookie', `livechat_visitor=${cookie}`)
+      .send({ currentUrl: 'https://example.com/heartbeat' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('GET /visitor/chats/current without a cookie is unauthorized', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const res = await request(baseUrl).get('/api/v1/visitor/chats/current');
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /visitor/chats/current returns null chat + empty messages when none exists', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('nochat', 'staff@nochat.example');
+    const { cookie } = await initVisitor(baseUrl, 'nochat');
+
+    const res = await request(baseUrl)
+      .get('/api/v1/visitor/chats/current')
+      .set('cookie', `livechat_visitor=${cookie}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.chat).toBeNull();
+    expect(res.body.data.messages).toEqual([]);
+  });
+});

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.d.ts', 'src/reset.d.ts', 'src/server.ts', 'src/config/index.ts'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/reset.d.ts',
+        // Process entrypoints: they wire the app together and run on boot, so
+        // exercising them proves nothing the integration suite does not.
+        'src/server.ts',
+        'src/config/index.ts',
+        // Operator CLI scripts, run by hand against a real database.
+        'src/scripts/**',
+      ],
       thresholds: {
         lines: 80,
         statements: 80,

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "test:api": "npm --workspace api run test",
     "test:ui": "npm --workspace ui run test:unit",
     "test:widget": "npm --workspace widget run test:unit",
+    "test:coverage": "npm --workspace api run test:coverage",
+    "test:ci": "npm-run-all -s test:shared test:coverage test:ui test:widget",
     "test:e2e": "npm-run-all -s usecases:generate test:e2e:journeys test:e2e:ui test:e2e:widget",
     "test:e2e:ui": "npm --workspace ui run test:e2e",
     "test:e2e:widget": "npm --workspace widget run test:e2e",
@@ -97,7 +99,7 @@
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "license-checker-rseidelsohn --production --csv --out reports/licenses.csv",
     "check": "npm-run-all -p lint typecheck stylelint markdownlint usecases:validate",
-    "check:all": "npm-run-all -s check test build size dupes links security license:check",
+    "check:all": "npm-run-all -s check test:ci build size dupes links security license:check",
     "ci": "npm run check:all",
     "test:e2e:journeys": "npm --workspace @livechat/e2e run test"
   },


### PR DESCRIPTION
The 80/75/80/80 thresholds in `api/vitest.config.ts` were **never enforced** — `check:all` ran `test`, not `test:coverage`. So the gate was decorative, and the project sat well below its own bar.

### Coverage

| Metric | Before | After | Threshold |
|---|---|---|---|
| Statements | 64.30% | **93.24%** | 80 |
| **Branches** | **39.53%** | **80.89%** | 75 |
| Functions | 73.99% | **98.64%** | 80 |
| Lines | 69.11% | **96.65%** | 80 |

Branch coverage — the number that actually reflects tested decision paths — went from **39.5% to 80.9%**, with ~6 points of headroom rather than scraping the line.

**Tests: 22 → 191, across 7 → 22 files.**

### Wiring
`check:all` now runs `test:ci`, which runs the api suite **once under coverage** (no duplicate run); `shared`/`ui`/`widget` are unchanged. Plain `npm test` stays fast for local work, so only the gate pays the coverage cost.

Entrypoints are excluded alongside the existing `server.ts`: `src/scripts/**` are operator CLIs run by hand against a real database. That exclusion is worth ~1.5 points — everything else is real tests.

### What was added
- **Middlewares + utils** — 7 co-located unit test files, all at **100%** across every metric. `authorize.ts` was 13.33% branch, the densest gap in the codebase.
- **Route integration tests** (admin, chats, auth lifecycle) weighted toward *denial and error* branches, not happy paths: 401/403, 404, expired and reused tokens, account lockout, suspended accounts, invalid payloads, duplicate-slug conflicts.
- **Live-socket tests** for `visitor-namespace.ts` (25% → 87.5% branch). `chat:typing` had no coverage anywhere in the repo.
- **Config factory unit tests** — `env.ts`, `logger.ts`, `redis.ts` were all at 0%.

### Verified
`check:all` exits **0** with thresholds enforced; 191/191 api tests, all 8 e2e journeys still green, lint + typecheck clean.

### ⚠️ Found while writing these — needs a separate decision
Two agents independently hit the same wall: **the REST API does not enforce tenant isolation.**
- `requireTenantAccess()` is defined in `authorize.ts` and **used nowhere**.
- `chats.ts` and `users.ts` scope by caller-supplied `?tenantId`, never `req.user.tenantId`.
- `tenants.ts` has no tenant scoping at all — role-only.

A tenant-scoped admin at Acme can read Globex's chats, users, and tenants. The *socket* layer is correctly isolated (proven in `chat-flow.test.ts`), which likely masked it. `chat-routes.test.ts` contains a clearly-labelled **characterization test** asserting the current (insecure) 200 — it will fail when this is fixed, which is the intent.

Also noted: `audit-service.record()` is never called from any route or service — audit logging is effectively inert.

Neither is fixed here; both are out of scope for a coverage PR.