### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,54 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
 _Nothing yet._
 
+## [0.1.2] - 2026-07-23
+
+A security release. The REST API enforced role but not tenant, so a
+tenant-scoped operator could reach another tenant's data. Also makes the
+coverage gate real rather than decorative.
+
+### Security
+
+- **The REST API now enforces tenant isolation.** A tenant-scoped `admin` or
+  `staff` could read — and in places modify — another tenant's chats, users and
+  tenants over HTTP: list endpoints filtered on a caller-supplied
+  `?tenantId` (omitting it returned every tenant's rows), and by-id routes
+  never compared the record's tenant to the caller's.
+  `requireTenantAccess()` existed but was dead code, and would not have helped
+  if wired up — it returned early for `super_admin`/`admin`/`staff`, so it only
+  ever constrained `client`. Replaced with `callerTenantScope()`,
+  `assertTenantAccess()` and `resolveTenantFilter()`, keyed on the caller's own
+  `tenant_id` rather than their role, and applied across chats, users and
+  tenants. Lists are pinned to the caller's tenant; naming another tenant is a
+  403 rather than a silent rewrite. Untenanted AFixt staff still span every
+  tenant, per the issue #19 decision. ([#43], [#44])
+
+  The Socket.IO layer was already isolated, which is why this went unnoticed —
+  one layer was tested and the adjacent one was not, the same shape as the
+  migration drift fixed in 0.1.1.
+
+### Fixed
+
+- **The e2e stack no longer fails on a fresh MySQL volume.** The entrypoint's
+  temporary init server accepts `CREATE DATABASE`, so the readiness gate could
+  pass against it and the real server would then drop the seed's connection
+  mid-migration (`PROTOCOL_CONNECTION_LOST`). Setup now waits for the init
+  phase to complete before provisioning, and retries the seed. ([#44])
+
+### Changed
+
+- **Coverage thresholds are enforced.** `check:all` ran `test`, not
+  `test:coverage`, so the 80/75/80/80 thresholds in `api/vitest.config.ts` were
+  decorative and the project sat below its own bar. It now runs `test:ci`,
+  which runs the api suite once under coverage; plain `npm test` stays fast for
+  local work. Coverage went from 64.30/39.53/73.99/69.11 to
+  93.24/80.89/98.64/96.65, with the api suite growing from 22 to 191 tests
+  (197 including the isolation tests above). ([#42])
+
+[#42]: https://github.com/AFixt/livechat/pull/42
+[#43]: https://github.com/AFixt/livechat/issues/43
+[#44]: https://github.com/AFixt/livechat/pull/44
+
 ## [0.1.1] - 2026-07-22
 
 A correctness release. v0.1.0 shipped a database schema the ORM could not read
@@ -116,7 +164,8 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
   ships with Node 22, and effective on toolchain upgrade.
 - `body-parser` bumped to 2.3.0, clearing OSV `GHSA-v422-hmwv-36x6`.
 
-[Unreleased]: https://github.com/AFixt/livechat/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/AFixt/livechat/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/AFixt/livechat/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/AFixt/livechat/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/AFixt/livechat/releases/tag/v0.1.0
 [#1]: https://github.com/AFixt/livechat/issues/1

--- a/api/src/config/env.test.ts
+++ b/api/src/config/env.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const REQUIRED_ENV: Record<string, string> = {
+  DB_HOST: 'localhost',
+  DB_NAME: 'livechat',
+  DB_USER: 'livechat_user',
+  DB_PASS: 'livechat_pass',
+  REDIS_HOST: 'localhost',
+  JWT_ACCESS_SECRET: 'access-secret',
+  JWT_REFRESH_SECRET: 'refresh-secret',
+  COOKIE_SECRET: 'cookie-secret',
+  APP_URL: 'http://localhost:3000',
+  API_URL: 'http://localhost:3001',
+  WIDGET_URL: 'http://localhost:3002',
+  SMTP_HOST: 'localhost',
+  S3_ACCESS_KEY: 'access-key',
+  S3_SECRET_KEY: 'secret-key',
+  S3_BUCKET: 'bucket',
+};
+
+const REQUIRED_KEYS = Object.keys(REQUIRED_ENV);
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of REQUIRED_KEYS) savedEnv[key] = process.env[key];
+  savedEnv['NODE_ENV'] = process.env['NODE_ENV'];
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) Reflect.deleteProperty(process.env, key);
+    else process.env[key] = value;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('loadEnv', () => {
+  it('accepts a fully-populated, valid environment', async () => {
+    for (const [key, value] of Object.entries(REQUIRED_ENV)) process.env[key] = value;
+    process.env['NODE_ENV'] = 'test';
+
+    const { loadEnv } = await import('./env.js');
+    const env = loadEnv();
+
+    expect(env.DB_HOST).toBe('localhost');
+    expect(env.NODE_ENV).toBe('test');
+    // Defaulted values prove the schema actually ran rather than passing
+    // through untouched input.
+    expect(env.PORT).toBe(3000);
+    expect(env.DB_SSL).toBe(false);
+    expect(env.LOG_LEVEL).toBe('info');
+  });
+
+  it('exits the process (via the envalid default reporter) when required vars are missing', async () => {
+    for (const key of REQUIRED_KEYS) Reflect.deleteProperty(process.env, key);
+    process.env['NODE_ENV'] = 'test';
+
+    // envalid's default reporter binds `console.error` once, at module load
+    // (`var defaultLogger = console.error.bind(console)`), before this test
+    // gets a chance to spy on it — so only `process.exit` is observable here.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    const { loadEnv } = await import('./env.js');
+    loadEnv();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/api/src/config/logger.test.ts
+++ b/api/src/config/logger.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LoggerOptions } from 'pino';
+
+const { pinoMock } = vi.hoisted(() => ({
+  pinoMock: vi.fn((options: LoggerOptions) => ({ __options: options })),
+}));
+
+vi.mock('pino', () => ({
+  pino: (options: LoggerOptions) => pinoMock(options),
+}));
+
+describe('createLogger', () => {
+  it('sets the level from env.LOG_LEVEL', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'production', LOG_LEVEL: 'warn' });
+    expect(pinoMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ level: 'warn' }));
+  });
+
+  it('redacts sensitive fields and removes them entirely', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'test', LOG_LEVEL: 'error' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.redact).toEqual({
+      paths: [
+        'req.headers.authorization',
+        'req.headers.cookie',
+        'req.headers["x-xsrf-token"]',
+        'password',
+        'password_hash',
+        'token',
+        'refreshToken',
+        'accessToken',
+      ],
+      remove: true,
+    });
+  });
+
+  it('does not attach a pretty-print transport outside development', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'production', LOG_LEVEL: 'info' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.transport).toBeUndefined();
+  });
+
+  it('attaches the pino-pretty transport in development', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'development', LOG_LEVEL: 'debug' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.transport).toEqual({
+      target: 'pino-pretty',
+      options: { translateTime: 'HH:MM:ss.l', ignore: 'pid,hostname,env' },
+    });
+  });
+
+  it('carries NODE_ENV through as base.env', async () => {
+    const { createLogger } = await import('./logger.js');
+    pinoMock.mockClear();
+    createLogger({ NODE_ENV: 'test', LOG_LEVEL: 'info' });
+    const options = pinoMock.mock.calls[0]?.[0];
+    expect(options?.base).toEqual({ env: 'test' });
+  });
+});

--- a/api/src/config/mysql.test.ts
+++ b/api/src/config/mysql.test.ts
@@ -1,9 +1,10 @@
 import { pino } from 'pino';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createSequelize } from './mysql.js';
 
 import type { Env } from './env.js';
+import type { Logger } from 'pino';
 import type { Sequelize } from 'sequelize';
 
 const logger = pino({ level: 'silent' });
@@ -34,6 +35,39 @@ function sslOf(sequelize: Sequelize): Ssl | undefined {
   };
   return withOptions.options.dialectOptions?.ssl;
 }
+
+/**
+ * Read the resolved `logging` function off a built Sequelize instance, the
+ * same narrow-cast approach as {@link sslOf}.
+ * @param sequelize - The instance built by createSequelize.
+ * @returns The logging option, either `false` or a `(sql: string) => void`.
+ */
+function loggingOf(sequelize: Sequelize): false | ((sql: string) => void) {
+  const withOptions = sequelize as unknown as {
+    options: { logging: false | ((sql: string) => void) };
+  };
+  return withOptions.options.logging;
+}
+
+describe('createSequelize SQL logging', () => {
+  it('disables query logging outside development', () => {
+    const sequelize = createSequelize({ ...baseEnv, DB_SSL: false, DB_SSL_CA: '' }, logger);
+    expect(loggingOf(sequelize)).toBe(false);
+  });
+
+  it('logs each query at debug level in development', () => {
+    const debugSpy = vi.fn();
+    const devLogger = { debug: debugSpy } as unknown as Logger;
+    const sequelize = createSequelize(
+      { ...baseEnv, NODE_ENV: 'development', DB_SSL: false, DB_SSL_CA: '' },
+      devLogger,
+    );
+    const logging = loggingOf(sequelize);
+    expect(typeof logging).toBe('function');
+    if (typeof logging === 'function') logging('SELECT 1');
+    expect(debugSpy).toHaveBeenCalledExactlyOnceWith({ sql: 'SELECT 1' }, 'sql');
+  });
+});
 
 describe('createSequelize DB TLS', () => {
   it('omits ssl when DB_SSL is false (local docker-compose stays plaintext)', () => {

--- a/api/src/config/redis.test.ts
+++ b/api/src/config/redis.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'pino';
+
+interface CapturedRedisOptions {
+  host: string;
+  port: number;
+  lazyConnect: boolean;
+  maxRetriesPerRequest: number;
+  enableReadyCheck: boolean;
+}
+
+type ErrorHandler = (error: Error) => void;
+
+const { FakeRedis, constructed } = vi.hoisted(() => {
+  const instances: {
+    options: CapturedRedisOptions;
+    triggerError: (error: Error) => void;
+  }[] = [];
+
+  class FakeRedisImpl {
+    public readonly options: CapturedRedisOptions;
+    private errorHandler: ErrorHandler | undefined;
+
+    public constructor(options: CapturedRedisOptions) {
+      this.options = options;
+      instances.push(this);
+    }
+
+    public on(event: string, handler: ErrorHandler): this {
+      if (event === 'error') this.errorHandler = handler;
+      return this;
+    }
+
+    public triggerError(error: Error): void {
+      this.errorHandler?.(error);
+    }
+  }
+
+  return { FakeRedis: FakeRedisImpl, constructed: instances };
+});
+
+vi.mock('ioredis', () => ({ default: FakeRedis }));
+
+function fakeLogger(): Logger {
+  return { error: vi.fn() } as unknown as Logger;
+}
+
+describe('createRedis', () => {
+  beforeEach(() => {
+    constructed.length = 0;
+  });
+
+  it('builds a lazy-connect client from the given host and port', async () => {
+    const { createRedis } = await import('./redis.js');
+    const logger = fakeLogger();
+    createRedis({ REDIS_HOST: 'redis.internal', REDIS_PORT: 6380 }, logger);
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0]?.options).toEqual({
+      host: 'redis.internal',
+      port: 6380,
+      lazyConnect: true,
+      maxRetriesPerRequest: 3,
+      enableReadyCheck: true,
+    });
+  });
+
+  it('logs redis errors through the provided logger', async () => {
+    const { createRedis } = await import('./redis.js');
+    const logger = fakeLogger();
+    createRedis({ REDIS_HOST: 'localhost', REDIS_PORT: 6379 }, logger);
+    const instance = constructed[0];
+    expect(instance).toBeDefined();
+    const boom = new Error('connection refused');
+    instance?.triggerError(boom);
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith({ err: boom }, 'redis error');
+  });
+});

--- a/api/src/middlewares/authorize.test.ts
+++ b/api/src/middlewares/authorize.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from '../utils/api-error.js';
 
-import { requireRole, requireStaffOrAdmin, requireTenantAccess } from './authorize.js';
+import {
+  assertTenantAccess,
+  callerTenantScope,
+  requireRole,
+  requireStaffOrAdmin,
+  resolveTenantFilter,
+} from './authorize.js';
 
 import type { User } from '../models/index.js';
 import type { Request, Response } from 'express';
@@ -86,88 +92,90 @@ describe('requireStaffOrAdmin', () => {
   });
 });
 
-describe('requireTenantAccess', () => {
-  it('calls next with 401 when no user is authenticated', () => {
-    const next = vi.fn();
-    const req = fakeReq({});
-    requireTenantAccess()(req, res, next);
-    const err = next.mock.calls[0]?.[0] as ApiError;
-    expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(401);
+describe('callerTenantScope', () => {
+  it('returns undefined for an untenanted AFixt staff account', () => {
+    expect(callerTenantScope(fakeReq({ user: fakeUser('super_admin', null) }))).toBeUndefined();
   });
 
-  it.each(['super_admin', 'admin', 'staff'] as const)(
-    'lets %s through regardless of tenant mismatch',
-    (role) => {
-      const next = vi.fn();
-      const req = fakeReq({
-        user: fakeUser(role, 'tenant-a'),
-        params: { tenantId: 'tenant-b' },
-      });
-      requireTenantAccess()(req, res, next);
-      expect(next).toHaveBeenCalledExactlyOnceWith();
-    },
-  );
-
-  it('allows a client through when no tenantId is present anywhere on the request', () => {
-    const next = vi.fn();
-    const req = fakeReq({ user: fakeUser('client', 'tenant-a') });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('returns undefined when nobody is authenticated', () => {
+    expect(callerTenantScope(fakeReq({}))).toBeUndefined();
   });
 
-  it('allows a client whose params.tenantId matches their own tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      params: { tenantId: 'tenant-a' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('returns the tenant a scoped caller is confined to', () => {
+    expect(callerTenantScope(fakeReq({ user: fakeUser('admin', 'tenant-a') }))).toBe('tenant-a');
+  });
+});
+
+describe('assertTenantAccess', () => {
+  it('permits an untenanted caller to touch any tenant', () => {
+    const req = fakeReq({ user: fakeUser('super_admin', null) });
+    expect(() => {
+      assertTenantAccess(req, 'tenant-b');
+    }).not.toThrow();
   });
 
-  it('allows a client whose body.tenantId matches their own tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      body: { tenantId: 'tenant-a' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('permits a scoped caller to touch their own tenant', () => {
+    const req = fakeReq({ user: fakeUser('staff', 'tenant-a') });
+    expect(() => {
+      assertTenantAccess(req, 'tenant-a');
+    }).not.toThrow();
   });
 
-  it('allows a client whose query.tenantId matches their own tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      query: { tenantId: 'tenant-a' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('rejects a scoped caller touching another tenant', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(() => {
+      assertTenantAccess(req, 'tenant-b');
+    }).toThrow(ApiError);
   });
 
-  it('prefers params.tenantId over body/query when present', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      params: { tenantId: 'tenant-a' },
-      body: { tenantId: 'tenant-b' },
-      query: { tenantId: 'tenant-c' },
-    });
-    requireTenantAccess()(req, res, next);
-    expect(next).toHaveBeenCalledExactlyOnceWith();
+  it('rejects a scoped caller when the resource has no tenant at all', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    let thrown: unknown;
+    try {
+      assertTenantAccess(req, null);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(403);
+  });
+});
+
+describe('resolveTenantFilter', () => {
+  it('lets an untenanted caller ask for any single tenant', () => {
+    const req = fakeReq({ user: fakeUser('super_admin', null) });
+    expect(resolveTenantFilter(req, 'tenant-b')).toBe('tenant-b');
   });
 
-  it('calls next with 403 when the resolved tenantId does not match the user tenant', () => {
-    const next = vi.fn();
-    const req = fakeReq({
-      user: fakeUser('client', 'tenant-a'),
-      params: { tenantId: 'tenant-b' },
-    });
-    requireTenantAccess()(req, res, next);
-    const err = next.mock.calls[0]?.[0] as ApiError;
-    expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(403);
-    expect(err.message).toBe('Access denied to this tenant');
+  it('lets an untenanted caller ask for every tenant', () => {
+    const req = fakeReq({ user: fakeUser('super_admin', null) });
+    expect(resolveTenantFilter(req, undefined)).toBeUndefined();
+  });
+
+  it('pins a scoped caller to their own tenant when they ask for nothing', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(resolveTenantFilter(req, undefined)).toBe('tenant-a');
+  });
+
+  it('pins a scoped caller to their own tenant when they ask for it explicitly', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(resolveTenantFilter(req, 'tenant-a')).toBe('tenant-a');
+  });
+
+  it('ignores a non-string filter and still pins a scoped caller', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    expect(resolveTenantFilter(req, 42)).toBe('tenant-a');
+  });
+
+  it('rejects a scoped caller explicitly asking for another tenant', () => {
+    const req = fakeReq({ user: fakeUser('admin', 'tenant-a') });
+    let thrown: unknown;
+    try {
+      resolveTenantFilter(req, 'tenant-b');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(403);
   });
 });

--- a/api/src/middlewares/authorize.test.ts
+++ b/api/src/middlewares/authorize.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { requireRole, requireStaffOrAdmin, requireTenantAccess } from './authorize.js';
+
+import type { User } from '../models/index.js';
+import type { Request, Response } from 'express';
+
+/**
+ * Build a minimal fake User for a given role/tenant, cast to the real type so
+ * call sites see the shape they expect without standing up Sequelize.
+ * @param role - Role to assign.
+ * @param tenantId - Tenant id, or null for tenantless accounts.
+ * @returns A fake User.
+ */
+function fakeUser(role: User['role'], tenantId: string | null = null): User {
+  return { role, tenantId } as unknown as User;
+}
+
+/**
+ * Build a fake Express Request carrying only what these middlewares read.
+ * @param overrides - Partial fields to set on the request.
+ * @returns A fake Request.
+ */
+function fakeReq(overrides: {
+  user?: User;
+  params?: Record<string, unknown>;
+  body?: unknown;
+  query?: Record<string, unknown>;
+}): Request {
+  return {
+    user: overrides.user,
+    params: overrides.params ?? {},
+    body: overrides.body ?? {},
+    query: overrides.query ?? {},
+  } as unknown as Request;
+}
+
+const res = {} as Response;
+
+describe('requireRole', () => {
+  it('calls next with 401 when no user is authenticated', () => {
+    const next = vi.fn();
+    const req = fakeReq({});
+    requireRole('admin')(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+  });
+
+  it('calls next with 403 when the user role is not in the allowed list', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('client') });
+    requireRole('admin', 'staff')(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Insufficient permissions');
+  });
+
+  it('calls next with no argument when the user role is allowed', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('admin') });
+    requireRole('admin', 'staff')(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+});
+
+describe('requireStaffOrAdmin', () => {
+  it.each(['super_admin', 'admin', 'staff'] as const)('allows role %s through', (role) => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser(role) });
+    requireStaffOrAdmin()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('rejects a client', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('client') });
+    requireStaffOrAdmin()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.status).toBe(403);
+  });
+});
+
+describe('requireTenantAccess', () => {
+  it('calls next with 401 when no user is authenticated', () => {
+    const next = vi.fn();
+    const req = fakeReq({});
+    requireTenantAccess()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+  });
+
+  it.each(['super_admin', 'admin', 'staff'] as const)(
+    'lets %s through regardless of tenant mismatch',
+    (role) => {
+      const next = vi.fn();
+      const req = fakeReq({
+        user: fakeUser(role, 'tenant-a'),
+        params: { tenantId: 'tenant-b' },
+      });
+      requireTenantAccess()(req, res, next);
+      expect(next).toHaveBeenCalledExactlyOnceWith();
+    },
+  );
+
+  it('allows a client through when no tenantId is present anywhere on the request', () => {
+    const next = vi.fn();
+    const req = fakeReq({ user: fakeUser('client', 'tenant-a') });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('allows a client whose params.tenantId matches their own tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      params: { tenantId: 'tenant-a' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('allows a client whose body.tenantId matches their own tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      body: { tenantId: 'tenant-a' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('allows a client whose query.tenantId matches their own tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      query: { tenantId: 'tenant-a' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('prefers params.tenantId over body/query when present', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      params: { tenantId: 'tenant-a' },
+      body: { tenantId: 'tenant-b' },
+      query: { tenantId: 'tenant-c' },
+    });
+    requireTenantAccess()(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('calls next with 403 when the resolved tenantId does not match the user tenant', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      user: fakeUser('client', 'tenant-a'),
+      params: { tenantId: 'tenant-b' },
+    });
+    requireTenantAccess()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Access denied to this tenant');
+  });
+});

--- a/api/src/middlewares/authorize.ts
+++ b/api/src/middlewares/authorize.ts
@@ -1,7 +1,7 @@
 import { ApiError } from '../utils/api-error.js';
 
 import type { Role } from '@livechat/shared';
-import type { RequestHandler } from 'express';
+import type { Request, RequestHandler } from 'express';
 
 /**
  * Require the authenticated user to hold one of the listed roles.
@@ -31,28 +31,56 @@ export function requireStaffOrAdmin(): RequestHandler {
 }
 
 /**
- * Restrict access to a resource by tenant: super_admin/admin/staff may touch
- * any tenant; clients may only touch their own.
- * @returns Express middleware that reads a tenantId from params/body/query.
+ * The tenant a caller is confined to, or `undefined` when unrestricted.
+ *
+ * Mirrors the identity model: AFixt staff carry no tenant of their own
+ * (`tenant_id` is null) and serve every tenant, matching how untenanted staff
+ * watch all tenants over Socket.IO. Anyone carrying a `tenant_id` — a
+ * tenant-scoped admin, staff member, or client — is confined to it.
+ * @param req - The authenticated request.
+ * @returns The tenant id the caller is limited to, or undefined for none.
  */
-export function requireTenantAccess(): RequestHandler {
-  return (req, _res, next) => {
-    if (req.user === undefined) {
-      next(ApiError.unauthorized());
-      return;
-    }
-    if (['super_admin', 'admin', 'staff'].includes(req.user.role)) {
-      next();
-      return;
-    }
-    const tenantId =
-      (req.params.tenantId as string | undefined) ??
-      ((req.body as Record<string, unknown>).tenantId as string | undefined) ??
-      (req.query.tenantId as string | undefined);
-    if (tenantId !== undefined && req.user.tenantId !== tenantId) {
-      next(ApiError.forbidden('Access denied to this tenant'));
-      return;
-    }
-    next();
-  };
+export function callerTenantScope(req: Request): string | undefined {
+  return req.user?.tenantId ?? undefined;
+}
+
+/**
+ * Reject the request unless the caller may act on `tenantId`.
+ *
+ * Resource-level rather than request-level on purpose: for routes addressed by
+ * resource id (`/chats/:id`, `/users/:id`) the owning tenant is a property of
+ * the fetched row, so it cannot be checked from params/body/query before the
+ * lookup happens.
+ * @param req - The authenticated request.
+ * @param tenantId - The owning tenant of the resource being touched.
+ * @throws {ApiError} 403 when the caller is scoped to a different tenant.
+ */
+export function assertTenantAccess(req: Request, tenantId: string | null): void {
+  const scope = callerTenantScope(req);
+  if (scope === undefined) return;
+  if (tenantId !== scope) {
+    throw ApiError.forbidden('Access denied to this tenant');
+  }
+}
+
+/**
+ * Resolve the tenant filter for a collection endpoint.
+ *
+ * A scoped caller is pinned to their own tenant regardless of what they ask
+ * for, so omitting `?tenantId` can never widen the result set across tenants.
+ * Explicitly requesting a different tenant is a 403 rather than a silent
+ * override, so the caller is told rather than quietly given the wrong answer.
+ * @param req - The authenticated request.
+ * @param requested - The caller-supplied tenant filter, if any.
+ * @returns The tenant id to filter by, or undefined for all tenants.
+ * @throws {ApiError} 403 when a scoped caller requests another tenant.
+ */
+export function resolveTenantFilter(req: Request, requested: unknown): string | undefined {
+  const asked = typeof requested === 'string' ? requested : undefined;
+  const scope = callerTenantScope(req);
+  if (scope === undefined) return asked;
+  if (asked !== undefined && asked !== scope) {
+    throw ApiError.forbidden('Access denied to this tenant');
+  }
+  return scope;
 }

--- a/api/src/middlewares/error-handler.test.ts
+++ b/api/src/middlewares/error-handler.test.ts
@@ -1,0 +1,121 @@
+import { pino } from 'pino';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { errorHandler } from './error-handler.js';
+
+import type { Request, Response } from 'express';
+import type { Logger } from 'pino';
+import type { ZodError } from 'zod';
+
+/**
+ * A logger that records `error` calls instead of writing them.
+ * @returns The stub logger and the recorded calls.
+ */
+function stubLogger(): { logger: Logger; errors: { err: unknown; msg: string }[] } {
+  const errors: { err: unknown; msg: string }[] = [];
+  const base = pino({ level: 'silent' });
+  const logger = Object.create(base) as Logger;
+  logger.error = ((obj: { err: unknown }, msg: string) => {
+    errors.push({ err: obj.err, msg });
+  }) as Logger['error'];
+  return { logger, errors };
+}
+
+/**
+ * Build a fake response that records `status` and `json` calls.
+ * @returns The fake response plus the captured status/body.
+ */
+function fakeRes(): { res: Response; captured: { status?: number; body?: unknown } } {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status: vi.fn((code: number) => {
+      captured.status = code;
+      return res;
+    }),
+    json: vi.fn((body: unknown) => {
+      captured.body = body;
+      return res;
+    }),
+  } as unknown as Response;
+  return { res, captured };
+}
+
+const req = { correlationId: 'corr-1', path: '/api/v1/thing' } as unknown as Request;
+
+describe('errorHandler', () => {
+  it('serializes an ApiError with its own status and message', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)(ApiError.forbidden('nope'), req, res, next);
+    expect(captured.status).toBe(403);
+    expect(captured.body).toEqual({ success: false, message: 'nope' });
+    expect(errors).toEqual([]);
+  });
+
+  it('includes details on the payload when the ApiError carries them', () => {
+    const { logger } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)(ApiError.badRequest('bad', { field: 'name' }), req, res, next);
+    expect(captured.status).toBe(400);
+    expect(captured.body).toEqual({
+      success: false,
+      message: 'bad',
+      details: { field: 'name' },
+    });
+  });
+
+  it('omits details when the ApiError has none', () => {
+    const { logger } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)(ApiError.notFound(), req, res, next);
+    expect(captured.body).toEqual({ success: false, message: 'Not found' });
+    expect(captured.body).not.toHaveProperty('details');
+  });
+
+  it('serializes a bare ZodError as a 400 validation failure', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    const schema = z.object({ name: z.string() });
+    const zodError = schema.safeParse({ name: 42 }).error as ZodError;
+    errorHandler(logger)(zodError, req, res, next);
+    expect(captured.status).toBe(400);
+    expect(captured.body).toEqual({
+      success: false,
+      message: 'Validation failed',
+      details: zodError.issues,
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('logs and returns a generic 500 for an unrecognized Error', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    const boom = new Error('kaboom');
+    errorHandler(logger)(boom, req, res, next);
+    expect(captured.status).toBe(500);
+    expect(captured.body).toEqual({ success: false, message: 'Internal server error' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.err).toBe(boom);
+    expect(errors[0]?.msg).toBe('unhandled error');
+  });
+
+  it('logs and returns a generic 500 for a non-Error throw', () => {
+    const { logger, errors } = stubLogger();
+    const { res, captured } = fakeRes();
+    const next = vi.fn();
+    errorHandler(logger)('a string was thrown', req, res, next);
+    expect(captured.status).toBe(500);
+    expect(captured.body).toEqual({ success: false, message: 'Internal server error' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.err).toBe('a string was thrown');
+    expect(errors[0]?.msg).toBe('unhandled non-error throw');
+  });
+});

--- a/api/src/middlewares/not-found-handler.test.ts
+++ b/api/src/middlewares/not-found-handler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { notFoundHandler } from './not-found-handler.js';
+
+import type { Request, Response } from 'express';
+
+describe('notFoundHandler', () => {
+  it('calls next with a 404 ApiError describing the missing route', () => {
+    const next = vi.fn();
+    const req = { method: 'GET', path: '/api/v1/nope' } as unknown as Request;
+    const res = {} as Response;
+    notFoundHandler()(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Route not found: GET /api/v1/nope');
+  });
+
+  it('reflects the actual method and path for a different route', () => {
+    const next = vi.fn();
+    const req = { method: 'POST', path: '/widgets' } as unknown as Request;
+    const res = {} as Response;
+    notFoundHandler()(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.message).toBe('Route not found: POST /widgets');
+  });
+});

--- a/api/src/middlewares/origin-allowed.test.ts
+++ b/api/src/middlewares/origin-allowed.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Tenant } from '../models/index.js';
+import { ApiError } from '../utils/api-error.js';
+
+import { originAllowed } from './origin-allowed.js';
+
+import type { Request, Response } from 'express';
+
+/**
+ * Build a fake Express Request with a header lookup, query, and body.
+ * @param overrides - Partial fields to set on the request.
+ * @returns A fake Request.
+ */
+function fakeReq(overrides: {
+  origin?: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+}): Request {
+  return {
+    header: (name: string) => (name === 'origin' ? overrides.origin : undefined),
+    query: overrides.query ?? {},
+    body: overrides.body,
+  } as unknown as Request;
+}
+
+const res = {} as Response;
+
+/** Wait for the microtask queue to flush so the async IIFE inside the middleware settles. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('originAllowed', () => {
+  it('lets the request through when there is no Origin header', async () => {
+    const findOne = vi.spyOn(Tenant, 'findOne');
+    const next = vi.fn();
+    const req = fakeReq({});
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('lets the request through when the tenant key cannot be resolved', async () => {
+    const findOne = vi.spyOn(Tenant, 'findOne');
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com' });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('resolves the tenant key from the query string', async () => {
+    const findOne = vi
+      .spyOn(Tenant, 'findOne')
+      .mockResolvedValue({ allowedOrigins: [] } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(findOne).toHaveBeenCalledExactlyOnceWith({
+      where: { slug: 'acme' },
+      attributes: ['id', 'allowedOrigins'],
+    });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('resolves the tenant key from the body when absent from the query', async () => {
+    const findOne = vi
+      .spyOn(Tenant, 'findOne')
+      .mockResolvedValue({ allowedOrigins: [] } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', body: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(findOne).toHaveBeenCalledExactlyOnceWith({
+      where: { slug: 'acme' },
+      attributes: ['id', 'allowedOrigins'],
+    });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when the tenant cannot be found', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue(null);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'ghost' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when allowedOrigins is null (no restriction)', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({ allowedOrigins: null } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when allowedOrigins is an empty array', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({ allowedOrigins: [] } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('lets the request through when the origin is in the allowed list', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({
+      allowedOrigins: ['https://example.com', 'https://other.com'],
+    } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('calls next with a 403 ApiError when the origin is not in the allowed list', async () => {
+    vi.spyOn(Tenant, 'findOne').mockResolvedValue({
+      allowedOrigins: ['https://other.com'],
+    } as unknown as Tenant);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Origin not allowed for this tenant');
+  });
+
+  it('calls next with the rejection reason when the tenant lookup throws', async () => {
+    const boom = new Error('db unreachable');
+    vi.spyOn(Tenant, 'findOne').mockRejectedValue(boom);
+    const next = vi.fn();
+    const req = fakeReq({ origin: 'https://example.com', query: { tenantKey: 'acme' } });
+    originAllowed()(req, res, next);
+    await flush();
+    expect(next).toHaveBeenCalledExactlyOnceWith(boom);
+  });
+});

--- a/api/src/middlewares/rate-limit.test.ts
+++ b/api/src/middlewares/rate-limit.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RequestHandler } from 'express';
+import type { Redis } from 'ioredis';
+
+/**
+ * Options captured from the real `rateLimit()` call so tests can assert on
+ * them without pulling in express or a live Redis connection.
+ */
+interface CapturedRateLimitOptions {
+  windowMs: number;
+  limit: number;
+  standardHeaders: string;
+  legacyHeaders: boolean;
+  store: unknown;
+}
+
+const noopHandler: RequestHandler = (_req, _res, next) => {
+  next();
+};
+
+const rateLimitMock = vi.fn((_options: CapturedRateLimitOptions): RequestHandler => noopHandler);
+
+/**
+ * Options captured from the real `RedisStore` constructor.
+ */
+interface CapturedStoreOptions {
+  sendCommand: (command: string, ...args: (string | number | Buffer)[]) => Promise<unknown>;
+  prefix: string;
+}
+
+let lastStoreOptions: CapturedStoreOptions | undefined;
+
+class FakeRedisStore {
+  public readonly options: CapturedStoreOptions;
+
+  public constructor(options: CapturedStoreOptions) {
+    this.options = options;
+    lastStoreOptions = options;
+  }
+}
+
+vi.mock('express-rate-limit', () => ({
+  rateLimit: (options: CapturedRateLimitOptions): RequestHandler => rateLimitMock(options),
+}));
+
+vi.mock('rate-limit-redis', () => ({
+  RedisStore: FakeRedisStore,
+}));
+
+const { createAuthLimiter, createGlobalLimiter, createRateLimiter } = await import(
+  './rate-limit.js'
+);
+
+/**
+ * Build a fake ioredis client that just records `call` invocations.
+ * @returns The fake client and the list of recorded calls.
+ */
+function fakeRedis(): { redis: Redis; calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  const redis = {
+    call: (...args: unknown[]) => {
+      calls.push(args);
+      return Promise.resolve('OK');
+    },
+  } as unknown as Redis;
+  return { redis, calls };
+}
+
+describe('createRateLimiter', () => {
+  it('builds a rate limiter with the given window, max, and Redis-backed store', () => {
+    rateLimitMock.mockClear();
+    const { redis } = fakeRedis();
+    createRateLimiter({ redis, windowMs: 1000, max: 10, prefix: 'rl:test:' });
+    expect(rateLimitMock).toHaveBeenCalledTimes(1);
+    const options = rateLimitMock.mock.calls[0]?.[0];
+    expect(options?.windowMs).toBe(1000);
+    expect(options?.limit).toBe(10);
+    expect(options?.standardHeaders).toBe('draft-7');
+    expect(options?.legacyHeaders).toBe(false);
+    expect(options?.store).toBeInstanceOf(FakeRedisStore);
+  });
+
+  it('wires the store prefix through to RedisStore', () => {
+    const { redis } = fakeRedis();
+    createRateLimiter({ redis, windowMs: 1000, max: 10, prefix: 'rl:custom:' });
+    expect(lastStoreOptions?.prefix).toBe('rl:custom:');
+  });
+
+  it('forwards sendCommand calls to redis.call with the command and args', async () => {
+    const { redis, calls } = fakeRedis();
+    createRateLimiter({ redis, windowMs: 1000, max: 10, prefix: 'rl:test:' });
+    await lastStoreOptions?.sendCommand('EVALSHA', 'abc123', 1, 'key');
+    expect(calls).toEqual([['EVALSHA', 'abc123', 1, 'key']]);
+  });
+});
+
+describe('createGlobalLimiter', () => {
+  it('configures a 300-per-15-minutes limiter under the rl:global: prefix', () => {
+    rateLimitMock.mockClear();
+    const { redis } = fakeRedis();
+    createGlobalLimiter(redis);
+    const options = rateLimitMock.mock.calls[0]?.[0];
+    expect(options?.windowMs).toBe(15 * 60 * 1000);
+    expect(options?.limit).toBe(300);
+    expect(lastStoreOptions?.prefix).toBe('rl:global:');
+  });
+});
+
+describe('createAuthLimiter', () => {
+  it('configures a 5-per-15-minutes limiter under the rl:auth: prefix', () => {
+    rateLimitMock.mockClear();
+    const { redis } = fakeRedis();
+    createAuthLimiter(redis);
+    const options = rateLimitMock.mock.calls[0]?.[0];
+    expect(options?.windowMs).toBe(15 * 60 * 1000);
+    expect(options?.limit).toBe(5);
+    expect(lastStoreOptions?.prefix).toBe('rl:auth:');
+  });
+});

--- a/api/src/middlewares/validate.test.ts
+++ b/api/src/middlewares/validate.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { ApiError } from '../utils/api-error.js';
+
+import { parsedBody, validate } from './validate.js';
+
+import type { Request, Response } from 'express';
+
+/**
+ * Build a fake Express Request carrying only body/query/params.
+ * @param overrides - Partial fields to set on the request.
+ * @returns A fake Request.
+ */
+function fakeReq(overrides: {
+  body?: unknown;
+  query?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+}): Request {
+  return {
+    body: overrides.body ?? {},
+    query: overrides.query ?? {},
+    params: overrides.params ?? {},
+  } as unknown as Request;
+}
+
+const res = {} as Response;
+
+describe('validate', () => {
+  it('parses and replaces req.body when a body schema is given', () => {
+    const next = vi.fn();
+    const schema = z.object({ name: z.string() });
+    const req = fakeReq({ body: { name: 'ada' } });
+    validate({ body: schema })(req, res, next);
+    expect(req.body).toEqual({ name: 'ada' });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('parses and merges req.query when a query schema is given', () => {
+    const next = vi.fn();
+    const schema = z.object({ page: z.coerce.number() });
+    const req = fakeReq({ query: { page: '2' } });
+    validate({ query: schema })(req, res, next);
+    expect(req.query).toEqual({ page: 2 });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('parses and merges req.params when a params schema is given', () => {
+    const next = vi.fn();
+    const schema = z.object({ id: z.uuid() });
+    const id = '123e4567-e89b-12d3-a456-426614174000';
+    const req = fakeReq({ params: { id } });
+    validate({ params: schema })(req, res, next);
+    expect(req.params).toEqual({ id });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('applies body, query, and params schemas together', () => {
+    const next = vi.fn();
+    const req = fakeReq({
+      body: { name: 'ada' },
+      query: { page: '1' },
+      params: { id: 'abc' },
+    });
+    validate({
+      body: z.object({ name: z.string() }),
+      query: z.object({ page: z.coerce.number() }),
+      params: z.object({ id: z.string() }),
+    })(req, res, next);
+    expect(req.body).toEqual({ name: 'ada' });
+    expect(req.query).toEqual({ page: 1 });
+    expect(req.params).toEqual({ id: 'abc' });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('skips validation entirely when no schemas are given', () => {
+    const next = vi.fn();
+    const req = fakeReq({ body: { anything: true } });
+    validate({})(req, res, next);
+    expect(req.body).toEqual({ anything: true });
+    expect(next).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('calls next with a 400 ApiError carrying Zod issues when body fails validation', () => {
+    const next = vi.fn();
+    const schema = z.object({ name: z.string() });
+    const req = fakeReq({ body: { name: 42 } });
+    validate({ body: schema })(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('Validation failed');
+    expect(Array.isArray(err.details)).toBe(true);
+  });
+
+  it('calls next with a 400 ApiError when query fails validation', () => {
+    const next = vi.fn();
+    const schema = z.object({ page: z.coerce.number() });
+    const req = fakeReq({ query: { page: 'not-a-number' } });
+    validate({ query: schema })(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.status).toBe(400);
+  });
+
+  it('calls next with a 400 ApiError when params fails validation', () => {
+    const next = vi.fn();
+    const schema = z.object({ id: z.uuid() });
+    const req = fakeReq({ params: { id: 'not-a-uuid' } });
+    validate({ params: schema })(req, res, next);
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.status).toBe(400);
+  });
+
+  it('propagates a non-Zod error thrown by a schema untouched', () => {
+    const next = vi.fn();
+    const boom = new Error('schema exploded');
+    const schema = {
+      parse: () => {
+        throw boom;
+      },
+    } as unknown as z.ZodType;
+    const req = fakeReq({ body: {} });
+    validate({ body: schema })(req, res, next);
+    expect(next).toHaveBeenCalledExactlyOnceWith(boom);
+  });
+});
+
+describe('parsedBody', () => {
+  it('returns req.body typed to the schema without re-parsing', () => {
+    const schema = z.object({ name: z.string() });
+    const req = { body: { name: 'ada' } };
+    expect(parsedBody(req, schema)).toEqual({ name: 'ada' });
+  });
+});

--- a/api/src/routes/chats.ts
+++ b/api/src/routes/chats.ts
@@ -9,7 +9,11 @@ import {
 import { Router } from 'express';
 
 import { authenticate } from '../middlewares/authenticate.js';
-import { requireStaffOrAdmin } from '../middlewares/authorize.js';
+import {
+  assertTenantAccess,
+  requireStaffOrAdmin,
+  resolveTenantFilter,
+} from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
 
@@ -47,10 +51,10 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
   router.get(
     '/',
     asyncHandler(async (req, res) => {
-      const tenantId = req.query.tenantId;
+      const tenantId = resolveTenantFilter(req, req.query.tenantId);
       const status = parseStatusQuery(req.query.status);
       const filter: Parameters<ChatService['list']>[0] = {};
-      if (typeof tenantId === 'string') filter.tenantId = tenantId;
+      if (tenantId !== undefined) filter.tenantId = tenantId;
       if (status !== undefined) filter.status = status;
       const chats = await deps.chat.list(filter);
       res.json({ success: true, data: chats });
@@ -63,6 +67,7 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const chat = await deps.chat.getById(id);
+      assertTenantAccess(req, chat.tenantId);
       res.json({ success: true, data: chat });
     }),
   );
@@ -72,6 +77,9 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string') return;
+      // Resolve the chat first so its owning tenant can gate the transcript.
+      const chat = await deps.chat.getById(id);
+      assertTenantAccess(req, chat.tenantId);
       const messages = await deps.chat.listMessages(id);
       res.json({ success: true, data: messages });
     }),
@@ -83,6 +91,8 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string' || req.user === undefined) return;
+      const target = await deps.chat.getById(id);
+      assertTenantAccess(req, target.tenantId);
       const body = parsedBody(req, sendMessageInputSchema) satisfies SendMessageInput;
       const message = await deps.chat.sendMessage({
         chatId: id,
@@ -99,6 +109,8 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string' || req.user === undefined) return;
+      const target = await deps.chat.getById(id);
+      assertTenantAccess(req, target.tenantId);
       const chat = await deps.chat.assign(id, req.user.id);
       res.json({ success: true, data: chat });
     }),
@@ -110,6 +122,8 @@ export function buildChatsRouter(deps: ChatsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string') return;
+      const target = await deps.chat.getById(id);
+      assertTenantAccess(req, target.tenantId);
       const body = parsedBody(req, endChatInputSchema) satisfies EndChatInput;
       const chat = await deps.chat.endChat({ chatId: id, endedBy: body.endedBy });
       res.json({ success: true, data: chat });

--- a/api/src/routes/tenants.ts
+++ b/api/src/routes/tenants.ts
@@ -5,7 +5,7 @@ import {
   type UpdateTenantInput,
 } from '@livechat/shared';
 
-import { requireRole } from '../middlewares/authorize.js';
+import { assertTenantAccess, callerTenantScope, requireRole } from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
 
@@ -29,9 +29,12 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
 
   router.get(
     '/',
-    asyncHandler(async (_req, res) => {
+    asyncHandler(async (req, res) => {
       const tenants = await deps.tenant.list();
-      res.json({ success: true, data: tenants });
+      // A tenant-scoped admin sees only their own tenant in the list.
+      const scope = callerTenantScope(req);
+      const visible = scope === undefined ? tenants : tenants.filter((t) => t.id === scope);
+      res.json({ success: true, data: visible });
     }),
   );
 
@@ -52,6 +55,7 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const tenant = await deps.tenant.getById(id);
+      assertTenantAccess(req, tenant.id);
       res.json({ success: true, data: tenant });
     }),
   );

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { updateUserInputSchema, type UpdateUserInput } from '@livechat/shared';
 
+import { assertTenantAccess, resolveTenantFilter } from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
 
@@ -24,8 +25,7 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
   router.get(
     '/',
     asyncHandler(async (req, res) => {
-      const tenantId = req.query.tenantId;
-      const users = await deps.user.list(typeof tenantId === 'string' ? tenantId : undefined);
+      const users = await deps.user.list(resolveTenantFilter(req, req.query.tenantId));
       res.json({ success: true, data: users });
     }),
   );
@@ -36,6 +36,7 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const user = await deps.user.getById(id);
+      assertTenantAccess(req, user.tenantId);
       res.json({ success: true, data: user });
     }),
   );
@@ -46,6 +47,10 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const id = req.params.id;
       if (typeof id !== 'string') return;
+      // Check the existing row's tenant before mutating it, so a scoped caller
+      // cannot edit — or re-tenant — someone else's user.
+      const existing = await deps.user.getById(id);
+      assertTenantAccess(req, existing.tenantId);
       const body = parsedBody(req, updateUserInputSchema) satisfies UpdateUserInput;
       const user = await deps.user.update(id, body);
       res.json({ success: true, data: user });

--- a/api/src/services/invitation-service.test.ts
+++ b/api/src/services/invitation-service.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Invitation, Tenant } from '../models/index.js';
+import { ApiError } from '../utils/api-error.js';
+
+import { createInvitationService } from './invitation-service.js';
+
+import type { EmailService } from './email-service.js';
+import type { CreateInvitationInput } from '@livechat/shared';
+
+function fakeEmail(): EmailService {
+  return {
+    sendInvitationEmail: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EmailService;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('invitation-service', () => {
+  describe('create', () => {
+    it('creates a tenant-scoped invitation and emails the recipient', async () => {
+      vi.spyOn(Tenant, 'findByPk').mockResolvedValue({ id: 'tenant-1' } as Tenant);
+      const created = { id: 'inv-1' } as Invitation;
+      const createSpy = vi.spyOn(Invitation, 'create').mockResolvedValue(created);
+      const email = fakeEmail();
+      const service = createInvitationService({ email });
+
+      const input: CreateInvitationInput = {
+        tenantId: 'tenant-1',
+        email: 'new@example.com',
+        name: 'New Person',
+        role: 'staff',
+        expiresInDays: 7,
+      };
+      const result = await service.create(input, 'inviter-1');
+
+      expect(result).toBe(created);
+      expect(createSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          tenantId: 'tenant-1',
+          email: 'new@example.com',
+          name: 'New Person',
+          role: 'staff',
+          invitedBy: 'inviter-1',
+        }),
+      );
+      expect(email.sendInvitationEmail).toHaveBeenCalledExactlyOnceWith(
+        'new@example.com',
+        'New Person',
+        expect.any(String),
+      );
+    });
+
+    it('creates an untenanted invitation without checking the tenant', async () => {
+      const findByPk = vi.spyOn(Tenant, 'findByPk');
+      const created = { id: 'inv-2' } as Invitation;
+      vi.spyOn(Invitation, 'create').mockResolvedValue(created);
+      const email = fakeEmail();
+      const service = createInvitationService({ email });
+
+      const input: CreateInvitationInput = {
+        tenantId: null,
+        email: 'global@example.com',
+        role: 'staff',
+        expiresInDays: 3,
+      };
+      const result = await service.create(input, 'inviter-1');
+
+      expect(result).toBe(created);
+      expect(findByPk).not.toHaveBeenCalled();
+      expect(email.sendInvitationEmail).toHaveBeenCalledExactlyOnceWith(
+        'global@example.com',
+        null,
+        expect.any(String),
+      );
+    });
+
+    it('throws 400 when the given tenantId does not exist', async () => {
+      vi.spyOn(Tenant, 'findByPk').mockResolvedValue(null);
+      const createSpy = vi.spyOn(Invitation, 'create');
+      const email = fakeEmail();
+      const service = createInvitationService({ email });
+
+      const input: CreateInvitationInput = {
+        tenantId: 'ghost-tenant',
+        email: 'x@example.com',
+        role: 'staff',
+        expiresInDays: 7,
+      };
+
+      await expect(service.create(input, 'inviter-1')).rejects.toMatchObject({
+        status: 400,
+        message: 'Tenant not found',
+      });
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(email.sendInvitationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('list', () => {
+    it('lists all invitations when no tenant filter is given', async () => {
+      const findAll = vi.spyOn(Invitation, 'findAll').mockResolvedValue([]);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await service.list();
+
+      expect(findAll).toHaveBeenCalledExactlyOnceWith({
+        where: {},
+        order: [['createdAt', 'DESC']],
+      });
+    });
+
+    it('filters by tenant when a tenantId is given', async () => {
+      const findAll = vi.spyOn(Invitation, 'findAll').mockResolvedValue([]);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await service.list('tenant-9');
+
+      expect(findAll).toHaveBeenCalledExactlyOnceWith({
+        where: { tenantId: 'tenant-9' },
+        order: [['createdAt', 'DESC']],
+      });
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes a pending invitation', async () => {
+      const update = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(Invitation, 'findByPk').mockResolvedValue({
+        status: 'pending',
+        update,
+      } as unknown as Invitation);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await service.revoke('inv-1');
+
+      expect(update).toHaveBeenCalledExactlyOnceWith({ status: 'revoked' });
+    });
+
+    it('throws 404 when the invitation does not exist', async () => {
+      vi.spyOn(Invitation, 'findByPk').mockResolvedValue(null);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await expect(service.revoke('missing')).rejects.toMatchObject({
+        status: 404,
+        message: 'Invitation not found',
+      });
+    });
+
+    it('throws 400 when the invitation is not pending', async () => {
+      const update = vi.fn();
+      vi.spyOn(Invitation, 'findByPk').mockResolvedValue({
+        status: 'accepted',
+        update,
+      } as unknown as Invitation);
+      const service = createInvitationService({ email: fakeEmail() });
+
+      await expect(service.revoke('inv-2')).rejects.toBeInstanceOf(ApiError);
+      await expect(service.revoke('inv-2')).rejects.toMatchObject({
+        status: 400,
+        message: 'Cannot revoke a accepted invitation',
+      });
+      expect(update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/utils/api-error.test.ts
+++ b/api/src/utils/api-error.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './api-error.js';
+
+describe('ApiError', () => {
+  it('sets status, message, name, and details from the constructor', () => {
+    const err = new ApiError(418, "I'm a teapot", { hint: 'brew' });
+    expect(err.status).toBe(418);
+    expect(err.message).toBe("I'm a teapot");
+    expect(err.name).toBe('ApiError');
+    expect(err.details).toEqual({ hint: 'brew' });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('leaves details undefined when not supplied', () => {
+    const err = new ApiError(500, 'boom');
+    expect(err.details).toBeUndefined();
+  });
+
+  it('badRequest defaults status 400 and accepts details', () => {
+    const err = ApiError.badRequest('bad input', { field: 'email' });
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('bad input');
+    expect(err.details).toEqual({ field: 'email' });
+  });
+
+  it('unauthorized defaults its message', () => {
+    const err = ApiError.unauthorized();
+    expect(err.status).toBe(401);
+    expect(err.message).toBe('Authentication required');
+  });
+
+  it('unauthorized accepts a custom message', () => {
+    const err = ApiError.unauthorized('Token expired');
+    expect(err.status).toBe(401);
+    expect(err.message).toBe('Token expired');
+  });
+
+  it('forbidden defaults its message', () => {
+    const err = ApiError.forbidden();
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Insufficient permissions');
+  });
+
+  it('forbidden accepts a custom message', () => {
+    const err = ApiError.forbidden('Access denied to this tenant');
+    expect(err.status).toBe(403);
+    expect(err.message).toBe('Access denied to this tenant');
+  });
+
+  it('notFound defaults its message', () => {
+    const err = ApiError.notFound();
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Not found');
+  });
+
+  it('notFound accepts a custom message', () => {
+    const err = ApiError.notFound('Route not found: GET /nope');
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Route not found: GET /nope');
+  });
+
+  it('conflict requires and sets a message', () => {
+    const err = ApiError.conflict('Email already in use');
+    expect(err.status).toBe(409);
+    expect(err.message).toBe('Email already in use');
+  });
+
+  it('tooManyRequests defaults its message', () => {
+    const err = ApiError.tooManyRequests();
+    expect(err.status).toBe(429);
+    expect(err.message).toBe('Too many requests');
+  });
+
+  it('tooManyRequests accepts a custom message', () => {
+    const err = ApiError.tooManyRequests('Slow down');
+    expect(err.status).toBe(429);
+    expect(err.message).toBe('Slow down');
+  });
+});

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -1,0 +1,683 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { Tenant, User } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { Role } from '@livechat/shared';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+let harness: Harness;
+
+/**
+ * Create a tenant with sane defaults for the fields the model requires.
+ * @param overrides - Partial field overrides.
+ * @returns The created tenant.
+ */
+async function seedTenant(
+  overrides: Partial<{ name: string; slug: string }> = {},
+): Promise<Tenant> {
+  return Tenant.create({
+    name: overrides.name ?? 'Acme Corp',
+    slug: overrides.slug ?? `acme-${Math.random().toString(36).slice(2, 8)}`,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+}
+
+/**
+ * Create a user with a given role/tenant and return its plaintext password
+ * for login. `passwordHash` is set to plaintext — the model's `beforeCreate`
+ * hook bcrypt-hashes it.
+ * @param role - Role to assign.
+ * @param tenantId - Tenant id, or `null` for untenanted roles.
+ * @param overrides - Optional email override so callers can avoid collisions.
+ * @returns The created user and its plaintext password.
+ */
+async function seedUser(
+  role: Role,
+  tenantId: string | null,
+  overrides: Partial<{ email: string }> = {},
+): Promise<{ user: User; password: string }> {
+  const password = 'Sup3r!Secret1';
+  const user = await User.create({
+    email: overrides.email ?? `${role}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    passwordHash: password,
+    firstName: 'Test',
+    lastName: role,
+    role,
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { user, password };
+}
+
+/**
+ * Log a seeded user in and return an access token.
+ * @param email - Login email.
+ * @param password - Plaintext password.
+ * @returns Bearer access token.
+ */
+async function login(email: string, password: string): Promise<string> {
+  if (harness === null) throw new Error('harness not initialized');
+  const res = await request(harness.app).post('/api/v1/auth/login').send({ email, password });
+  expect(res.status).toBe(200);
+  return res.body.data.accessToken as string;
+}
+
+describe('admin routes (integration)', () => {
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  describe('authentication and authorization guards', () => {
+    test.runIf(() => harness !== null)(
+      'unauthenticated requests are rejected with 401',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+
+        const getTenants = await request(app).get('/api/v1/tenants');
+        expect(getTenants.status).toBe(401);
+        expect(getTenants.body.success).toBe(false);
+
+        const postTenants = await request(app).post('/api/v1/tenants').send({});
+        expect(postTenants.status).toBe(401);
+
+        const tenant = await seedTenant();
+        const patchTenant = await request(app).patch(`/api/v1/tenants/${tenant.id}`).send({});
+        expect(patchTenant.status).toBe(401);
+
+        const deleteTenant = await request(app).delete(`/api/v1/tenants/${tenant.id}`);
+        expect(deleteTenant.status).toBe(401);
+
+        const rotate = await request(app).post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`);
+        expect(rotate.status).toBe(401);
+
+        const origins = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .send({});
+        expect(origins.status).toBe(401);
+
+        const getUsers = await request(app).get('/api/v1/users');
+        expect(getUsers.status).toBe(401);
+
+        const patchUser = await request(app).patch('/api/v1/users/some-id').send({});
+        expect(patchUser.status).toBe(401);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'a malformed bearer token is rejected with 401',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const res = await request(app)
+          .get('/api/v1/tenants')
+          .set('authorization', 'Bearer not-a-real-token');
+        expect(res.status).toBe(401);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'staff cannot reach any /tenants or /users route (403 — admin-router base guard)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('staff', null);
+        const token = await login(user.email, password);
+        const tenant = await seedTenant();
+
+        const list = await request(app)
+          .get('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`);
+        expect(list.status).toBe(403);
+        expect(list.body.message).toMatch(/permission/i);
+
+        const create = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Nope', slug: 'nope' });
+        expect(create.status).toBe(403);
+
+        const getOne = await request(app)
+          .get(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(getOne.status).toBe(403);
+
+        const patchOne = await request(app)
+          .patch(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Nope' });
+        expect(patchOne.status).toBe(403);
+
+        const deleteOne = await request(app)
+          .delete(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(deleteOne.status).toBe(403);
+
+        const rotate = await request(app)
+          .post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`)
+          .set('authorization', `Bearer ${token}`);
+        expect(rotate.status).toBe(403);
+
+        const origins = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: ['https://example.com'] });
+        expect(origins.status).toBe(403);
+
+        const listUsers = await request(app)
+          .get('/api/v1/users')
+          .set('authorization', `Bearer ${token}`);
+        expect(listUsers.status).toBe(403);
+
+        const patchUser = await request(app)
+          .patch(`/api/v1/users/${user.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ firstName: 'X' });
+        expect(patchUser.status).toBe(403);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'client role cannot reach any /tenants or /users route (403)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('client', tenant.id);
+        const token = await login(user.email, password);
+
+        const list = await request(app)
+          .get('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`);
+        expect(list.status).toBe(403);
+
+        const listUsers = await request(app)
+          .get('/api/v1/users')
+          .set('authorization', `Bearer ${token}`);
+        expect(listUsers.status).toBe(403);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'tenant-scoped admin is forbidden from super_admin-only tenant mutations (403)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const ownTenant = await seedTenant();
+        const otherTenant = await seedTenant();
+        const { user, password } = await seedUser('admin', ownTenant.id);
+        const token = await login(user.email, password);
+
+        const create = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Blocked', slug: `blocked-${Math.random().toString(36).slice(2, 8)}` });
+        expect(create.status).toBe(403);
+
+        const patchOwn = await request(app)
+          .patch(`/api/v1/tenants/${ownTenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Renamed' });
+        expect(patchOwn.status).toBe(403);
+
+        const patchOther = await request(app)
+          .patch(`/api/v1/tenants/${otherTenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Renamed' });
+        expect(patchOther.status).toBe(403);
+
+        const deleteOther = await request(app)
+          .delete(`/api/v1/tenants/${otherTenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(deleteOther.status).toBe(403);
+
+        const rotate = await request(app)
+          .post(`/api/v1/tenants/${otherTenant.id}/rotate-embed-secret`)
+          .set('authorization', `Bearer ${token}`);
+        expect(rotate.status).toBe(403);
+
+        const origins = await request(app)
+          .put(`/api/v1/tenants/${otherTenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: ['https://example.com'] });
+        expect(origins.status).toBe(403);
+
+        // Read-only tenant routes have no super_admin guard, so admin CAN
+        // read any tenant (including one it is not scoped to) — the admin
+        // console's whole point is cross-tenant visibility for AFixt staff.
+        const readOther = await request(app)
+          .get(`/api/v1/tenants/${otherTenant.id}`)
+          .set('authorization', `Bearer ${token}`);
+        expect(readOther.status).toBe(200);
+        expect(readOther.body.data.id).toBe(otherTenant.id);
+      },
+    );
+  });
+
+  describe('/tenants CRUD', () => {
+    test.runIf(() => harness !== null)('list returns all tenants for an admin', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await seedTenant();
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app).get('/api/v1/tenants').set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThan(0);
+    });
+
+    test.runIf(() => harness !== null)(
+      'create succeeds for super_admin with a valid payload',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({
+            name: 'Brand New Co',
+            slug: `brand-new-${Math.random().toString(36).slice(2, 8)}`,
+          });
+        expect(res.status).toBe(201);
+        expect(res.body.data.name).toBe('Brand New Co');
+        expect(res.body.data.status).toBe('active');
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'create rejects an invalid slug with 400 (zod validation branch)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ name: 'Bad Slug Co', slug: 'not a valid slug!' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.details).toBeDefined();
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'create rejects a missing required field with 400',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post('/api/v1/tenants')
+          .set('authorization', `Bearer ${token}`)
+          .send({ slug: 'no-name-here' });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('create rejects a duplicate slug with 409', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+      const slug = `dupe-${Math.random().toString(36).slice(2, 8)}`;
+
+      const first = await request(app)
+        .post('/api/v1/tenants')
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'First', slug });
+      expect(first.status).toBe(201);
+
+      const second = await request(app)
+        .post('/api/v1/tenants')
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'Second', slug });
+      expect(second.status).toBe(409);
+      expect(second.body.message).toMatch(/slug/i);
+    });
+
+    test.runIf(() => harness !== null)('get by id 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .get('/api/v1/tenants/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)('get by id returns the tenant when it exists', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenant = await seedTenant();
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .get(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.id).toBe(tenant.id);
+    });
+
+    test.runIf(() => harness !== null)('update applies fields and persists them', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenant = await seedTenant();
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .patch(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'Updated Name', status: 'suspended' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.name).toBe('Updated Name');
+      expect(res.body.data.status).toBe('suspended');
+    });
+
+    test.runIf(() => harness !== null)('update 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .patch('/api/v1/tenants/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`)
+        .send({ name: 'Ghost' });
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'update rejects an invalid status enum with 400',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .patch(`/api/v1/tenants/${tenant.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ status: 'not-a-real-status' });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('delete soft-deletes the tenant, then 404s', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenant = await seedTenant();
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const del = await request(app)
+        .delete(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(del.status).toBe(200);
+      expect(del.body.success).toBe(true);
+
+      const after = await request(app)
+        .get(`/api/v1/tenants/${tenant.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(after.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)('delete 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .delete('/api/v1/tenants/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'rotate-embed-secret returns a fresh secret different from the original',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const originalSecret = tenant.embedSecret;
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`)
+          .set('authorization', `Bearer ${token}`);
+        expect(res.status).toBe(200);
+        expect(res.body.data.embedSecret).toBeTypeOf('string');
+        expect(res.body.data.embedSecret).not.toBe(originalSecret);
+      },
+    );
+
+    test.runIf(() => harness !== null)('rotate-embed-secret 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .post('/api/v1/tenants/00000000-0000-4000-8000-000000000000/rotate-embed-secret')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'allowed-origins sets the list when given a valid array',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: ['https://example.com', 'https://foo.example.com'] });
+        expect(res.status).toBe(200);
+        expect(res.body.data.allowedOrigins).toEqual([
+          'https://example.com',
+          'https://foo.example.com',
+        ]);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'allowed-origins clears to null when origins is not an array (branch coverage)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const tenant = await seedTenant();
+        const { user, password } = await seedUser('super_admin', null);
+        const token = await login(user.email, password);
+
+        const res = await request(app)
+          .put(`/api/v1/tenants/${tenant.id}/allowed-origins`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ origins: 'not-an-array' });
+        expect(res.status).toBe(200);
+        expect(res.body.data.allowedOrigins).toBeNull();
+      },
+    );
+
+    test.runIf(() => harness !== null)('allowed-origins 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('super_admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .put('/api/v1/tenants/00000000-0000-4000-8000-000000000000/allowed-origins')
+        .set('authorization', `Bearer ${token}`)
+        .send({ origins: ['https://example.com'] });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('/users', () => {
+    test.runIf(() => harness !== null)('list returns all users for an admin', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app).get('/api/v1/users').set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThan(0);
+      expect(res.body.data[0].passwordHash).toBeUndefined();
+    });
+
+    test.runIf(() => harness !== null)('list filters by tenantId query when provided', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const tenantA = await seedTenant();
+      const tenantB = await seedTenant();
+      await seedUser('client', tenantA.id);
+      await seedUser('client', tenantB.id);
+      const { user: admin, password } = await seedUser('admin', null);
+      const token = await login(admin.email, password);
+
+      const res = await request(app)
+        .get(`/api/v1/users?tenantId=${tenantA.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBeGreaterThan(0);
+      for (const returned of res.body.data as { tenantId: string | null }[]) {
+        expect(returned.tenantId).toBe(tenantA.id);
+      }
+    });
+
+    test.runIf(() => harness !== null)('get by id 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .get('/api/v1/users/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)('get by id returns the user when it exists', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user: target } = await seedUser('client', null);
+      const { user: admin, password } = await seedUser('admin', null);
+      const token = await login(admin.email, password);
+
+      const res = await request(app)
+        .get(`/api/v1/users/${target.id}`)
+        .set('authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.id).toBe(target.id);
+      expect(res.body.data.passwordHash).toBeUndefined();
+    });
+
+    test.runIf(() => harness !== null)('update applies fields and persists them', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user: target } = await seedUser('client', null);
+      const { user: admin, password } = await seedUser('admin', null);
+      const token = await login(admin.email, password);
+
+      const res = await request(app)
+        .patch(`/api/v1/users/${target.id}`)
+        .set('authorization', `Bearer ${token}`)
+        .send({ firstName: 'Renamed', status: 'suspended' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.firstName).toBe('Renamed');
+      expect(res.body.data.status).toBe('suspended');
+    });
+
+    test.runIf(() => harness !== null)('update 404s for an unknown id', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const { user, password } = await seedUser('admin', null);
+      const token = await login(user.email, password);
+
+      const res = await request(app)
+        .patch('/api/v1/users/00000000-0000-4000-8000-000000000000')
+        .set('authorization', `Bearer ${token}`)
+        .send({ firstName: 'Ghost' });
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'update rejects an invalid role enum with 400 (zod branch)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user: target } = await seedUser('client', null);
+        const { user: admin, password } = await seedUser('admin', null);
+        const token = await login(admin.email, password);
+
+        const res = await request(app)
+          .patch(`/api/v1/users/${target.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ role: 'not-a-real-role' });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'update rejects an invalid status enum with 400 (zod branch)',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const { user: target } = await seedUser('client', null);
+        const { user: admin, password } = await seedUser('admin', null);
+        const token = await login(admin.email, password);
+
+        const res = await request(app)
+          .patch(`/api/v1/users/${target.id}`)
+          .set('authorization', `Bearer ${token}`)
+          .send({ status: 'not-a-real-status' });
+        expect(res.status).toBe(400);
+      },
+    );
+  });
+});

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -267,14 +267,12 @@ describe('admin routes (integration)', () => {
           .send({ origins: ['https://example.com'] });
         expect(origins.status).toBe(403);
 
-        // Read-only tenant routes have no super_admin guard, so admin CAN
-        // read any tenant (including one it is not scoped to) — the admin
-        // console's whole point is cross-tenant visibility for AFixt staff.
+        // A tenant-scoped admin cannot read a tenant it is not scoped to
+        // (issue #43). Only untenanted AFixt staff get cross-tenant visibility.
         const readOther = await request(app)
           .get(`/api/v1/tenants/${otherTenant.id}`)
           .set('authorization', `Bearer ${token}`);
-        expect(readOther.status).toBe(200);
-        expect(readOther.body.data.id).toBe(otherTenant.id);
+        expect(readOther.status).toBe(403);
       },
     );
   });
@@ -679,5 +677,92 @@ describe('admin routes (integration)', () => {
         expect(res.status).toBe(400);
       },
     );
+  });
+
+  // Issue #43: role alone never granted cross-tenant access. A caller carrying
+  // a tenant_id is confined to it; only untenanted AFixt staff span tenants.
+  test.runIf(() => harness !== null)(
+    "a tenant-scoped admin cannot read or modify another tenant's user",
+    async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const own = await seedTenant({ slug: `iso-own-${Math.random().toString(36).slice(2, 8)}` });
+      const other = await seedTenant({
+        slug: `iso-other-${Math.random().toString(36).slice(2, 8)}`,
+      });
+      const admin = await seedUser('admin', own.id);
+      const victim = await seedUser('staff', other.id);
+      const token = await login(admin.user.email, admin.password);
+      const auth = `Bearer ${token}`;
+
+      const read = await request(app)
+        .get(`/api/v1/users/${victim.user.id}`)
+        .set('authorization', auth);
+      expect(read.status).toBe(403);
+
+      const write = await request(app)
+        .patch(`/api/v1/users/${victim.user.id}`)
+        .set('authorization', auth)
+        .send({ status: 'suspended' });
+      expect(write.status).toBe(403);
+
+      // The victim must be untouched by the refused write.
+      await victim.user.reload();
+      expect(victim.user.status).toBe('active');
+    },
+  );
+
+  test.runIf(() => harness !== null)(
+    'list endpoints are pinned to the caller tenant and refuse a cross-tenant filter',
+    async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const own = await seedTenant({ slug: `pin-own-${Math.random().toString(36).slice(2, 8)}` });
+      const other = await seedTenant({
+        slug: `pin-other-${Math.random().toString(36).slice(2, 8)}`,
+      });
+      const admin = await seedUser('admin', own.id);
+      const outsider = await seedUser('staff', other.id);
+      const token = await login(admin.user.email, admin.password);
+      const auth = `Bearer ${token}`;
+
+      const users = await request(app).get('/api/v1/users').set('authorization', auth);
+      expect(users.status).toBe(200);
+      const userIds = (users.body.data as { id: string }[]).map((u) => u.id);
+      expect(userIds).toContain(admin.user.id);
+      expect(userIds).not.toContain(outsider.user.id);
+
+      const crossFilter = await request(app)
+        .get('/api/v1/users')
+        .query({ tenantId: other.id })
+        .set('authorization', auth);
+      expect(crossFilter.status).toBe(403);
+
+      const tenants = await request(app).get('/api/v1/tenants').set('authorization', auth);
+      expect(tenants.status).toBe(200);
+      const tenantIds = (tenants.body.data as { id: string }[]).map((t) => t.id);
+      expect(tenantIds).toEqual([own.id]);
+    },
+  );
+
+  test.runIf(() => harness !== null)('untenanted AFixt staff still span every tenant', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const a = await seedTenant({ slug: `span-a-${Math.random().toString(36).slice(2, 8)}` });
+    const b = await seedTenant({ slug: `span-b-${Math.random().toString(36).slice(2, 8)}` });
+    const su = await seedUser('super_admin', null);
+    const token = await login(su.user.email, su.password);
+    const auth = `Bearer ${token}`;
+
+    const readA = await request(app).get(`/api/v1/tenants/${a.id}`).set('authorization', auth);
+    expect(readA.status).toBe(200);
+    const readB = await request(app).get(`/api/v1/tenants/${b.id}`).set('authorization', auth);
+    expect(readB.status).toBe(200);
+
+    const filtered = await request(app)
+      .get('/api/v1/users')
+      .query({ tenantId: b.id })
+      .set('authorization', auth);
+    expect(filtered.status).toBe(200);
   });
 });

--- a/api/tests/integration/auth-lifecycle.test.ts
+++ b/api/tests/integration/auth-lifecycle.test.ts
@@ -1,0 +1,874 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { AuditLog, Invitation, Tenant, User, UserSession } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { Role, UserStatus } from '@livechat/shared';
+import type { Express } from 'express';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+interface UserOverrides {
+  email: string;
+  password: string;
+  role?: Role;
+  tenantId?: string | null;
+  status?: UserStatus;
+  emailVerified?: boolean;
+  emailVerificationToken?: string | null;
+  emailVerificationExpires?: Date | null;
+  passwordResetToken?: string | null;
+  passwordResetExpires?: Date | null;
+  lockedUntil?: Date | null;
+  failedLoginAttempts?: number;
+}
+
+/**
+ * Create a fully-specified test user. Mirrors the field list required by
+ * `InferCreationAttributes<User>` — every plain-nullable field must be
+ * passed explicitly.
+ * @param overrides - Per-test field overrides.
+ * @returns The created user.
+ */
+async function createUser(overrides: UserOverrides): Promise<User> {
+  return User.create({
+    email: overrides.email,
+    passwordHash: overrides.password,
+    firstName: 'Test',
+    lastName: 'User',
+    role: overrides.role ?? 'client',
+    tenantId: overrides.tenantId ?? null,
+    status: overrides.status ?? 'active',
+    emailVerified: overrides.emailVerified ?? true,
+    emailVerificationToken: overrides.emailVerificationToken ?? null,
+    emailVerificationExpires: overrides.emailVerificationExpires ?? null,
+    passwordResetToken: overrides.passwordResetToken ?? null,
+    passwordResetExpires: overrides.passwordResetExpires ?? null,
+    failedLoginAttempts: overrides.failedLoginAttempts ?? 0,
+    lockedUntil: overrides.lockedUntil ?? null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+}
+
+/**
+ * Create a super_admin user and log in, returning the bearer access token.
+ * @param app - The Express app under test.
+ * @param email - Unique email for this admin.
+ * @returns The bearer access token.
+ */
+async function loginAsSuperAdmin(app: Express, email: string): Promise<string> {
+  const password = 'Admin!Password1';
+  await createUser({ email, password, role: 'super_admin' });
+  const res = await request(app).post('/api/v1/auth/login').send({ email, password });
+  return res.body.data.accessToken as string;
+}
+
+describe('auth lifecycle (integration)', () => {
+  let harness: Harness;
+
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  describe('forgot-password', () => {
+    test.runIf(() => harness !== null)('known email issues a reset token', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'forgot-known@example.com', password: 'Original!Pass1' });
+
+      const res = await request(app)
+        .post('/api/v1/auth/forgot-password')
+        .send({ email: 'forgot-known@example.com' });
+      expect(res.status).toBe(200);
+
+      const user = await User.findOne({ where: { email: 'forgot-known@example.com' } });
+      expect(user?.passwordResetToken).toBeTypeOf('string');
+      expect(user?.passwordResetExpires).not.toBeNull();
+    });
+
+    test.runIf(() => harness !== null)(
+      'unknown email returns the same response without leaking existence',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const res = await request(app)
+          .post('/api/v1/auth/forgot-password')
+          .send({ email: 'never-registered@example.com' });
+        expect(res.status).toBe(200);
+        expect(res.body.message).toMatch(/if the email exists/i);
+
+        const user = await User.findOne({ where: { email: 'never-registered@example.com' } });
+        expect(user).toBeNull();
+      },
+    );
+  });
+
+  describe('reset-password', () => {
+    test.runIf(() => harness !== null)(
+      'valid token resets the password, is single-use, and destroys sessions',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'reset-valid@example.com', password: 'Original!Pass1' });
+
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'reset-valid@example.com',
+          password: 'Original!Pass1',
+        });
+        expect(loginRes.status).toBe(200);
+        const preResetRefresh = loginRes.body.data.refreshToken as string;
+
+        await request(app)
+          .post('/api/v1/auth/forgot-password')
+          .send({ email: 'reset-valid@example.com' });
+        const user = await User.findOne({ where: { email: 'reset-valid@example.com' } });
+        const token = user?.passwordResetToken;
+        expect(token).toBeTypeOf('string');
+
+        const resetRes = await request(app)
+          .post('/api/v1/auth/reset-password')
+          .send({ token, password: 'BrandNew!Pass1' });
+        expect(resetRes.status).toBe(200);
+
+        const loginOld = await request(app).post('/api/v1/auth/login').send({
+          email: 'reset-valid@example.com',
+          password: 'Original!Pass1',
+        });
+        expect(loginOld.status).toBe(401);
+
+        const loginNew = await request(app).post('/api/v1/auth/login').send({
+          email: 'reset-valid@example.com',
+          password: 'BrandNew!Pass1',
+        });
+        expect(loginNew.status).toBe(200);
+
+        // Sessions destroyed by the reset — the pre-reset refresh token is dead.
+        const refreshAfterReset = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: preResetRefresh });
+        expect(refreshAfterReset.status).toBe(401);
+
+        // Token is single-use — replaying it fails even with a fresh password.
+        const replay = await request(app)
+          .post('/api/v1/auth/reset-password')
+          .send({ token, password: 'AnotherNew!Pass1' });
+        expect(replay.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('invalid token is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token: 'not-a-real-token', password: 'Whatever!Pass1' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/invalid/i);
+    });
+
+    test.runIf(() => harness !== null)('expired token is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const token = randomBytes(32).toString('hex');
+      await createUser({
+        email: 'reset-expired@example.com',
+        password: 'Original!Pass1',
+        passwordResetToken: token,
+        passwordResetExpires: new Date(Date.now() - HOUR_MS),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token, password: 'Whatever!Pass1' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/expired/i);
+    });
+  });
+
+  describe('change-password', () => {
+    test.runIf(() => harness !== null)('correct current password succeeds', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'change-ok@example.com', password: 'Original!Pass1' });
+      const loginRes = await request(app).post('/api/v1/auth/login').send({
+        email: 'change-ok@example.com',
+        password: 'Original!Pass1',
+      });
+      const access = loginRes.body.data.accessToken as string;
+
+      const changeRes = await request(app)
+        .put('/api/v1/auth/change-password')
+        .set('authorization', `Bearer ${access}`)
+        .send({ currentPassword: 'Original!Pass1', newPassword: 'Updated!Pass1' });
+      expect(changeRes.status).toBe(200);
+
+      const relogin = await request(app).post('/api/v1/auth/login').send({
+        email: 'change-ok@example.com',
+        password: 'Updated!Pass1',
+      });
+      expect(relogin.status).toBe(200);
+    });
+
+    test.runIf(() => harness !== null)('wrong current password is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'change-wrong@example.com', password: 'Original!Pass1' });
+      const loginRes = await request(app).post('/api/v1/auth/login').send({
+        email: 'change-wrong@example.com',
+        password: 'Original!Pass1',
+      });
+      const access = loginRes.body.data.accessToken as string;
+
+      const changeRes = await request(app)
+        .put('/api/v1/auth/change-password')
+        .set('authorization', `Bearer ${access}`)
+        .send({ currentPassword: 'NotItAtAll1', newPassword: 'Updated!Pass1' });
+      expect(changeRes.status).toBe(400);
+      expect(changeRes.body.message).toMatch(/incorrect/i);
+    });
+
+    test.runIf(() => harness !== null)('requires authentication', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .put('/api/v1/auth/change-password')
+        .send({ currentPassword: 'Whatever1', newPassword: 'Updated!Pass1' });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('verify-email/:token', () => {
+    test.runIf(() => harness !== null)('valid token verifies the account', async () => {
+      if (harness === null) return;
+      const token = randomBytes(32).toString('hex');
+      await createUser({
+        email: 'verify-valid@example.com',
+        password: 'Original!Pass1',
+        emailVerified: false,
+        emailVerificationToken: token,
+        emailVerificationExpires: new Date(Date.now() + DAY_MS),
+      });
+      const { app } = harness;
+
+      const res = await request(app).get(`/api/v1/auth/verify-email/${token}`);
+      expect(res.status).toBe(200);
+
+      const user = await User.findOne({ where: { email: 'verify-valid@example.com' } });
+      expect(user?.emailVerified).toBe(true);
+      expect(user?.emailVerificationToken).toBeNull();
+    });
+
+    test.runIf(() => harness !== null)('invalid token is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app).get('/api/v1/auth/verify-email/not-a-real-token');
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)('expired token is rejected', async () => {
+      if (harness === null) return;
+      const token = randomBytes(32).toString('hex');
+      await createUser({
+        email: 'verify-expired@example.com',
+        password: 'Original!Pass1',
+        emailVerified: false,
+        emailVerificationToken: token,
+        emailVerificationExpires: new Date(Date.now() - HOUR_MS),
+      });
+      const { app } = harness;
+
+      const res = await request(app).get(`/api/v1/auth/verify-email/${token}`);
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/expired/i);
+    });
+  });
+
+  describe('login edge branches', () => {
+    test.runIf(() => harness !== null)('failed attempts increment the counter', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'login-fail-count@example.com', password: 'Real!Password1' });
+
+      const res = await request(app).post('/api/v1/auth/login').send({
+        email: 'login-fail-count@example.com',
+        password: 'wrong-password',
+      });
+      expect(res.status).toBe(401);
+
+      const user = await User.findOne({ where: { email: 'login-fail-count@example.com' } });
+      expect(user?.failedLoginAttempts).toBe(1);
+      expect(user?.lockedUntil).toBeNull();
+    });
+
+    test.runIf(() => harness !== null)(
+      'locked account rejects login even with correct password',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({
+          email: 'login-locked@example.com',
+          password: 'Real!Password1',
+          lockedUntil: new Date(Date.now() + HOUR_MS),
+          failedLoginAttempts: 5,
+        });
+
+        const res = await request(app).post('/api/v1/auth/login').send({
+          email: 'login-locked@example.com',
+          password: 'Real!Password1',
+        });
+        expect(res.status).toBe(403);
+        expect(res.body.message).toMatch(/locked/i);
+      },
+    );
+
+    test.runIf(() => harness !== null)('suspended account is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({
+        email: 'login-suspended@example.com',
+        password: 'Real!Password1',
+        status: 'suspended',
+      });
+
+      const res = await request(app).post('/api/v1/auth/login').send({
+        email: 'login-suspended@example.com',
+        password: 'Real!Password1',
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/not active/i);
+    });
+
+    test.runIf(() => harness !== null)('pending account is rejected', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({
+        email: 'login-pending@example.com',
+        password: 'Real!Password1',
+        status: 'pending',
+      });
+
+      const res = await request(app).post('/api/v1/auth/login').send({
+        email: 'login-pending@example.com',
+        password: 'Real!Password1',
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/not active/i);
+    });
+
+    test.runIf(() => harness !== null)(
+      'unknown email is rejected without distinguishing detail',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const res = await request(app).post('/api/v1/auth/login').send({
+          email: 'does-not-exist@example.com',
+          password: 'Whatever!Pass1',
+        });
+        expect(res.status).toBe(401);
+      },
+    );
+  });
+
+  describe('refresh-token / logout', () => {
+    test.runIf(() => harness !== null)(
+      'refresh rotates the token and the old one is rejected',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'refresh-rotate@example.com', password: 'Real!Password1' });
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'refresh-rotate@example.com',
+          password: 'Real!Password1',
+        });
+        const oldRefresh = loginRes.body.data.refreshToken as string;
+
+        const refreshRes = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: oldRefresh });
+        expect(refreshRes.status).toBe(200);
+        const newRefresh = refreshRes.body.data.refreshToken as string;
+        expect(newRefresh).not.toBe(oldRefresh);
+
+        const reuseOld = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: oldRefresh });
+        expect(reuseOld.status).toBe(401);
+
+        const useNew = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken: newRefresh });
+        expect(useNew.status).toBe(200);
+      },
+    );
+
+    test.runIf(() => harness !== null)('refresh-token requires a body field', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app).post('/api/v1/auth/refresh-token').send({});
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)('refresh rejects a malformed token', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .post('/api/v1/auth/refresh-token')
+        .send({ refreshToken: 'garbage.not.a.jwt' });
+      expect(res.status).toBe(401);
+    });
+
+    test.runIf(() => harness !== null)('refresh rejects a suspended user', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await createUser({ email: 'refresh-suspend@example.com', password: 'Real!Password1' });
+      const loginRes = await request(app).post('/api/v1/auth/login').send({
+        email: 'refresh-suspend@example.com',
+        password: 'Real!Password1',
+      });
+      const refreshToken = loginRes.body.data.refreshToken as string;
+
+      const user = await User.findOne({ where: { email: 'refresh-suspend@example.com' } });
+      await user?.update({ status: 'suspended' });
+
+      const res = await request(app).post('/api/v1/auth/refresh-token').send({ refreshToken });
+      expect(res.status).toBe(401);
+    });
+
+    test.runIf(() => harness !== null)(
+      'logout destroys the session so refresh stops working',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'logout-destroys@example.com', password: 'Real!Password1' });
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'logout-destroys@example.com',
+          password: 'Real!Password1',
+        });
+        const access = loginRes.body.data.accessToken as string;
+        const refreshToken = loginRes.body.data.refreshToken as string;
+
+        const logoutRes = await request(app)
+          .post('/api/v1/auth/logout')
+          .set('authorization', `Bearer ${access}`);
+        expect(logoutRes.status).toBe(200);
+
+        const meRes = await request(app)
+          .get('/api/v1/auth/me')
+          .set('authorization', `Bearer ${access}`);
+        expect(meRes.status).toBe(401);
+
+        const refreshRes = await request(app)
+          .post('/api/v1/auth/refresh-token')
+          .send({ refreshToken });
+        expect(refreshRes.status).toBe(401);
+      },
+    );
+  });
+
+  describe('invitations', () => {
+    test.runIf(() => harness !== null)(
+      'admin can create, list, and register succeeds with the token',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-1@example.com');
+
+        const createRes = await request(app)
+          .post('/api/v1/invitations')
+          .set('authorization', `Bearer ${adminAccess}`)
+          .send({ email: 'invitee-1@example.com', role: 'client', expiresInDays: 7 });
+        expect(createRes.status).toBe(201);
+
+        const listRes = await request(app)
+          .get('/api/v1/invitations')
+          .set('authorization', `Bearer ${adminAccess}`);
+        expect(listRes.status).toBe(200);
+        expect(Array.isArray(listRes.body.data)).toBe(true);
+
+        const invitation = await Invitation.findOne({ where: { email: 'invitee-1@example.com' } });
+        const token = invitation?.token as string;
+
+        const registerRes = await request(app).post('/api/v1/auth/register').send({
+          email: 'invitee-1@example.com',
+          password: 'NewUser!Pass1',
+          firstName: 'In',
+          lastName: 'Vitee',
+          token,
+        });
+        expect(registerRes.status).toBe(201);
+
+        const accepted = await Invitation.findOne({ where: { email: 'invitee-1@example.com' } });
+        expect(accepted?.status).toBe('accepted');
+
+        // Single-use: the same token cannot register a second account.
+        const replay = await request(app).post('/api/v1/auth/register').send({
+          email: 'invitee-1@example.com',
+          password: 'NewUser!Pass1',
+          firstName: 'In',
+          lastName: 'Vitee',
+          token,
+        });
+        expect(replay.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('create rejects an unknown tenantId', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-2@example.com');
+
+      const res = await request(app)
+        .post('/api/v1/invitations')
+        .set('authorization', `Bearer ${adminAccess}`)
+        .send({ email: 'invitee-2@example.com', role: 'client', tenantId: randomUUID() });
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)(
+      'create succeeds with a real tenantId and list can filter by it',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-3@example.com');
+        const tenant = await Tenant.create({
+          name: 'Filter Co',
+          slug: 'filter-co',
+          status: 'active',
+          domain: null,
+          expiresAt: null,
+          settings: null,
+        });
+
+        const createRes = await request(app)
+          .post('/api/v1/invitations')
+          .set('authorization', `Bearer ${adminAccess}`)
+          .send({ email: 'invitee-3@example.com', role: 'staff', tenantId: tenant.id });
+        expect(createRes.status).toBe(201);
+
+        const filtered = await request(app)
+          .get(`/api/v1/invitations?tenantId=${tenant.id}`)
+          .set('authorization', `Bearer ${adminAccess}`);
+        expect(filtered.status).toBe(200);
+        const data = filtered.body.data as { email: string }[];
+        const emails: string[] = [];
+        for (const invite of data) emails.push(invite.email);
+        expect(emails).toContain('invitee-3@example.com');
+      },
+    );
+
+    test.runIf(() => harness !== null)('register rejects an unknown token', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const res = await request(app)
+        .post('/api/v1/auth/register')
+        .send({
+          email: 'nobody@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'No',
+          lastName: 'Body',
+          token: randomBytes(16).toString('hex'),
+        });
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)(
+      'register rejects an expired invitation and marks it expired',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await loginAsSuperAdmin(app, 'inv-admin-4@example.com');
+        const admin = await User.findOne({ where: { email: 'inv-admin-4@example.com' } });
+        const invitation = await Invitation.create({
+          email: 'expired-invite@example.com',
+          role: 'client',
+          token: randomBytes(16).toString('hex'),
+          invitedBy: (admin as User).id,
+          expiresAt: new Date(Date.now() - HOUR_MS),
+          tenantId: null,
+          name: null,
+          acceptedAt: null,
+        });
+
+        const res = await request(app).post('/api/v1/auth/register').send({
+          email: 'expired-invite@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'Ex',
+          lastName: 'Pired',
+          token: invitation.token,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/expired/i);
+
+        const reloaded = await Invitation.findByPk(invitation.id);
+        expect(reloaded?.status).toBe('expired');
+      },
+    );
+
+    test.runIf(() => harness !== null)(
+      'register rejects an already-accepted invitation',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await loginAsSuperAdmin(app, 'inv-admin-5@example.com');
+        const admin = await User.findOne({ where: { email: 'inv-admin-5@example.com' } });
+        const invitation = await Invitation.create({
+          email: 'already-accepted@example.com',
+          role: 'client',
+          token: randomBytes(16).toString('hex'),
+          invitedBy: (admin as User).id,
+          expiresAt: new Date(Date.now() + DAY_MS),
+          tenantId: null,
+          name: null,
+          acceptedAt: new Date(),
+          status: 'accepted',
+        });
+
+        const res = await request(app).post('/api/v1/auth/register').send({
+          email: 'already-accepted@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'Al',
+          lastName: 'Ready',
+          token: invitation.token,
+        });
+        expect(res.status).toBe(400);
+      },
+    );
+
+    test.runIf(() => harness !== null)('register rejects a revoked invitation', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      await loginAsSuperAdmin(app, 'inv-admin-6@example.com');
+      const admin = await User.findOne({ where: { email: 'inv-admin-6@example.com' } });
+      const invitation = await Invitation.create({
+        email: 'revoked-invite@example.com',
+        role: 'client',
+        token: randomBytes(16).toString('hex'),
+        invitedBy: (admin as User).id,
+        expiresAt: new Date(Date.now() + DAY_MS),
+        tenantId: null,
+        name: null,
+        acceptedAt: null,
+        status: 'revoked',
+      });
+
+      const res = await request(app).post('/api/v1/auth/register').send({
+        email: 'revoked-invite@example.com',
+        password: 'Whatever!Pass1',
+        firstName: 'Re',
+        lastName: 'Voked',
+        token: invitation.token,
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test.runIf(() => harness !== null)(
+      'register rejects an email that no longer matches the invitation',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await loginAsSuperAdmin(app, 'inv-admin-7@example.com');
+        const admin = await User.findOne({ where: { email: 'inv-admin-7@example.com' } });
+        const invitation = await Invitation.create({
+          email: 'target@example.com',
+          role: 'client',
+          token: randomBytes(16).toString('hex'),
+          invitedBy: (admin as User).id,
+          expiresAt: new Date(Date.now() + DAY_MS),
+          tenantId: null,
+          name: null,
+          acceptedAt: null,
+        });
+        await createUser({ email: 'target@example.com', password: 'Existing!Pass1' });
+
+        const res = await request(app).post('/api/v1/auth/register').send({
+          email: 'target@example.com',
+          password: 'Whatever!Pass1',
+          firstName: 'Ta',
+          lastName: 'Rget',
+          token: invitation.token,
+        });
+        expect(res.status).toBe(409);
+        expect(res.body.message).toMatch(/already registered/i);
+      },
+    );
+
+    test.runIf(() => harness !== null)('revoke succeeds for a pending invitation', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-8@example.com');
+      const createRes = await request(app)
+        .post('/api/v1/invitations')
+        .set('authorization', `Bearer ${adminAccess}`)
+        .send({ email: 'revoke-me@example.com', role: 'client' });
+      expect(createRes.status).toBe(201);
+      const invitation = await Invitation.findOne({ where: { email: 'revoke-me@example.com' } });
+
+      const revokeRes = await request(app)
+        .post(`/api/v1/invitations/${(invitation as Invitation).id}/revoke`)
+        .set('authorization', `Bearer ${adminAccess}`);
+      expect(revokeRes.status).toBe(200);
+
+      const reloaded = await Invitation.findByPk((invitation as Invitation).id);
+      expect(reloaded?.status).toBe('revoked');
+    });
+
+    test.runIf(() => harness !== null)('revoke rejects a non-pending invitation', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-9@example.com');
+      const admin = await User.findOne({ where: { email: 'inv-admin-9@example.com' } });
+      const invitation = await Invitation.create({
+        email: 'already-revoked@example.com',
+        role: 'client',
+        token: randomBytes(16).toString('hex'),
+        invitedBy: (admin as User).id,
+        expiresAt: new Date(Date.now() + DAY_MS),
+        tenantId: null,
+        name: null,
+        acceptedAt: null,
+        status: 'revoked',
+      });
+
+      const res = await request(app)
+        .post(`/api/v1/invitations/${invitation.id}/revoke`)
+        .set('authorization', `Bearer ${adminAccess}`);
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/revoked/i);
+    });
+
+    test.runIf(() => harness !== null)('revoke of an unknown invitation is 404', async () => {
+      if (harness === null) return;
+      const { app } = harness;
+      const adminAccess = await loginAsSuperAdmin(app, 'inv-admin-10@example.com');
+
+      const res = await request(app)
+        .post(`/api/v1/invitations/${randomUUID()}/revoke`)
+        .set('authorization', `Bearer ${adminAccess}`);
+      expect(res.status).toBe(404);
+    });
+
+    test.runIf(() => harness !== null)(
+      'invitations endpoints require admin/super_admin',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'plain-client@example.com', password: 'Real!Password1' });
+        const loginRes = await request(app).post('/api/v1/auth/login').send({
+          email: 'plain-client@example.com',
+          password: 'Real!Password1',
+        });
+        const clientAccess = loginRes.body.data.accessToken as string;
+
+        const res = await request(app)
+          .post('/api/v1/invitations')
+          .set('authorization', `Bearer ${clientAccess}`)
+          .send({ email: 'someone@example.com', role: 'client' });
+        expect(res.status).toBe(403);
+      },
+    );
+  });
+
+  describe('audit-service', () => {
+    test.runIf(() => harness !== null)('records a login-shaped entry', async () => {
+      if (harness === null) return;
+      const user = await createUser({
+        email: 'audit-login@example.com',
+        password: 'Real!Password1',
+      });
+
+      await harness.services.audit.record({
+        userId: user.id,
+        action: 'auth.login',
+        resourceType: 'user',
+        resourceId: user.id,
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest',
+      });
+
+      const row = await AuditLog.findOne({ where: { userId: user.id, action: 'auth.login' } });
+      expect(row).not.toBeNull();
+      expect(row?.resourceType).toBe('user');
+      expect(row?.ipAddress).toBe('127.0.0.1');
+    });
+
+    test.runIf(() => harness !== null)(
+      'records an admin-action-shaped entry with metadata',
+      async () => {
+        if (harness === null) return;
+        const admin = await createUser({
+          email: 'audit-admin@example.com',
+          password: 'Real!Password1',
+          role: 'super_admin',
+        });
+
+        await harness.services.audit.record({
+          userId: admin.id,
+          action: 'invitation.create',
+          resourceType: 'invitation',
+          resourceId: randomUUID(),
+          metadata: { email: 'invitee@example.com', role: 'client' },
+        });
+
+        const row = await AuditLog.findOne({
+          where: { userId: admin.id, action: 'invitation.create' },
+        });
+        expect(row).not.toBeNull();
+        expect(row?.metadata).toEqual({ email: 'invitee@example.com', role: 'client' });
+      },
+    );
+
+    test.runIf(() => harness !== null)('swallows write failures instead of throwing', async () => {
+      if (harness === null) return;
+      // userId references `users.id` with an FK constraint — a well-formed
+      // but non-existent UUID trips the FK violation inside `AuditLog.create`,
+      // exercising the service's catch branch without ever throwing here.
+      await expect(
+        harness.services.audit.record({
+          userId: randomUUID(),
+          action: 'audit.fk-violation',
+        }),
+      ).resolves.toBeUndefined();
+
+      const row = await AuditLog.findOne({ where: { action: 'audit.fk-violation' } });
+      expect(row).toBeNull();
+    });
+  });
+
+  describe('UserSession bookkeeping sanity', () => {
+    test.runIf(() => harness !== null)(
+      'login creates exactly one session row per login',
+      async () => {
+        if (harness === null) return;
+        const { app } = harness;
+        await createUser({ email: 'session-count@example.com', password: 'Real!Password1' });
+        const user = await User.findOne({ where: { email: 'session-count@example.com' } });
+
+        await request(app).post('/api/v1/auth/login').send({
+          email: 'session-count@example.com',
+          password: 'Real!Password1',
+        });
+
+        const sessions = await UserSession.findAll({ where: { userId: (user as User).id } });
+        expect(sessions.length).toBe(1);
+      },
+    );
+  });
+});

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -231,13 +231,11 @@ describe('chat routes (integration)', () => {
     expect(res.status).toBe(403);
   });
 
-  // NOTE: `buildChatsRouter` (api/src/routes/chats.ts) only gates access on
-  // role via `requireStaffOrAdmin()` — it never compares a chat's tenantId
-  // against `req.user.tenantId`, unlike the tenant-scoped Socket.IO rooms
-  // exercised in chat-flow.test.ts. This test documents that actual, current
-  // REST-layer behavior; it is not an endorsement of it. Flagged separately
-  // as a cross-tenant data-exposure gap worth a follow-up fix.
-  test("current behavior: a tenant-scoped staff member can read another tenant's chat", async () => {
+  // Issue #43: the REST layer now enforces the same tenant isolation the
+  // Socket.IO rooms already did (see chat-flow.test.ts). A tenant-scoped staff
+  // member is confined to their own tenant across every chat route — reads and
+  // writes alike; only untenanted AFixt staff span tenants.
+  test("a tenant-scoped staff member cannot touch another tenant's chat", async () => {
     if (harness === null) return;
     const { app } = harness;
     const staffA = await seedTenantAndStaff('iso-a');
@@ -245,12 +243,32 @@ describe('chat routes (integration)', () => {
     const visitorB = await seedVisitorSession(staffB.tenantId);
     const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
     const tokenA = await loginAs(app, staffA.email, staffA.password);
+    const auth = `Bearer ${tokenA}`;
 
-    const res = await request(app)
-      .get(`/api/v1/chats/${chatB.id}`)
-      .set('authorization', `Bearer ${tokenA}`);
-    expect(res.status).toBe(200);
-    expect(res.body.data.id).toBe(chatB.id);
+    const read = await request(app).get(`/api/v1/chats/${chatB.id}`).set('authorization', auth);
+    expect(read.status).toBe(403);
+
+    const transcript = await request(app)
+      .get(`/api/v1/chats/${chatB.id}/messages`)
+      .set('authorization', auth);
+    expect(transcript.status).toBe(403);
+
+    const accept = await request(app)
+      .post(`/api/v1/chats/${chatB.id}/accept`)
+      .set('authorization', auth);
+    expect(accept.status).toBe(403);
+
+    const post = await request(app)
+      .post(`/api/v1/chats/${chatB.id}/messages`)
+      .set('authorization', auth)
+      .send({ body: 'should not land' });
+    expect(post.status).toBe(403);
+
+    const end = await request(app)
+      .post(`/api/v1/chats/${chatB.id}/end`)
+      .set('authorization', auth)
+      .send({ endedBy: 'support' });
+    expect(end.status).toBe(403);
   });
 
   test('lists chats, filterable by tenantId and status', async () => {
@@ -265,14 +283,23 @@ describe('chat routes (integration)', () => {
     const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
     const token = await loginAs(app, staffA.email, staffA.password);
 
+    // Omitting ?tenantId cannot widen the result set across tenants: a scoped
+    // caller is pinned to their own tenant (issue #43).
     const unfiltered = await request(app)
       .get('/api/v1/chats')
       .set('authorization', `Bearer ${token}`);
     expect(unfiltered.status).toBe(200);
     const unfilteredIds = (unfiltered.body.data as { id: string }[]).map((c) => c.id);
-    expect(unfilteredIds).toEqual(
-      expect.arrayContaining([pendingChatA.id, activeChatA.id, chatB.id]),
-    );
+    expect(unfilteredIds).toEqual(expect.arrayContaining([pendingChatA.id, activeChatA.id]));
+    expect(unfilteredIds).not.toContain(chatB.id);
+
+    // Explicitly asking for someone else's tenant is refused, not silently
+    // rewritten to your own.
+    const crossTenant = await request(app)
+      .get('/api/v1/chats')
+      .query({ tenantId: staffB.tenantId })
+      .set('authorization', `Bearer ${token}`);
+    expect(crossTenant.status).toBe(403);
 
     const byTenant = await request(app)
       .get('/api/v1/chats')

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -1,0 +1,482 @@
+import { randomUUID } from 'node:crypto';
+
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { Chat, ChatMessage, Tenant, User, VisitorSession } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { ChatStatus } from '@livechat/shared';
+import type { Express } from 'express';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+interface StaffSeed {
+  tenantId: string;
+  email: string;
+  password: string;
+}
+
+const STAFF_PASSWORD = 'Staff!Password1';
+let staffCounter = 0;
+
+/**
+ * Create a staff user attached to an existing tenant (or untenanted, if
+ * `tenantId` is `null`).
+ * @param tenantId - Owning tenant id, or `null` for an untenanted user.
+ * @param label - Unique-ish label folded into the generated email.
+ * @returns The new user's login credentials.
+ */
+async function seedStaff(
+  tenantId: string | null,
+  label: string,
+): Promise<{ email: string; password: string }> {
+  staffCounter += 1;
+  const email = `staff${String(staffCounter)}-${label}@example.com`;
+  await User.create({
+    email,
+    passwordHash: STAFF_PASSWORD,
+    firstName: 'St',
+    lastName: 'Aff',
+    role: 'staff',
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { email, password: STAFF_PASSWORD };
+}
+
+/**
+ * Create a fresh tenant plus one staff member belonging to it.
+ * @param tenantSlug - Unique tenant slug.
+ * @returns Tenant id and the staff member's login credentials.
+ */
+async function seedTenantAndStaff(tenantSlug: string): Promise<StaffSeed> {
+  const tenant = await Tenant.create({
+    name: `Tenant-${tenantSlug}`,
+    slug: tenantSlug,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+  const { email, password } = await seedStaff(tenant.id, tenantSlug);
+  return { tenantId: tenant.id, email, password };
+}
+
+/**
+ * Create a non-staff (`client`) user attached to a tenant.
+ * @param tenantId - Owning tenant id.
+ * @param label - Unique-ish label folded into the generated email.
+ * @returns The new user's login credentials.
+ */
+async function seedClient(
+  tenantId: string,
+  label: string,
+): Promise<{ email: string; password: string }> {
+  staffCounter += 1;
+  const email = `client${String(staffCounter)}-${label}@example.com`;
+  const password = 'Client!Password1';
+  await User.create({
+    email,
+    passwordHash: password,
+    firstName: 'Cl',
+    lastName: 'Ient',
+    role: 'client',
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { email, password };
+}
+
+/**
+ * Log in and return the access token.
+ * @param app - Express app under test.
+ * @param email - Login email.
+ * @param password - Login password.
+ * @returns The bearer access token.
+ */
+async function loginAs(app: Express, email: string, password: string): Promise<string> {
+  const res = await request(app).post('/api/v1/auth/login').send({ email, password });
+  expect(res.status).toBe(200);
+  return res.body.data.accessToken as string;
+}
+
+/**
+ * Create a visitor session directly via the model (bypassing the widget
+ * bootstrap endpoint, which isn't under test here).
+ * @param tenantId - Owning tenant id.
+ * @returns The new visitor session.
+ */
+async function seedVisitorSession(tenantId: string): Promise<VisitorSession> {
+  const now = new Date();
+  return VisitorSession.create({
+    tenantId,
+    sessionCookieHash: `hash-${randomUUID()}`,
+    identityTokenSub: null,
+    userAgent: null,
+    ipAddress: null,
+    country: null,
+    city: null,
+    language: null,
+    currentUrl: null,
+    referrer: null,
+    status: 'active',
+    firstSeenAt: now,
+    lastSeenAt: now,
+  });
+}
+
+interface ChatOverrides {
+  status?: ChatStatus;
+  assignedTo?: string | null;
+  initiatedBy?: 'customer' | 'support';
+  endedAt?: Date | null;
+}
+
+/**
+ * Create a chat directly via the model.
+ * @param tenantId - Owning tenant id.
+ * @param visitorSessionId - Owning visitor session id.
+ * @param overrides - Optional field overrides.
+ * @returns The new chat.
+ */
+async function seedChat(
+  tenantId: string,
+  visitorSessionId: string,
+  overrides: ChatOverrides = {},
+): Promise<Chat> {
+  return Chat.create({
+    tenantId,
+    visitorSessionId,
+    assignedTo: overrides.assignedTo ?? null,
+    initiatedBy: overrides.initiatedBy ?? 'customer',
+    status: overrides.status ?? 'pending',
+    customerName: 'Test Visitor',
+    customerEmail: null,
+    startedAt: new Date(),
+    endedAt: overrides.endedAt ?? null,
+  });
+}
+
+/**
+ * Create a chat message directly via the model, with an explicit
+ * `deliveredAt` so ordering can be tested independently of insertion order.
+ * @param chatId - Owning chat id.
+ * @param body - Message body.
+ * @param deliveredAt - Explicit delivery timestamp.
+ * @returns The new message.
+ */
+async function seedMessage(chatId: string, body: string, deliveredAt: Date): Promise<ChatMessage> {
+  return ChatMessage.create({
+    chatId,
+    senderKind: 'visitor',
+    senderUserId: null,
+    body,
+    deliveredAt,
+    readAt: null,
+  });
+}
+
+describe('chat routes (integration)', () => {
+  let harness: Harness;
+
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  test('unauthenticated request is rejected with 401', async () => {
+    if (harness === null) return;
+    const res = await request(harness.app).get('/api/v1/chats');
+    expect(res.status).toBe(401);
+  });
+
+  test('a non-staff role is forbidden with 403', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const { tenantId } = await seedTenantAndStaff('forbid');
+    const client = await seedClient(tenantId, 'forbid');
+    const token = await loginAs(app, client.email, client.password);
+
+    const res = await request(app).get('/api/v1/chats').set('authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  // NOTE: `buildChatsRouter` (api/src/routes/chats.ts) only gates access on
+  // role via `requireStaffOrAdmin()` — it never compares a chat's tenantId
+  // against `req.user.tenantId`, unlike the tenant-scoped Socket.IO rooms
+  // exercised in chat-flow.test.ts. This test documents that actual, current
+  // REST-layer behavior; it is not an endorsement of it. Flagged separately
+  // as a cross-tenant data-exposure gap worth a follow-up fix.
+  test("current behavior: a tenant-scoped staff member can read another tenant's chat", async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staffA = await seedTenantAndStaff('iso-a');
+    const staffB = await seedTenantAndStaff('iso-b');
+    const visitorB = await seedVisitorSession(staffB.tenantId);
+    const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
+    const tokenA = await loginAs(app, staffA.email, staffA.password);
+
+    const res = await request(app)
+      .get(`/api/v1/chats/${chatB.id}`)
+      .set('authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(chatB.id);
+  });
+
+  test('lists chats, filterable by tenantId and status', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staffA = await seedTenantAndStaff('list-a');
+    const staffB = await seedTenantAndStaff('list-b');
+    const visitorA = await seedVisitorSession(staffA.tenantId);
+    const visitorB = await seedVisitorSession(staffB.tenantId);
+    const pendingChatA = await seedChat(staffA.tenantId, visitorA.id, { status: 'pending' });
+    const activeChatA = await seedChat(staffA.tenantId, visitorA.id, { status: 'active' });
+    const chatB = await seedChat(staffB.tenantId, visitorB.id, { status: 'pending' });
+    const token = await loginAs(app, staffA.email, staffA.password);
+
+    const unfiltered = await request(app)
+      .get('/api/v1/chats')
+      .set('authorization', `Bearer ${token}`);
+    expect(unfiltered.status).toBe(200);
+    const unfilteredIds = (unfiltered.body.data as { id: string }[]).map((c) => c.id);
+    expect(unfilteredIds).toEqual(
+      expect.arrayContaining([pendingChatA.id, activeChatA.id, chatB.id]),
+    );
+
+    const byTenant = await request(app)
+      .get('/api/v1/chats')
+      .query({ tenantId: staffA.tenantId })
+      .set('authorization', `Bearer ${token}`);
+    expect(byTenant.status).toBe(200);
+    const tenantIds = (byTenant.body.data as { id: string }[]).map((c) => c.id);
+    expect(tenantIds).toEqual(expect.arrayContaining([pendingChatA.id, activeChatA.id]));
+    expect(tenantIds).not.toContain(chatB.id);
+
+    const byStatus = await request(app)
+      .get('/api/v1/chats')
+      .query({ status: 'pending' })
+      .set('authorization', `Bearer ${token}`);
+    expect(byStatus.status).toBe(200);
+    const statusIds = (byStatus.body.data as { id: string }[]).map((c) => c.id);
+    expect(statusIds).toContain(pendingChatA.id);
+    expect(statusIds).not.toContain(activeChatA.id);
+
+    // An invalid status value fails `chatStatusSchema.safeParse` inside
+    // `parseStatusQuery`, so the filter is silently dropped rather than
+    // rejected — exercises the `parsed.success === false` branch.
+    const invalidStatus = await request(app)
+      .get('/api/v1/chats')
+      .query({ status: 'not-a-real-status' })
+      .set('authorization', `Bearer ${token}`);
+    expect(invalidStatus.status).toBe(200);
+    const invalidStatusIds = (invalidStatus.body.data as { id: string }[]).map((c) => c.id);
+    expect(invalidStatusIds).toEqual(expect.arrayContaining([pendingChatA.id, activeChatA.id]));
+  });
+
+  test('GET /:id returns a chat, and 404s for an unknown id', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('get-one');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id);
+    const token = await loginAs(app, staff.email, staff.password);
+
+    const found = await request(app)
+      .get(`/api/v1/chats/${chat.id}`)
+      .set('authorization', `Bearer ${token}`);
+    expect(found.status).toBe(200);
+    expect(found.body.data.id).toBe(chat.id);
+
+    const missing = await request(app)
+      .get(`/api/v1/chats/${randomUUID()}`)
+      .set('authorization', `Bearer ${token}`);
+    expect(missing.status).toBe(404);
+  });
+
+  test('POST /:id/accept assigns a pending chat and reassigns an already-active one', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('accept');
+    const second = await seedStaff(staff.tenantId, 'accept-second');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id, { status: 'pending' });
+    const token = await loginAs(app, staff.email, staff.password);
+    const secondToken = await loginAs(app, second.email, second.password);
+    const staffUser = await User.findOne({ where: { email: staff.email } });
+    const secondUser = await User.findOne({ where: { email: second.email } });
+
+    const firstAccept = await request(app)
+      .post(`/api/v1/chats/${chat.id}/accept`)
+      .set('authorization', `Bearer ${token}`);
+    expect(firstAccept.status).toBe(200);
+    expect(firstAccept.body.data.status).toBe('active');
+    expect(firstAccept.body.data.assignedTo).toBe(staffUser?.id);
+
+    // Chat is already active: the `status === 'pending'` branch in
+    // `assign()` is NOT retaken, only `assignedTo` changes.
+    const secondAccept = await request(app)
+      .post(`/api/v1/chats/${chat.id}/accept`)
+      .set('authorization', `Bearer ${secondToken}`);
+    expect(secondAccept.status).toBe(200);
+    expect(secondAccept.body.data.status).toBe('active');
+    expect(secondAccept.body.data.assignedTo).toBe(secondUser?.id);
+
+    const missing = await request(app)
+      .post(`/api/v1/chats/${randomUUID()}/accept`)
+      .set('authorization', `Bearer ${token}`);
+    expect(missing.status).toBe(404);
+  });
+
+  test('POST /:id/end transitions status by endedBy and is idempotent once ended', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('end');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const supportEndedChat = await seedChat(staff.tenantId, visitor.id, { status: 'active' });
+    const customerEndedChat = await seedChat(staff.tenantId, visitor.id, { status: 'active' });
+    const token = await loginAs(app, staff.email, staff.password);
+
+    const supportEnd = await request(app)
+      .post(`/api/v1/chats/${supportEndedChat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    expect(supportEnd.status).toBe(200);
+    expect(supportEnd.body.data.status).toBe('ended_by_support');
+    expect(supportEnd.body.data.endedAt).not.toBeNull();
+
+    const customerEnd = await request(app)
+      .post(`/api/v1/chats/${customerEndedChat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'customer' });
+    expect(customerEnd.status).toBe(200);
+    expect(customerEnd.body.data.status).toBe('ended_by_customer');
+
+    // Re-fetch from the DB rather than trusting the first response's
+    // in-memory Date: MySQL's DATETIME column truncates sub-second
+    // precision on write, so the persisted value differs from the
+    // millisecond-precise value the first response echoed back.
+    const persisted = await request(app)
+      .get(`/api/v1/chats/${customerEndedChat.id}`)
+      .set('authorization', `Bearer ${token}`);
+    const endedAtFirst = persisted.body.data.endedAt as string;
+
+    // Already-ended: `endChat()`'s `chat.endedAt !== null` early-return
+    // branch — status and endedAt must stay exactly as they were, even
+    // though this call asks for a different `endedBy`.
+    const secondEnd = await request(app)
+      .post(`/api/v1/chats/${customerEndedChat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    expect(secondEnd.status).toBe(200);
+    expect(secondEnd.body.data.status).toBe('ended_by_customer');
+    expect(secondEnd.body.data.endedAt).toBe(endedAtFirst);
+
+    const missing = await request(app)
+      .post(`/api/v1/chats/${randomUUID()}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    expect(missing.status).toBe(404);
+  });
+
+  test('GET /:id/messages returns the transcript ordered by deliveredAt, not insertion order', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('messages');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id, { status: 'active' });
+    const token = await loginAs(app, staff.email, staff.password);
+    const base = Date.now();
+
+    await seedMessage(chat.id, 'third', new Date(base + 2000));
+    await seedMessage(chat.id, 'first', new Date(base));
+    await seedMessage(chat.id, 'second', new Date(base + 1000));
+
+    const res = await request(app)
+      .get(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const bodies = (res.body.data as { body: string }[]).map((m) => m.body);
+    expect(bodies).toEqual(['first', 'second', 'third']);
+  });
+
+  test('POST /:id/messages activates a pending chat on first reply and assigns the sender', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const staff = await seedTenantAndStaff('activate');
+    const second = await seedStaff(staff.tenantId, 'activate-second');
+    const visitor = await seedVisitorSession(staff.tenantId);
+    const chat = await seedChat(staff.tenantId, visitor.id, {
+      status: 'pending',
+      assignedTo: null,
+    });
+    const token = await loginAs(app, staff.email, staff.password);
+    const secondToken = await loginAs(app, second.email, second.password);
+    const staffUser = await User.findOne({ where: { email: staff.email } });
+
+    const firstReply = await request(app)
+      .post(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ body: 'how can I help?' });
+    expect(firstReply.status).toBe(201);
+
+    const afterFirst = await Chat.findByPk(chat.id);
+    expect(afterFirst?.status).toBe('active');
+    expect(afterFirst?.assignedTo).toBe(staffUser?.id);
+
+    // Chat is already active: the `status === 'pending'` branch in
+    // `sendMessage()` is NOT retaken, so a second staffer's reply does not
+    // steal the assignment.
+    const secondReply = await request(app)
+      .post(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${secondToken}`)
+      .send({ body: 'still here' });
+    expect(secondReply.status).toBe(201);
+
+    const afterSecond = await Chat.findByPk(chat.id);
+    expect(afterSecond?.status).toBe('active');
+    expect(afterSecond?.assignedTo).toBe(staffUser?.id);
+
+    // Ending the chat then replying hits `sendMessage()`'s
+    // `chat.endedAt !== null` "chat has ended" rejection branch.
+    await request(app)
+      .post(`/api/v1/chats/${chat.id}/end`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ endedBy: 'support' });
+    const afterEndReply = await request(app)
+      .post(`/api/v1/chats/${chat.id}/messages`)
+      .set('authorization', `Bearer ${token}`)
+      .send({ body: 'too late' });
+    expect(afterEndReply.status).toBe(400);
+  });
+});

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -1,0 +1,397 @@
+import { io as ioClient, type Socket } from 'socket.io-client';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { Tenant, User } from '../../src/models/index.js';
+
+import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+
+const STAFF_PASSWORD = 'Staff!Password1';
+
+/**
+ * Create a tenant + one staff user attached to it, and return the tenant id.
+ * @param tenantSlug - Unique tenant slug.
+ * @param email - Staff login email.
+ * @returns The new tenant's id.
+ */
+async function seedTenantAndStaff(
+  tenantSlug: string,
+  email: string,
+): Promise<{ tenantId: string }> {
+  const tenant = await Tenant.create({
+    name: `Tenant-${tenantSlug}`,
+    slug: tenantSlug,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+  await User.create({
+    email,
+    passwordHash: STAFF_PASSWORD,
+    firstName: 'St',
+    lastName: 'Aff',
+    role: 'staff',
+    tenantId: tenant.id,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { tenantId: tenant.id };
+}
+
+/**
+ * Log in a staff user over HTTP and return the access token.
+ * @param baseUrl - Live harness base URL.
+ * @param email - Login email.
+ * @param password - Login password.
+ * @returns The bearer access token.
+ */
+async function loginAs(baseUrl: string, email: string, password: string): Promise<string> {
+  const res = await request(baseUrl).post('/api/v1/auth/login').send({ email, password });
+  expect(res.status).toBe(200);
+  return res.body.data.accessToken as string;
+}
+
+/**
+ * Init a visitor session over HTTP and return the raw cookie value + session id.
+ * @param baseUrl - Live harness base URL.
+ * @param tenantSlug - Tenant to attach the session to.
+ * @returns The raw `livechat_visitor` cookie value plus the session id.
+ */
+async function initVisitor(
+  baseUrl: string,
+  tenantSlug: string,
+): Promise<{ cookie: string; sessionId: string }> {
+  const res = await request(baseUrl)
+    .post('/api/v1/visitor/session')
+    .send({ tenantKey: tenantSlug });
+  expect(res.status).toBe(201);
+  const setCookie = res.headers['set-cookie'] as string | string[] | undefined;
+  const cookies: string[] = Array.isArray(setCookie)
+    ? setCookie
+    : setCookie === undefined
+      ? []
+      : [setCookie];
+  const visitorCookie = cookies.find((c) => c.startsWith('livechat_visitor='));
+  const cookie = visitorCookie?.split(';')[0]?.replace('livechat_visitor=', '') ?? '';
+  return { cookie, sessionId: res.body.data.sessionId as string };
+}
+
+function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`timeout waiting for ${event}`));
+    }, timeoutMs);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timer);
+      resolve(payload);
+    });
+  });
+}
+
+describe('visitor namespace + visitor routes (integration)', () => {
+  let harness: LiveTestHarness | null = null;
+
+  beforeAll(async () => {
+    harness = await probeLiveHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  test('connection is rejected without any cookie', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const socket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const err = await waitFor<Error>(socket, 'connect_error');
+    expect(err.message).toContain('Visitor cookie required');
+    socket.disconnect();
+  }, 10_000);
+
+  test('connection is rejected with a garbage cookie', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const socket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: 'not-a-real-cookie-value' },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const err = await waitFor<Error>(socket, 'connect_error');
+    expect(err.message).toContain('Invalid visitor cookie');
+    socket.disconnect();
+  }, 10_000);
+
+  test('connection accepts the cookie carried on the raw header instead of auth', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('typing-hdr', 'hdr-staff@typing.example');
+    const { cookie } = await initVisitor(baseUrl, 'typing-hdr');
+    const socket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      transports: ['websocket'],
+      forceNew: true,
+      extraHeaders: { cookie: `livechat_visitor=${cookie}` },
+    });
+    await waitFor(socket, 'connect');
+    socket.disconnect();
+  }, 10_000);
+
+  test('chat:typing fans out to the chat room and the staff namespace', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('typing', 'staff@typing.example');
+    const accessToken = await loginAs(baseUrl, 'staff@typing.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie } = await initVisitor(baseUrl, 'typing');
+
+    const initRes = await request(baseUrl)
+      .post('/api/v1/visitor/chats')
+      .set('cookie', `livechat_visitor=${visitorCookie}`)
+      .send({ customerName: 'Typer', body: 'hello' });
+    expect(initRes.status).toBe(201);
+    const chatId = initRes.body.data.chat.id as string;
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await Promise.all([waitFor(staffSocket, 'connect'), waitFor(visitorSocket, 'connect')]);
+    visitorSocket.emit('chat:join', { chatId });
+    // Staff only joins the `chat:{id}` room on accept — chat:typing (unlike
+    // chat:message) is not also mirrored to the tenant room, so without this
+    // the staff socket never sees it.
+    staffSocket.emit('chat:accept', { chatId });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const otherVisitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(otherVisitorSocket, 'connect');
+    otherVisitorSocket.emit('chat:join', { chatId });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const staffSeesTyping = waitFor<{ chatId: string; actor: string; isTyping: boolean }>(
+      staffSocket,
+      'chat:typing',
+    );
+    const roommateSeesTyping = waitFor<{ chatId: string; actor: string; isTyping: boolean }>(
+      otherVisitorSocket,
+      'chat:typing',
+    );
+    visitorSocket.emit('chat:typing', { chatId, isTyping: true });
+    const [staffTyping, roommateTyping] = await Promise.all([staffSeesTyping, roommateSeesTyping]);
+    expect(staffTyping.chatId).toBe(chatId);
+    expect(staffTyping.actor).toBe('visitor');
+    expect(staffTyping.isTyping).toBe(true);
+    expect(roommateTyping.actor).toBe('visitor');
+
+    staffSocket.disconnect();
+    visitorSocket.disconnect();
+    otherVisitorSocket.disconnect();
+  }, 30_000);
+
+  test('visitor chat:end ends the chat as customer and notifies staff', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('vend', 'staff@vend.example');
+    const accessToken = await loginAs(baseUrl, 'staff@vend.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie } = await initVisitor(baseUrl, 'vend');
+
+    const initRes = await request(baseUrl)
+      .post('/api/v1/visitor/chats')
+      .set('cookie', `livechat_visitor=${visitorCookie}`)
+      .send({ customerName: 'Ender', body: 'bye soon' });
+    expect(initRes.status).toBe(201);
+    const chatId = initRes.body.data.chat.id as string;
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await Promise.all([waitFor(staffSocket, 'connect'), waitFor(visitorSocket, 'connect')]);
+    visitorSocket.emit('chat:join', { chatId });
+    staffSocket.emit('chat:accept', { chatId });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const staffSeesEnd = waitFor<{ chatId: string; endedBy: string }>(staffSocket, 'chat:ended');
+    visitorSocket.emit('chat:end', { chatId });
+    const ended = await staffSeesEnd;
+    expect(ended.chatId).toBe(chatId);
+    expect(ended.endedBy).toBe('customer');
+
+    staffSocket.disconnect();
+    visitorSocket.disconnect();
+  }, 30_000);
+
+  test('visitor:page_changed fans out to the tenant staff room', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('pagechange', 'staff@pagechange.example');
+    const accessToken = await loginAs(baseUrl, 'staff@pagechange.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'pagechange');
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(staffSocket, 'connect');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(visitorSocket, 'connect');
+
+    const staffSeesPageChange = waitFor<{ visitorSessionId: string; currentUrl: string }>(
+      staffSocket,
+      'visitor:page_changed',
+    );
+    visitorSocket.emit('visitor:page_changed', { currentUrl: 'https://example.com/pricing' });
+    const evt = await staffSeesPageChange;
+    expect(evt.visitorSessionId).toBe(sessionId);
+    expect(evt.currentUrl).toBe('https://example.com/pricing');
+
+    staffSocket.disconnect();
+    visitorSocket.disconnect();
+  }, 30_000);
+
+  test('visitor disconnect removes presence and notifies staff visitor:left', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('leaving', 'staff@leaving.example');
+    const accessToken = await loginAs(baseUrl, 'staff@leaving.example', STAFF_PASSWORD);
+    const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'leaving');
+
+    const staffSocket: Socket = ioClient(`${baseUrl}/staff`, {
+      path: '/api/socket.io',
+      auth: { token: accessToken },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(staffSocket, 'connect');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
+      path: '/api/socket.io',
+      auth: { cookie: visitorCookie },
+      transports: ['websocket'],
+      forceNew: true,
+    });
+    await waitFor(visitorSocket, 'connect');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const staffSeesLeft = waitFor<{ tenantId: string; visitorSessionId: string }>(
+      staffSocket,
+      'visitor:left',
+    );
+    visitorSocket.disconnect();
+    const evt = await staffSeesLeft;
+    expect(evt.visitorSessionId).toBe(sessionId);
+
+    staffSocket.disconnect();
+  }, 30_000);
+
+  test('POST /visitor/session persists the optional language/currentUrl/referrer fields', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('optfields', 'staff@optfields.example');
+    const res = await request(baseUrl).post('/api/v1/visitor/session').send({
+      tenantKey: 'optfields',
+      language: 'en-US',
+      currentUrl: 'https://example.com/landing',
+      referrer: 'https://google.com/search',
+    });
+    expect(res.status).toBe(201);
+
+    const { VisitorSession } = await import('../../src/models/index.js');
+    const session = await VisitorSession.findByPk(res.body.data.sessionId as string);
+    expect(session?.language).toBe('en-US');
+    expect(session?.currentUrl).toBe('https://example.com/landing');
+    expect(session?.referrer).toBe('https://google.com/search');
+  });
+
+  test('POST /visitor/heartbeat without a cookie is unauthorized', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const res = await request(baseUrl).post('/api/v1/visitor/heartbeat').send({});
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('POST /visitor/heartbeat with a valid cookie updates the session and returns 200', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('heartbeat', 'staff@heartbeat.example');
+    const { cookie } = await initVisitor(baseUrl, 'heartbeat');
+
+    const res = await request(baseUrl)
+      .post('/api/v1/visitor/heartbeat')
+      .set('cookie', `livechat_visitor=${cookie}`)
+      .send({ currentUrl: 'https://example.com/heartbeat' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('GET /visitor/chats/current without a cookie is unauthorized', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    const res = await request(baseUrl).get('/api/v1/visitor/chats/current');
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /visitor/chats/current returns null chat + empty messages when none exists', async () => {
+    if (harness === null) return;
+    const { baseUrl } = harness;
+    await seedTenantAndStaff('nochat', 'staff@nochat.example');
+    const { cookie } = await initVisitor(baseUrl, 'nochat');
+
+    const res = await request(baseUrl)
+      .get('/api/v1/visitor/chats/current')
+      .set('cookie', `livechat_visitor=${cookie}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.chat).toBeNull();
+    expect(res.body.data.messages).toEqual([]);
+  });
+});

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.d.ts', 'src/reset.d.ts', 'src/server.ts', 'src/config/index.ts'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/reset.d.ts',
+        // Process entrypoints: they wire the app together and run on boot, so
+        // exercising them proves nothing the integration suite does not.
+        'src/server.ts',
+        'src/config/index.ts',
+        // Operator CLI scripts, run by hand against a real database.
+        'src/scripts/**',
+      ],
       thresholds: {
         lines: 80,
         statements: 80,

--- a/e2e/setup-and-serve-api.sh
+++ b/e2e/setup-and-serve-api.sh
@@ -13,28 +13,55 @@ ROOT_PASS="${DB_ROOT_PASS:-livechat_root_pass}"
 
 docker compose up -d mysql redis mailhog
 
-# Retry the provisioning statement itself rather than probing first and acting
-# after. On a fresh volume (CI) the entrypoint runs a temporary server during
-# init: it answers `mysqladmin ping`, and even a root `SELECT 1`, then shuts
-# down before the real server starts. So a probe that passes is no guarantee
-# the *next* command finds a live socket — that window is how this failed with
-# "ERROR 2002: Can't connect to local MySQL server through socket". Making the
-# idempotent CREATE/GRANT the readiness check closes it.
-echo "e2e: waiting for MySQL and provisioning ${DB_NAME}…"
-deadline=$(( SECONDS + 120 ))
-until docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
-  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
-   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;" >/dev/null 2>&1; do
+# On a fresh volume (CI) the entrypoint runs a *temporary* server during init.
+# It answers `mysqladmin ping`, a root `SELECT 1`, and even `CREATE DATABASE` —
+# then shuts down before the real server starts, killing any connection opened
+# in that window (`PROTOCOL_CONNECTION_LOST`). Retrying a single statement is
+# not sufficient, because the statement can succeed against the temporary
+# server; the init phase has to be observed to completion first. The image logs
+# "Temporary server started" on entry and "MySQL init process done" on exit, so
+# wait for the latter whenever the former appears. An existing volume logs
+# neither and falls straight through to the connectivity check.
+mysql_ready() {
+  local logs
+  logs=$(docker logs livechat-mysql 2>&1 || true)
+  if grep -q 'Temporary server started' <<<"$logs" \
+    && ! grep -q 'MySQL init process done' <<<"$logs"; then
+    return 1
+  fi
+  docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e 'SELECT 1' >/dev/null 2>&1
+}
+
+echo "e2e: waiting for MySQL…"
+deadline=$(( SECONDS + 180 ))
+until mysql_ready; do
   if [ "$SECONDS" -ge "$deadline" ]; then
-    echo "e2e: MySQL did not become ready within 120s" >&2
+    echo "e2e: MySQL did not become ready within 180s" >&2
     docker logs --tail 50 livechat-mysql >&2 || true
     exit 1
   fi
   sleep 1
 done
 
+echo "e2e: provisioning ${DB_NAME}…"
+docker exec livechat-mysql mysql -uroot "-p${ROOT_PASS}" -e \
+  "CREATE DATABASE IF NOT EXISTS ${DB_NAME}; \
+   GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"
+
+# Belt and braces: the seed drops every table and replays the migrations, so it
+# is safe to repeat, and a connection dropped mid-migration should not fail the
+# whole run.
 echo "e2e: seeding ${DB_NAME}…"
-node_modules/.bin/tsx e2e/support/seed.ts
+seed_attempt=1
+until node_modules/.bin/tsx e2e/support/seed.ts; do
+  if [ "$seed_attempt" -ge 3 ]; then
+    echo "e2e: seeding failed after ${seed_attempt} attempts" >&2
+    exit 1
+  fi
+  echo "e2e: seed attempt ${seed_attempt} failed; retrying…" >&2
+  seed_attempt=$(( seed_attempt + 1 ))
+  sleep 3
+done
 
 # Deterministic availability: start with no staff available so the journey
 # suite controls it via real agent sockets (reconnecting agents re-add

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "workspaces": [
         "shared",
         "api",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "test:api": "npm --workspace api run test",
     "test:ui": "npm --workspace ui run test:unit",
     "test:widget": "npm --workspace widget run test:unit",
+    "test:coverage": "npm --workspace api run test:coverage",
+    "test:ci": "npm-run-all -s test:shared test:coverage test:ui test:widget",
     "test:e2e": "npm-run-all -s usecases:generate test:e2e:journeys test:e2e:ui test:e2e:widget",
     "test:e2e:ui": "npm --workspace ui run test:e2e",
     "test:e2e:widget": "npm --workspace widget run test:e2e",
@@ -97,7 +99,7 @@
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "license-checker-rseidelsohn --production --csv --out reports/licenses.csv",
     "check": "npm-run-all -p lint typecheck stylelint markdownlint usecases:validate",
-    "check:all": "npm-run-all -s check test build size dupes links security license:check",
+    "check:all": "npm-run-all -s check test:ci build size dupes links security license:check",
     "ci": "npm run check:all",
     "test:e2e:journeys": "npm --workspace @livechat/e2e run test"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",


### PR DESCRIPTION
Patch release. No `feat`, no breaking changes. **Contains a security fix — worth shipping promptly.**

### 🔒 Security — REST tenant isolation ([#43], [#44])
`main` currently lets a tenant-scoped `admin`/`staff` reach **another tenant's** chats, users and tenants over HTTP:
- list endpoints filtered on a caller-supplied `?tenantId` — omitting it returned **every** tenant's rows
- by-id routes never compared the record's tenant to the caller's, so cross-tenant `PATCH /users/:id`, `accept`, `end` and `send message` all worked

`requireTenantAccess()` existed but was dead code, and would not have helped if wired up — it returned early for `super_admin`/`admin`/`staff`, so it only ever constrained `client`. Replaced with `callerTenantScope()` / `assertTenantAccess()` / `resolveTenantFilter()`, keyed on the caller's own `tenant_id` rather than their role.

Lists are pinned to the caller's tenant; naming another tenant is a 403, not a silent rewrite. Untenanted AFixt staff still span every tenant, per the #19 decision.

The Socket.IO layer was already isolated — one layer tested, the adjacent one not, the same shape as the migration drift fixed in 0.1.1.

### Fixed ([#44])
The e2e stack no longer fails on a fresh MySQL volume. The entrypoint's temporary init server accepts `CREATE DATABASE`, so the readiness gate could pass against it and the real server would then drop the seed's connection mid-migration. Setup now waits out the init phase and retries the seed.

### Changed ([#42])
Coverage thresholds are now **enforced** — `check:all` ran `test`, not `test:coverage`, so the 80/75/80/80 bar was decorative. Coverage went from 64.30/39.53/73.99/69.11 to **93.24/80.89/98.64/96.65**, and the api suite from **22 to 197 tests**.

### Verified
`check:all` exits 0 with thresholds enforced; 197 api tests; all 18 e2e specs (8 journeys + 8 ui + 2 widget) green.

### Known, not addressed
`audit-service.record()` still has no call sites, so tenant denials, logins and admin actions are not audit-logged.

https://github.com/AFixt/livechat/compare/v0.1.1...develop

[#42]: https://github.com/AFixt/livechat/pull/42
[#43]: https://github.com/AFixt/livechat/issues/43
[#44]: https://github.com/AFixt/livechat/pull/44