### PR TITLE
fix(api): enforce tenant isolation on the REST surface

### DIFF
--- a/api/src/middlewares/authorize.test.ts
+++ b/api/src/middlewares/authorize.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from '../utils/api-error.js';
 
-import { requireRole, requireStaffOrAdmin, requireTenantAccess } from './authorize.js';
+import {
+  assertTenantAccess,
+  callerTenantScope,
+  requireRole,
+  requireStaffOrAdmin,
+  resolveTenantFilter,
+} from './authorize.js';
 
 import type { User } from '../models/index.js';
 import type { Request, Response } from 'express';
@@ -86,88 +92,90 @@ describe('requireStaffOrAdmin', () => {
   });
 });
 
-describe('requireTenantAccess', () => {
-  it('calls next with 401 when no user is authenticated', () => {
-    const next = vi.fn();
-    const req = fakeReq({});
-    requireTenantAccess()(req, res, next);
-    const err = next.mock.calls[0]?.[0] as ApiError;
-    expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(401);
+describe('callerTenantScope', () => {
+  it('returns undefined for an untenanted AFixt staff account', () => {
+    expect(callerTenantScope(fakeReq({ user: fakeUser('super_admin', null) }))).toBeUndefined();
   });
 
-  it.each(['super_admin', 'admin', 'staff'] as const)(
-    'lets %s through regardless of tenant mismatch',
-    (role) => {
-      const next = vi.fn();
-      const req = fakeReq({
-        user: fakeUser(role, 'tenant-a'),
-        params: { tenantId: 'tenant-b' },
-      });
-      requireTenantAccess()(req, res, next);
-      expect(next).toHaveBeenCalledExactlyOnceWith();
-    },
-  );
-
-  it('allows a client through when no tenantId is present anywhere on the request', () => {
-    const next = vi.fn();
-    const req = fakeReq({ user: fakeUser('client', 'tenant-a') });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('returns undefined when nobody is authenticated', () => {
+    expect(callerTenantScope(fakeReq({}))).toBeUndefined();
   });
 
-  it('allows a client whose params.tenantId matches their own tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      params: { tenantId: 'tenant-a' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('returns the tenant a scoped caller is confined to', () => {
+    expect(callerTenantScope(fakeReq({ user: fakeUser('admin', 'tenant-a') }))).toBe('tenant-a');
+  });
+});
+
+describe('assertTenantAccess', () => {
+  it('permits an untenanted caller to touch any tenant', () => {
+    const req = fakeReq({ user: fakeUser('super_admin', null) });
+    expect(() => {
+      assertTenantAccess(req, 'tenant-b');
+    }).not.toThrow();
   });
 
-  it('allows a client whose body.tenantId matches their own tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      body: { tenantId: 'tenant-a' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('permits a scoped caller to touch their own tenant', () => {
+    const req = fakeReq({ user: fakeUser('staff', 'tenant-a') });
+    expect(() => {
+      assertTenantAccess(req, 'tenant-a');
+    }).not.toThrow();
   });
 
-  it('allows a client whose query.tenantId matches their own tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      query: { tenantId: 'tenant-a' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('rejects a scoped caller touching another tenant', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(() => {
+      assertTenantAccess(req, 'tenant-b');
+    }).toThrow(ApiError);
   });
 
-  it('prefers params.tenantId over body/query when present', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      params: { tenantId: 'tenant-a' },
-      body: { tenantId: 'tenant-b' },
-      query: { tenantId: 'tenant-c' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('rejects a scoped caller when the resource has no tenant at all', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    let thrown: unknown;
+    try {
+      assertTenantAccess(req, null);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(403);
+  });
+});
+
+describe('resolveTenantFilter', () => {
+  it('lets an untenanted caller ask for any single tenant', () => {
+    const req = fakeReq({ user: fakeUser('super_admin', null) });
+    expect(resolveTenantFilter(req, 'tenant-b')).toBe('tenant-b');
   });
 
-  it('calls next with 403 when the resolved tenantId does not match the user tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      params: { tenantId: 'tenant-b' },
-    });
-    requireTenantAccess()(req, res, next);
-    const err = next.mock.calls[0]?.[0] as ApiError;
-    expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(403);
-    expect(err.message).toBe('Access denied to this tenant');
+  it('lets an untenanted caller ask for every tenant', () => {
+    const req = fakeReq({ user: fakeUser('super_admin', null) });
+    expect(resolveTenantFilter(req, undefined)).toBeUndefined();
+  });
+
+  it('pins a scoped caller to their own tenant when they ask for nothing', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(resolveTenantFilter(req, undefined)).toBe('tenant-a');
+  });
+
+  it('pins a scoped caller to their own tenant when they ask for it explicitly', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(resolveTenantFilter(req, 'tenant-a')).toBe('tenant-a');
+  });
+
+  it('ignores a non-string filter and still pins a scoped caller', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(resolveTenantFilter(req, 42)).toBe('tenant-a');
+  });
+
+  it('rejects a scoped caller explicitly asking for another tenant', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    let thrown: unknown;
+    try {
+      resolveTenantFilter(req, 'tenant-b');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(403);
   });
 });

--- a/api/src/middlewares/authorize.ts
+++ b/api/src/middlewares/authorize.ts
@@ -1,7 +1,7 @@
 import { ApiError } from '../utils/api-error.js';
 
 import type { Role } from '@livechat/shared';
-import type { RequestHandler } from 'express';
+import type { Request, RequestHandler } from 'express';
 
 /**
  * Require the authenticated user to hold one of the listed roles.
@@ -31,28 +31,56 @@ export function requireStaffOrAdmin(): RequestHandler {
 }
 
 /**
- * Restrict access to a resource by tenant: super_admin/admin/staff may touch
- * any tenant; clients may only touch their own.
- * @returns Express middleware that reads a tenantId from params/body/query.
+ * The tenant a caller is confined to, or `undefined` when unrestricted.
+ *
+ * Mirrors the identity model: AFixt staff carry no tenant of their own
+ * (`tenant_id` is null) and serve every tenant, matching how untenanted staff
+ * watch all tenants over Socket.IO. Anyone carrying a `tenant_id` — a
+ * tenant-scoped admin, staff member, or client — is confined to it.
+ * @param req - The authenticated request.
+ * @returns The tenant id the caller is limited to, or undefined for none.
  */
-export function requireTenantAccess(): RequestHandler {
-  return (req, _res, next) => {
-    if (req.user === undefined) {
-      next(ApiError.unauthorized());
-      return;
-    }
-    if (['super_admin', 'admin', 'staff'].includes(req.user.role)) {
-      next();
-      return;
-    }
-    const tenantId =
-      (req.params.tenantId as string | undefined) ??
-      ((req.body as Record<string, unknown>).tenantId as string | undefined) ??
-      (req.query.tenantId as string | undefined);
-    if (tenantId !== undefined && req.user.tenantId !== tenantId) {
-      next(ApiError.forbidden('Access denied to this tenant'));
-      return;
-    }
-    next();
-  };
+export function callerTenantScope(req: Request): string | undefined {
+  return req.user?.tenantId ?? undefined;
+}
+
+/**
+ * Reject the request unless the caller may act on `tenantId`.
+ *
+ * Resource-level rather than request-level on purpose: for routes addressed by
+ * resource id (`/chats/:id`, `/users/:id`) the owning tenant is a property of
+ * the fetched row, so it cannot be checked from params/body/query before the
+ * lookup happens.
+ * @param req - The authenticated request.
+ * @param tenantId - The owning tenant of the resource being touched.
+ * @throws {ApiError} 403 when the caller is scoped to a different tenant.
+ */
+export function assertTenantAccess(req: Request, tenantId: string | null): void {
+  const scope = callerTenantScope(req);
+  if (scope === undefined) return;
+  if (tenantId !== scope) {
+    throw ApiError.forbidden('Access denied to this tenant');
+  }
+}
+
+/**
+ * Resolve the tenant filter for a collection endpoint.
+ *
+ * A scoped caller is pinned to their own tenant regardless of what they ask
+ * for, so omitting `?tenantId` can never widen the result set across tenants.
+ * Explicitly requesting a different tenant is a 403 rather than a silent
+ * override, so the caller is told rather than quietly given the wrong answer.
+ * @param req - The authenticated request.
+ * @param requested - The caller-supplied tenant filter, if any.
+ * @returns The tenant id to filter by, or undefined for all tenants.
+ * @throws {ApiError} 403 when a scoped caller requests another tenant.
+ */
+export function resolveTenantFilter(req: Request, requested: unknown): string | undefined {
+  const asked = typeof requested === 'string' ? requested : undefined;
+  const scope = callerTenantScope(req);
+  if (scope === undefined) return asked;
+  if (asked !== undefined && asked !== scope) {
+    throw ApiError.forbidden('Access denied to this tenant');
+  }
+  return scope;
 }

--- a/api/src/routes/chats.ts
+++ b/api/src/routes/chats.ts
@@ -9,7 +9,11 @@ import {
 import { Router } from 'express';
 
 import { authenticate } from '../middlewares/authenticate.js';
-import { requireStaffOrAdmin } from '../middlewares/authorize.js';
+import {
+  assertTenantAccess,
+  requireStaffOrAdmin,
+  resolveTenantFilter,
+} from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
 
@@ -47,10 +51,10 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
   router.get(
     '/',
     asyncHandler(async (req, res) => {
-      const tenantId = req.query.tenantId;
+      const tenantId = resolveTenantFilter(req, req.query.tenantId);
       const status = parseStatusQuery(req.query.status);
       const filter: Parameters<ChatService['list']>[0] = {};
-      if (typeof tenantId === 'string') filter.tenantId = tenantId;
+      if (tenantId !== undefined) filter.tenantId = tenantId;
       if (status !== undefined) filter.status = status;
       const chats = await deps.chat.list(filter);
       res.json({ success: true, data: chats });
@@ -63,6 +67,7 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const chat = await deps.chat.getById(id);
+      assertTenantAccess(req, chat.tenantId);
       res.json({ success: true, data: chat });
     }),
   );
@@ -72,6 +77,9 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string') return;
+      // Resolve the chat first so its owning tenant can gate the transcript.
+      const chat = await deps.chat.getById(id);
+      assertTenantAccess(req, chat.tenantId);
       const messages = await deps.chat.listMessages(id);
       res.json({ success: true, data: messages });
     }),
@@ -83,6 +91,8 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string' || req.user === undefined) return;
+      const target = await deps.chat.getById(id);
+      assertTenantAccess(req, target.tenantId);
       const body = parsedBody(req, sendMessageInputSchema) satisfies SendMessageInput;
       const message = await deps.chat.sendMessage({
         chatId: id,
@@ -99,6 +109,8 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string' || req.user === undefined) return;
+      const target = await deps.chat.getById(id);
+      assertTenantAccess(req, target.tenantId);
       const chat = await deps.chat.assign(id, req.user.id);
       res.json({ success: true, data: chat });
     }),
@@ -110,6 +122,8 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string') return;
+      const target = await deps.chat.getById(id);
+      assertTenantAccess(req, target.tenantId);
       const body = parsedBody(req, endChatInputSchema) satisfies EndChatInput;
       const chat = await deps.chat.endChat({ chatId: id, endedBy: body.endedBy });
       res.json({ success: true, data: chat });

--- a/api/src/routes/tenants.ts
+++ b/api/src/routes/tenants.ts
@@ -5,7 +5,7 @@ import {
   type UpdateTenantInput,
 } from '@livechat/shared';
 
-import { requireRole } from '../middlewares/authorize.js';
+import { assertTenantAccess, callerTenantScope, requireRole } from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
 
@@ -29,9 +29,12 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
 
   router.get(
     '/',
-    asyncHandler(async (_req, res) => {
+    asyncHandler(async (req, res) => {
       const tenants = await deps.tenant.list();
-      res.json({ success: true, data: tenants });
+      // A tenant-scoped admin sees only their own tenant in the list.
+      const scope = callerTenantScope(req);
+      const visible = scope === undefined ? tenants : tenants.filter((t) => t.id === scope);
+      res.json({ success: true, data: visible });
     }),
   );
 
@@ -52,6 +55,7 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const tenant = await deps.tenant.getById(id);
+      assertTenantAccess(req, tenant.id);
       res.json({ success: true, data: tenant });
     }),
   );

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { updateUserInputSchema, type UpdateUserInput } from '@livechat/shared';
 
+import { assertTenantAccess, resolveTenantFilter } from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
 
@@ -24,8 +25,7 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
   router.get(
     '/',
     asyncHandler(async (req, res) => {
-      const tenantId = req.query.tenantId;
-      const users = await deps.user.list(typeof tenantId === 'string' ? tenantId : undefined);
+      const users = await deps.user.list(resolveTenantFilter(req, req.query.tenantId));
       res.json({ success: true, data: users });
     }),
   );
@@ -36,6 +36,7 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const user = await deps.user.getById(id);
+      assertTenantAccess(req, user.tenantId);
       res.json({ success: true, data: user });
     }),
   );
@@ -46,6 +47,10 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string') return;
+      // Check the existing row's tenant before mutating it, so a scoped caller
+      // cannot edit — or re-tenant — someone else's user.
+      const existing = await deps.user.getById(id);
+      assertTenantAccess(req, existing.tenantId);
       const body = parsedBody(req, updateUserInputSchema) satisfies UpdateUserInput;
       const user = await deps.user.update(id, body);
       res.json({ success: true, data: user });

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -267,14 +267,12 @@ describe('admin routes (integration)', () => {
           .send({ origins: ['https://example.com'] });
         expect(origins.status).toBe(403);
 
-        // Read-only tenant routes have no super_admin guard, so admin CAN
-        // read any tenant (including one it is not scoped to) — the admin
-        // console's whole point is cross-tenant visibility for AFixt staff.
+        // A tenant-scoped admin cannot read a tenant it is not scoped to
+        // (issue #43). Only untenanted AFixt staff get cross-tenant visibility.
         const readOther = await request(app)
           .get(`/api/v1/tenants/${otherTenant.id}`)
           .set('authorization', `Bearer ${token}`);
-        expect(readOther.status).toBe(200);
-        expect(readOther.body.data.id).toBe(otherTenant.id);
+        expect(readOther.status).toBe(403);
       },
     );
   });
@@ -679,5 +677,92 @@ describe('admin routes (integration)', () => {
         expect(res.status).toBe(400);
       },
     );
+  });
+
+  // Issue #43: role alone never granted cross-tenant access. A caller carrying
+  // a tenant_id is confined to it; only untenanted AFixt staff span tenants.
+  test.runIf(() => harness !== null)(
+    "a tenant-scoped admin cannot read or modify another tenant's user",
+    async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const own = await seedTenant({ slug: `iso-own-${Math.random().toString(36).slice(2, 8)}` });
+      const other = await seedTenant({
+        slug: `iso-other-${Math.random().toString(36).slice(2, 8)}`,
+      });
+      const admin = await seedUser('admin', own.id);
+      const victim = await seedUser('staff', other.id);
+      const token = await login(admin.user.email, admin.password);
+      const auth = `Bearer ${token}`;
+
+      const read = await request(app)
+        .get(`/api/v1/users/${victim.user.id}`)
+        .set('authorization', auth);
+      expect(read.status).toBe(403);
+
+      const write = await request(app)
+        .patch(`/api/v1/users/${victim.user.id}`)
+        .set('authorization', auth)
+        .send({ status: 'suspended' });
+      expect(write.status).toBe(403);
+
+      // The victim must be untouched by the refused write.
+      await victim.user.reload();
+      expect(victim.user.status).toBe('active');
+    },
+  );
+
+  test.runIf(() => harness !== null)(
+    'list endpoints are pinned to the caller tenant and refuse a cross-tenant filter',
+    async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const own = await seedTenant({ slug: `pin-own-${Math.random().toString(36).slice(2, 8)}` });
+      const other = await seedTenant({
+        slug: `pin-other-${Math.random().toString(36).slice(2, 8)}`,
+      });
+      const admin = await seedUser('admin', own.id);
+      const outsider = await seedUser('staff', other.id);
+      const token = await login(admin.user.email, admin.password);
+      const auth = `Bearer ${token}`;
+
+      const users = await request(app).get('/api/v1/users').set('authorization', auth);
+      expect(users.status).toBe(200);
+      const userIds = (users.body.data as { id: string }[]).map((u) => u.id);
+      expect(userIds).toContain(admin.user.id);
+      expect(userIds).not.toContain(outsider.user.id);
+
+      const crossFilter = await request(app)
+        .get('/api/v1/users')
+        .query({ tenantId: other.id })
+        .set('authorization', auth);
+      expect(crossFilter.status).toBe(403);
+
+      const tenants = await request(app).get('/api/v1/tenants').set('authorization', auth);
+      expect(tenants.status).toBe(200);
+      const tenantIds = (tenants.body.data as { id: string }[]).map((t) => t.id);
+      expect(tenantIds).toEqual([own.id]);
+    },
+  );
+
+  test.runIf(() => harness !== null)('untenanted AFixt staff still span every tenant', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const a = await seedTenant({ slug: `span-a-${Math.random().toString(36).slice(2, 8)}` });
+    const b = await seedTenant({ slug: `span-b-${Math.random().toString(36).slice(2, 8)}` });
+    const su = await seedUser('super_admin', null);
+    const token = await login(su.user.email, su.password);
+    const auth = `Bearer ${token}`;
+
+    const readA = await request(app).get(`/api/v1/tenants/${a.id}`).set('authorization', auth);
+    expect(readA.status).toBe(200);
+    const readB = await request(app).get(`/api/v1/tenants/${b.id}`).set('authorization', auth);
+    expect(readB.status).toBe(200);
+
+    const filtered = await request(app)
+      .get('/api/v1/users')
+      .query({ tenantId: b.id })
+      .set('authorization', auth);
+    expect(filtered.status).toBe(200);
   });
 });

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -231,13 +231,11 @@ describe('chat routes (integration)', () => {
     expect(res.status).toBe(403);
   });
 
-  // NOTE: `buildChatsRouter` (api/src/routes/chats.ts) only gates access on
-  // role via `requireStaffOrAdmin()` — it never compares a chat's tenantId
-  // against `req.user.tenantId`, unlike the tenant-scoped Socket.IO rooms
-  // exercised in chat-flow.test.ts. This test documents that actual, current
-  // REST-layer behavior; it is not an endorsement of it. Flagged separately
-  // as a cross-tenant data-exposure gap worth a follow-up fix.
-  test("current behavior: a tenant-scoped staff member can read another tenant's chat", async () => {
+  // Issue #43: the REST layer now enforces the same tenant isolation the
+  // Socket.IO rooms already did (see chat-flow.test.ts). A tenant-scoped staff
+  // member is confined to their own tenant across every chat route — reads and
+  // writes alike; only untenanted AFixt staff span tenants.
+  test("a tenant-scoped staff member cannot touch another tenant's chat", async () => {
     if (harness === null) return;
     const { app } = harness;
     const staffA = await seedTenantAndStaff('iso-a');
@@ -245,12 +243,32 @@ describe('chat routes (integration)', () => {
     const visitorB = await seedVisitorSession(staffB.tenantId);
     const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
     const tokenA = await loginAs(app, staffA.email, staffA.password);
+    const auth = `Bearer ${tokenA}`;
 
-    const res = await request(app)
-      .get(`/api/v1/chats/${chatB.id}`)
-      .set('authorization', `Bearer ${tokenA}`);
-    expect(res.status).toBe(200);
-    expect(res.body.data.id).toBe(chatB.id);
+    const read = await request(app).get(`/api/v1/chats/${chatB.id}`).set('authorization', auth);
+    expect(read.status).toBe(403);
+
+    const transcript = await request(app)
+      .get(`/api/v1/chats/${chatB.id}/messages`)
+      .set('authorization', auth);
+    expect(transcript.status).toBe(403);
+
+    const accept = await request(app)
+      .post(`/api/v1/chats/${chatB.id}/accept`)
+      .set('authorization', auth);
+    expect(accept.status).toBe(403);
+
+    const post = await request(app)
+      .post(`/api/v1/chats/${chatB.id}/messages`)
+      .set('authorization', auth)
+      .send({ body: 'should not land' });
+    expect(post.status).toBe(403);
+
+    const end = await request(app)
+      .post(`/api/v1/chats/${chatB.id}/end`)
+      .set('authorization', auth)
+      .send({ endedBy: 'support' });
+    expect(end.status).toBe(403);
   });
 
   test('lists chats, filterable by tenantId and status', async () => {
@@ -265,14 +283,23 @@ describe('chat routes (integration)', () => {
     const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
     const token = await loginAs(app, staffA.email, staffA.password);
 
+    // Omitting ?tenantId cannot widen the result set across tenants: a scoped
+    // caller is pinned to their own tenant (issue #43).
     const unfiltered = await request(app)
       .get('/api/v1/chats')
       .set('authorization', `Bearer ${token}`);
     expect(unfiltered.status).toBe(200);
     const unfilteredIds = (unfiltered.body.data as { id: string }[]).map((c) => c.id);
-    expect(unfilteredIds).toEqual(
-      expect.arrayContaining([pendingChatA.id, activeChatA.id, chatB.id]),
-    );
+    expect(unfilteredIds).toEqual(expect.arrayContaining([pendingChatA.id, activeChatA.id]));
+    expect(unfilteredIds).not.toContain(chatB.id);
+
+    // Explicitly asking for someone else's tenant is refused, not silently
+    // rewritten to your own.
+    const crossTenant = await request(app)
+      .get('/api/v1/chats')
+      .query({ tenantId: staffB.tenantId })
+      .set('authorization', `Bearer ${token}`);
+    expect(crossTenant.status).toBe(403);
 
     const byTenant = await request(app)
       .get('/api/v1/chats')

--- a/e2e/setup-and-serve-api.sh
+++ b/e2e/setup-and-serve-api.sh
@@ -13,28 +13,55 @@ ROOT_PASS="${DB_ROOT_PASS:-livechat_root_pass}"
 
 docker compose up -d mysql redis mailhog
 
-# Retry the provisioning statement itself rather than probing first and acting
-# after. On a fresh volume (CI) the entrypoint runs a temporary server during
-# init: it answers `mysqladmin ping`, and even a root `SELECT 1`, then shuts
-# down before the real server starts. So a probe that passes is no guarantee
-# the *next* command finds a live socket — that window is how this failed with
-# "ERROR 2002: Can't connect to local MySQL server through socket". Making the
-# idempotent CREATE/GRANT the readiness check closes it.
-echo "e2e: waiting for MySQL and provisioning ${DB_NAME}…"
-deadline=$(( SECONDS + 120 ))
-until docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
-  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
-   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;" >/dev/null 2>&1; do
+# On a fresh volume (CI) the entrypoint runs a *temporary* server during init.
+# It answers `mysqladmin ping`, a root `SELECT 1`, and even `CREATE DATABASE` —
+# then shuts down before the real server starts, killing any connection opened
+# in that window (`PROTOCOL_CONNECTION_LOST`). Retrying a single statement is
+# not sufficient, because the statement can succeed against the temporary
+# server; the init phase has to be observed to completion first. The image logs
+# "Temporary server started" on entry and "MySQL init process done" on exit, so
+# wait for the latter whenever the former appears. An existing volume logs
+# neither and falls straight through to the connectivity check.
+mysql_ready() {
+  local logs
+  logs=$(docker logs livechat-mysql 2>&1 || true)
+  if grep -q 'Temporary server started' <<<"$logs" \
+    && ! grep -q 'MySQL init process done' <<<"$logs"; then
+    return 1
+  fi
+  docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e 'SELECT 1' >/dev/null 2>&1
+}
+
+echo "e2e: waiting for MySQL…"
+deadline=$(( SECONDS + 180 ))
+until mysql_ready; do
   if [ "$SECONDS" -ge "$deadline" ]; then
-    echo "e2e: MySQL did not become ready within 120s" >&2
+    echo "e2e: MySQL did not become ready within 180s" >&2
     docker logs --tail 50 livechat-mysql >&2 || true
     exit 1
   fi
   sleep 1
 done
 
+echo "e2e: provisioning ${DB_NAME}…"
+docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
+  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
+   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"
+
+# Belt and braces: the seed drops every table and replays the migrations, so it
+# is safe to repeat, and a connection dropped mid-migration should not fail the
+# whole run.
 echo "e2e: seeding ${DB_NAME}…"
-node_modules/.bin/tsx e2e/support/seed.ts
+seed_attempt=1
+until node_modules/.bin/tsx e2e/support/seed.ts; do
+  if [ "$seed_attempt" -ge 3 ]; then
+    echo "e2e: seeding failed after ${seed_attempt} attempts" >&2
+    exit 1
+  fi
+  echo "e2e: seed attempt ${seed_attempt} failed; retrying…" >&2
+  seed_attempt=$(( seed_attempt + 1 ))
+  sleep 3
+done
 
 # Deterministic availability: start with no staff available so the journey
 # suite controls it via real agent sockets (reconnecting agents re-add


### PR DESCRIPTION
Closes #43.

The API enforced **role** but not **tenant**. A tenant-scoped `admin`/`staff` could read — and in places modify — another tenant's data over HTTP. The Socket.IO layer was already isolated, which is exactly why this went unnoticed: one layer tested, the adjacent one not (same shape as #37).

### `requireTenantAccess()` was worse than unwired
It was dead code **and** would not have helped if wired up — it returned early for `super_admin`/`admin`/`staff`, so it only ever constrained `client`. Removed rather than left as a guard-shaped no-op someone might later "fix" by calling it.

Replaced with three helpers that key on the caller's own `tenant_id`, not their role:

| Helper | Purpose |
|---|---|
| `callerTenantScope(req)` | the tenant a caller is confined to, or undefined |
| `assertTenantAccess(req, tenantId)` | 403 unless the caller may touch that tenant |
| `resolveTenantFilter(req, requested)` | pins a collection query to the caller's tenant |

### Applied
- **chats** — list, get, transcript, send message, accept, end
- **users** — list, get, patch
- **tenants** — list, get

By-id routes resolve the row *before* acting, because the owning tenant is a property of the record and can't be checked from params ahead of the lookup. That's why this isn't a single middleware.

### Semantics (follows the #19 decision)
`tenant_id = NULL` → AFixt staff, serves every tenant. `tenant_id` set → confined to it.

Listing is **pinned** to the caller's tenant, so omitting `?tenantId` can no longer widen results across tenants. Explicitly naming another tenant returns **403** rather than being silently rewritten — the caller is told, not quietly given a different answer.

### Tests
The two characterization tests that documented the insecure `200` now assert `403`, exactly as their comments anticipated. Added:
- write-path isolation — a refused `PATCH /users/:id` leaves the target **untouched** (verified by reload)
- list pinning + cross-tenant filter refusal for users, tenants, chats
- a positive test that **untenanted AFixt staff still span every tenant** (guards against over-correcting)

### Verified
`check:all` exits 0 — **197 api tests**, coverage 93.05 / 80.09 / 98.66 / 96.7 (all above threshold), lint + typecheck clean. **All 8 e2e journeys still pass**, which matters here: the tenanted agent must still work their own tenant's chats end-to-end, and does.

### Not addressed
`audit-service.record()` still has no call sites, so none of these denials are audit-logged. Worth a follow-up.