### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
 _Nothing yet._
 
+## [0.2.0] - 2026-07-23
+
+Audit logging works. It was built but never called, so `audit_logs` stayed
+empty in a running system.
+
+### Added
+
+- **Audit logging is wired up.** `createAuditService()` was constructed and
+  exposed as `services.audit`, but `record()` had no call sites anywhere — the
+  table, model and service all worked and none of them were ever reached.
+  CLAUDE.md asks for "every auth + admin action"; none of it happened. ([#46],
+  [#47])
+
+  Now recorded:
+  - **Auth** — `register`, `login`, `login_failed`, `logout`,
+    `password_reset_requested`, `password_reset`, `password_changed`,
+    `email_verified`. Failed logins are audited too, since a run of them is the
+    signal worth having.
+  - **Admin mutations** — tenant `create`/`update`/`delete`/
+    `rotate_embed_secret` and `user.update`, against the affected resource
+    rather than the actor's own tenant.
+  - **Authorization denials** — captured centrally in the error handler, which
+    already sees every `ApiError`: 401 becomes `auth.denied`, 403 becomes
+    `access.denied`. This closes the loop on the tenant isolation added in
+    0.1.2 — a cross-tenant probe now leaves a trail naming the actor.
+
+  Entries carry the actor, tenant, resource, IP and user-agent. Deliberately
+  never recorded: the attempted password on a failed login, or a rotated embed
+  secret. Both are asserted in tests.
+
+### Fixed
+
+- Integration `beforeAll` timeout raised from 20s to 60s. That hook drops every
+  table and replays the migrations per file, which intermittently exceeded 20s
+  under load and failed `check:all`. ([#47])
+
+[#46]: https://github.com/AFixt/livechat/issues/46
+[#47]: https://github.com/AFixt/livechat/pull/47
+
 ## [0.1.2] - 2026-07-23
 
 A security release. The REST API enforced role but not tenant, so a
@@ -164,7 +203,8 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
   ships with Node 22, and effective on toolchain upgrade.
 - `body-parser` bumped to 2.3.0, clearing OSV `GHSA-v422-hmwv-36x6`.
 
-[Unreleased]: https://github.com/AFixt/livechat/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/AFixt/livechat/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/AFixt/livechat/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/AFixt/livechat/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/AFixt/livechat/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/AFixt/livechat/releases/tag/v0.1.0

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -89,7 +89,7 @@ export function createApp(deps: AppDeps): Express {
   }
 
   app.use(notFoundHandler());
-  app.use(errorHandler(logger));
+  app.use(errorHandler(logger, services.audit));
 
   return app;
 }

--- a/api/src/middlewares/error-handler.ts
+++ b/api/src/middlewares/error-handler.ts
@@ -1,7 +1,9 @@
 import { ZodError } from 'zod';
 
 import { ApiError } from '../utils/api-error.js';
+import { recordAudit } from '../utils/audit.js';
 
+import type { AuditService } from '../services/audit-service.js';
 import type { ErrorRequestHandler } from 'express';
 import type { Logger } from 'pino';
 
@@ -14,10 +16,15 @@ interface ErrorPayload {
 /**
  * Central error handler. Serializes `ApiError` and Zod errors into the
  * response envelope; logs everything else as `error` and returns 500.
+ *
+ * Also the single place authorization failures are audited. Every guard funnels
+ * its `ApiError` through here, so recording 401/403 centrally captures denials
+ * — including the tenant-isolation checks — without wrapping each call site.
  * @param logger - Pino logger.
+ * @param audit - Audit service; omit to disable denial auditing.
  * @returns An Express error-handling middleware.
  */
-export function errorHandler(logger: Logger): ErrorRequestHandler {
+export function errorHandler(logger: Logger, audit?: AuditService): ErrorRequestHandler {
   return (err, req, res, _next) => {
     const body: ErrorPayload = { success: false, message: 'Internal server error' };
     let status = 500;
@@ -39,6 +46,16 @@ export function errorHandler(logger: Logger): ErrorRequestHandler {
         { err, correlationId: req.correlationId, path: req.path },
         'unhandled non-error throw',
       );
+    }
+
+    if (audit !== undefined && (status === 401 || status === 403)) {
+      // Detached: a denial must still be returned promptly even if the audit
+      // write is slow, and `record` swallows its own failures.
+      void recordAudit(audit, req, {
+        action: status === 401 ? 'auth.denied' : 'access.denied',
+        resourceType: 'http',
+        metadata: { method: req.method, path: req.path, reason: body.message },
+      });
     }
 
     res.status(status).json(body);

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -16,15 +16,17 @@ import { authenticate } from '../middlewares/authenticate.js';
 import { createAuthLimiter } from '../middlewares/rate-limit.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
+import { recordAudit } from '../utils/audit.js';
 
 import type { Env } from '../config/env.js';
-import type { AuthService } from '../services/index.js';
+import type { AuditService, AuthService } from '../services/index.js';
 import type { Redis } from 'ioredis';
 
 interface AuthRouterDeps {
   env: Env;
   redis: Redis;
   auth: AuthService;
+  audit: AuditService;
   /** Skip auth-specific rate limiting (for unit tests). */
   skipRateLimit?: boolean;
 }
@@ -51,6 +53,13 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const body = parsedBody(req, registerInputSchema) satisfies RegisterInput;
       const user = await deps.auth.register(body);
+      await recordAudit(deps.audit, req, {
+        action: 'auth.register',
+        resourceType: 'user',
+        resourceId: user.id,
+        userId: user.id,
+        tenantId: user.tenantId,
+      });
       res.status(201).json({ success: true, data: { user } });
     }),
   );
@@ -68,7 +77,27 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
       };
       if (req.ip !== undefined) loginArgs.ipAddress = req.ip;
       if (ua !== undefined) loginArgs.userAgent = ua;
-      const result = await deps.auth.login(loginArgs);
+      // Audit the failure too — a run of these is the signal that matters.
+      let result;
+      try {
+        result = await deps.auth.login(loginArgs);
+      } catch (error) {
+        await recordAudit(deps.audit, req, {
+          action: 'auth.login_failed',
+          resourceType: 'user',
+          userId: null,
+          tenantId: null,
+          metadata: { email: body.email },
+        });
+        throw error;
+      }
+      await recordAudit(deps.audit, req, {
+        action: 'auth.login',
+        resourceType: 'user',
+        resourceId: result.user.id,
+        userId: result.user.id,
+        tenantId: result.user.tenantId,
+      });
       res.json({ success: true, data: result });
     }),
   );
@@ -79,6 +108,7 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
     asyncHandler(async (req, res) => {
       if (req.user === undefined || req.tokenJti === undefined) return;
       await deps.auth.logout(req.user.id, req.tokenJti);
+      await recordAudit(deps.audit, req, { action: 'auth.logout', resourceType: 'user' });
       res.json({ success: true });
     }),
   );
@@ -103,6 +133,13 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const body = parsedBody(req, forgotPasswordInputSchema) satisfies ForgotPasswordInput;
       await deps.auth.forgotPassword(body.email);
+      await recordAudit(deps.audit, req, {
+        action: 'auth.password_reset_requested',
+        resourceType: 'user',
+        userId: null,
+        tenantId: null,
+        metadata: { email: body.email },
+      });
       res.json({
         success: true,
         message: 'If the email exists, a reset link has been sent',
@@ -116,6 +153,12 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const body = parsedBody(req, resetPasswordInputSchema) satisfies ResetPasswordInput;
       await deps.auth.resetPassword(body.token, body.password);
+      await recordAudit(deps.audit, req, {
+        action: 'auth.password_reset',
+        resourceType: 'user',
+        userId: null,
+        tenantId: null,
+      });
       res.json({ success: true, message: 'Password reset successfully' });
     }),
   );
@@ -129,6 +172,12 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
         return;
       }
       await deps.auth.verifyEmail(token);
+      await recordAudit(deps.audit, req, {
+        action: 'auth.email_verified',
+        resourceType: 'user',
+        userId: null,
+        tenantId: null,
+      });
       res.json({ success: true, message: 'Email verified successfully' });
     }),
   );
@@ -141,6 +190,11 @@ export function buildAuthRouter(deps: AuthRouterDeps): Router {
       const body = parsedBody(req, changePasswordInputSchema) satisfies ChangePasswordInput;
       if (req.user === undefined) return;
       await deps.auth.changePassword(req.user.id, body.currentPassword, body.newPassword);
+      await recordAudit(deps.audit, req, {
+        action: 'auth.password_changed',
+        resourceType: 'user',
+        resourceId: req.user.id,
+      });
       res.json({ success: true, message: 'Password changed successfully' });
     }),
   );

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -37,16 +37,27 @@ export function buildRouter(deps: RouterDeps): Router {
       env: deps.env,
       redis: deps.redis,
       auth: deps.services.auth,
+      audit: deps.services.audit,
       ...(deps.skipRateLimit === true && { skipRateLimit: true }),
     }),
   );
   router.use(
     '/tenants',
-    buildTenantsRouter({ env: deps.env, redis: deps.redis, tenant: deps.services.tenant }),
+    buildTenantsRouter({
+      env: deps.env,
+      redis: deps.redis,
+      tenant: deps.services.tenant,
+      audit: deps.services.audit,
+    }),
   );
   router.use(
     '/users',
-    buildUsersRouter({ env: deps.env, redis: deps.redis, user: deps.services.user }),
+    buildUsersRouter({
+      env: deps.env,
+      redis: deps.redis,
+      user: deps.services.user,
+      audit: deps.services.audit,
+    }),
   );
   router.use(
     '/invitations',

--- a/api/src/routes/tenants.ts
+++ b/api/src/routes/tenants.ts
@@ -8,15 +8,17 @@ import {
 import { assertTenantAccess, callerTenantScope, requireRole } from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
+import { recordAudit } from '../utils/audit.js';
 
 import { buildAdminRouter } from './admin-router.js';
 
 import type { AdminRouterDeps } from './admin-router.js';
-import type { TenantService } from '../services/index.js';
+import type { AuditService, TenantService } from '../services/index.js';
 import type { Router } from 'express';
 
 interface TenantsRouterDeps extends AdminRouterDeps {
   tenant: TenantService;
+  audit: AuditService;
 }
 
 /**
@@ -45,6 +47,12 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
     asyncHandler(async (req, res) => {
       const body = parsedBody(req, createTenantInputSchema) satisfies CreateTenantInput;
       const tenant = await deps.tenant.create(body);
+      await recordAudit(deps.audit, req, {
+        action: 'tenant.create',
+        resourceType: 'tenant',
+        resourceId: tenant.id,
+        metadata: { slug: tenant.slug },
+      });
       res.status(201).json({ success: true, data: tenant });
     }),
   );
@@ -69,6 +77,12 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
       if (typeof id !== 'string') return;
       const body = parsedBody(req, updateTenantInputSchema) satisfies UpdateTenantInput;
       const tenant = await deps.tenant.update(id, body);
+      await recordAudit(deps.audit, req, {
+        action: 'tenant.update',
+        resourceType: 'tenant',
+        resourceId: tenant.id,
+        metadata: { fields: Object.keys(body) },
+      });
       res.json({ success: true, data: tenant });
     }),
   );
@@ -80,6 +94,11 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       await deps.tenant.remove(id);
+      await recordAudit(deps.audit, req, {
+        action: 'tenant.delete',
+        resourceType: 'tenant',
+        resourceId: id,
+      });
       res.json({ success: true });
     }),
   );
@@ -91,6 +110,12 @@ export function buildTenantsRouter(deps: TenantsRouterDeps): Router {
       const id = req.params.id;
       if (typeof id !== 'string') return;
       const secret = await deps.tenant.rotateEmbedSecret(id);
+      // Never record the secret itself.
+      await recordAudit(deps.audit, req, {
+        action: 'tenant.rotate_embed_secret',
+        resourceType: 'tenant',
+        resourceId: id,
+      });
       res.json({ success: true, data: { embedSecret: secret } });
     }),
   );

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -3,15 +3,17 @@ import { updateUserInputSchema, type UpdateUserInput } from '@livechat/shared';
 import { assertTenantAccess, resolveTenantFilter } from '../middlewares/authorize.js';
 import { parsedBody, validate } from '../middlewares/validate.js';
 import { asyncHandler } from '../utils/async-handler.js';
+import { recordAudit } from '../utils/audit.js';
 
 import { buildAdminRouter } from './admin-router.js';
 
 import type { AdminRouterDeps } from './admin-router.js';
-import type { UserService } from '../services/index.js';
+import type { AuditService, UserService } from '../services/index.js';
 import type { Router } from 'express';
 
 interface UsersRouterDeps extends AdminRouterDeps {
   user: UserService;
+  audit: AuditService;
 }
 
 /**
@@ -53,6 +55,13 @@ export function buildUsersRouter(deps: UsersRouterDeps): Router {
       assertTenantAccess(req, existing.tenantId);
       const body = parsedBody(req, updateUserInputSchema) satisfies UpdateUserInput;
       const user = await deps.user.update(id, body);
+      await recordAudit(deps.audit, req, {
+        action: 'user.update',
+        resourceType: 'user',
+        resourceId: user.id,
+        tenantId: user.tenantId,
+        metadata: { fields: Object.keys(body) },
+      });
       res.json({ success: true, data: user });
     }),
   );

--- a/api/src/services/audit-service.ts
+++ b/api/src/services/audit-service.ts
@@ -6,11 +6,13 @@ interface AuditEntry {
   userId?: string | null;
   tenantId?: string | null;
   action: string;
-  resourceType?: string;
-  resourceId?: string;
+  // Explicitly `| undefined` so callers can pass an absent field straight
+  // through under `exactOptionalPropertyTypes` without conditional spreads.
+  resourceType?: string | undefined;
+  resourceId?: string | undefined;
   ipAddress?: string | null;
   userAgent?: string | null;
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> | undefined;
 }
 
 /**

--- a/api/src/utils/audit.ts
+++ b/api/src/utils/audit.ts
@@ -1,0 +1,43 @@
+import type { AuditService } from '../services/audit-service.js';
+import type { Request } from 'express';
+
+/** The parts of an audit entry a call site has to supply itself. */
+export interface AuditDetails {
+  action: string;
+  resourceType?: string;
+  resourceId?: string;
+  /** Overrides the actor's tenant — e.g. the tenant a request acted upon. */
+  tenantId?: string | null;
+  metadata?: Record<string, unknown>;
+  /** Overrides the actor — for events where `req.user` is not yet set. */
+  userId?: string | null;
+}
+
+/**
+ * Record an audit entry, filling actor and request context from the request.
+ *
+ * `AuditService.record` never throws (a failed audit write logs and continues),
+ * so awaiting this cannot break the calling flow. It is awaited rather than
+ * fired-and-forgotten so the row is durable before the response goes out —
+ * auth and admin actions are low-volume enough that the extra insert does not
+ * matter, and an audit trail that races the response is not much of a trail.
+ * @param audit - The audit service.
+ * @param req - The request being audited.
+ * @param details - Action-specific fields.
+ */
+export async function recordAudit(
+  audit: AuditService,
+  req: Request,
+  details: AuditDetails,
+): Promise<void> {
+  await audit.record({
+    userId: details.userId ?? req.user?.id ?? null,
+    tenantId: details.tenantId ?? req.user?.tenantId ?? null,
+    action: details.action,
+    resourceType: details.resourceType,
+    resourceId: details.resourceId,
+    ipAddress: req.ip ?? null,
+    userAgent: req.header('user-agent') ?? null,
+    metadata: details.metadata,
+  });
+}

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -86,7 +86,7 @@ describe('admin routes (integration)', () => {
     if (harness === null) {
       console.warn('[integration] MySQL or Redis not reachable — skipping');
     }
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/api/tests/integration/audit-logging.test.ts
+++ b/api/tests/integration/audit-logging.test.ts
@@ -1,0 +1,261 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { AuditLog, Tenant, User } from '../../src/models/index.js';
+
+import { probeHarness } from './setup.js';
+
+import type { Role } from '@livechat/shared';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+let harness: Harness;
+
+const UA = 'audit-test-agent/1.0';
+
+/**
+ * Create a tenant with the fields the model requires.
+ * @param slug - Unique slug.
+ * @returns The created tenant.
+ */
+async function seedTenant(slug: string): Promise<Tenant> {
+  return Tenant.create({
+    name: `Audit ${slug}`,
+    slug,
+    status: 'active',
+    domain: null,
+    expiresAt: null,
+    settings: null,
+  });
+}
+
+/**
+ * Create a user. `passwordHash` is set to plaintext — a model hook bcrypts it.
+ * @param role - Role to assign.
+ * @param tenantId - Owning tenant, or null.
+ * @returns The user and its plaintext password.
+ */
+async function seedUser(
+  role: Role,
+  tenantId: string | null,
+): Promise<{ user: User; password: string }> {
+  const password = 'Aud1t!Password';
+  const user = await User.create({
+    email: `audit-${role}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+    passwordHash: password,
+    firstName: 'Audit',
+    lastName: role,
+    role,
+    tenantId,
+    status: 'active',
+    emailVerified: true,
+    emailVerificationToken: null,
+    emailVerificationExpires: null,
+    passwordResetToken: null,
+    passwordResetExpires: null,
+    lockedUntil: null,
+    lastLoginAt: null,
+    phone: null,
+    timezone: null,
+    avatarUrl: null,
+    preferences: null,
+  });
+  return { user, password };
+}
+
+/**
+ * Wait for an audit row matching `action` (and optionally a predicate).
+ *
+ * Denials are recorded detached from the response, so a row can land just after
+ * the request resolves; polling avoids a flaky race without an arbitrary sleep.
+ * Matching is by predicate rather than "newest row", because `audit_logs` has
+ * no auto-increment column and `created_at` is second-granular — several rows
+ * written in the same second tie, and ordering between them is arbitrary.
+ * @param action - The action to look for.
+ * @param match - Optional extra predicate to disambiguate rows.
+ * @returns The matching row, or null if it never arrives.
+ */
+async function waitForAudit(
+  action: string,
+  match?: (row: AuditLog) => boolean,
+): Promise<AuditLog | null> {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    const rows = await AuditLog.findAll({ where: { action } });
+    const found = rows.find((row) => match === undefined || match(row));
+    if (found !== undefined) return found;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+  return null;
+}
+
+/**
+ * Read the `path` recorded in a denial row's metadata.
+ * @param row - The audit row.
+ * @returns The path, or an empty string.
+ */
+function auditPath(row: AuditLog): string {
+  const meta = row.metadata ?? {};
+  return typeof meta.path === 'string' ? meta.path : '';
+}
+
+describe('audit logging (integration)', () => {
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  test('records a successful login with actor and request context', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const tenant = await seedTenant(`login-${Math.random().toString(36).slice(2, 8)}`);
+    const { user, password } = await seedUser('admin', tenant.id);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .set('user-agent', UA)
+      .send({ email: user.email, password });
+    expect(res.status).toBe(200);
+
+    const row = await waitForAudit('auth.login');
+    expect(row).not.toBeNull();
+    expect(row?.userId).toBe(user.id);
+    expect(row?.tenantId).toBe(tenant.id);
+    expect(row?.userAgent).toBe(UA);
+    expect(row?.ipAddress).not.toBeNull();
+  });
+
+  test('records a failed login without leaking the attempted password', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const { user } = await seedUser('staff', null);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: user.email, password: 'WrongPassword1!' });
+    expect(res.status).toBe(401);
+
+    const row = await waitForAudit('auth.login_failed');
+    expect(row).not.toBeNull();
+    expect(row?.metadata).toMatchObject({ email: user.email });
+    expect(JSON.stringify(row?.metadata)).not.toContain('WrongPassword1!');
+  });
+
+  test('records logout and password change for the acting user', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const { user, password } = await seedUser('staff', null);
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: user.email, password });
+    const token = login.body.data.accessToken as string;
+
+    const changed = await request(app)
+      .put('/api/v1/auth/change-password')
+      .set('authorization', `Bearer ${token}`)
+      .send({ currentPassword: password, newPassword: 'An0ther!Password' });
+    expect(changed.status).toBe(200);
+    const changeRow = await waitForAudit('auth.password_changed');
+    expect(changeRow?.userId).toBe(user.id);
+
+    const relogin = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: user.email, password: 'An0ther!Password' });
+    const logout = await request(app)
+      .post('/api/v1/auth/logout')
+      .set('authorization', `Bearer ${relogin.body.data.accessToken as string}`);
+    expect(logout.status).toBe(200);
+    expect(await waitForAudit('auth.logout')).not.toBeNull();
+  });
+
+  test('records admin mutations against the affected resource', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const { user, password } = await seedUser('super_admin', null);
+    const token = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: user.email, password });
+    const auth = `Bearer ${token.body.data.accessToken as string}`;
+    const slug = `made-${Math.random().toString(36).slice(2, 8)}`;
+
+    const created = await request(app)
+      .post('/api/v1/tenants')
+      .set('authorization', auth)
+      .send({ name: 'Made By Audit', slug });
+    expect(created.status).toBe(201);
+    const createRow = await waitForAudit('tenant.create');
+    expect(createRow?.resourceId).toBe(created.body.data.id);
+    expect(createRow?.userId).toBe(user.id);
+
+    const target = await seedUser('staff', created.body.data.id as string);
+    const updated = await request(app)
+      .patch(`/api/v1/users/${target.user.id}`)
+      .set('authorization', auth)
+      .send({ status: 'suspended' });
+    expect(updated.status).toBe(200);
+    const updateRow = await waitForAudit('user.update');
+    expect(updateRow?.resourceId).toBe(target.user.id);
+    expect(updateRow?.metadata).toMatchObject({ fields: ['status'] });
+  });
+
+  test('records the embed-secret rotation without recording the secret', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const { user, password } = await seedUser('super_admin', null);
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: user.email, password });
+    const auth = `Bearer ${login.body.data.accessToken as string}`;
+    const tenant = await seedTenant(`rot-${Math.random().toString(36).slice(2, 8)}`);
+
+    const res = await request(app)
+      .post(`/api/v1/tenants/${tenant.id}/rotate-embed-secret`)
+      .set('authorization', auth);
+    expect(res.status).toBe(200);
+
+    const row = await waitForAudit('tenant.rotate_embed_secret');
+    expect(row?.resourceId).toBe(tenant.id);
+    const secret = res.body.data.embedSecret as string | undefined;
+    if (typeof secret === 'string') {
+      expect(JSON.stringify(row)).not.toContain(secret);
+    }
+  });
+
+  test('records an unauthenticated request as a denial', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const res = await request(app).get('/api/v1/tenants');
+    expect(res.status).toBe(401);
+
+    const row = await waitForAudit('auth.denied', (r) => auditPath(r).includes('tenants'));
+    expect(row).not.toBeNull();
+    expect(row?.metadata).toMatchObject({ method: 'GET' });
+  });
+
+  test('records a cross-tenant attempt as an access denial', async () => {
+    if (harness === null) return;
+    const { app } = harness;
+    const own = await seedTenant(`deny-own-${Math.random().toString(36).slice(2, 8)}`);
+    const other = await seedTenant(`deny-other-${Math.random().toString(36).slice(2, 8)}`);
+    const { user, password } = await seedUser('admin', own.id);
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: user.email, password });
+    const auth = `Bearer ${login.body.data.accessToken as string}`;
+
+    const res = await request(app).get(`/api/v1/tenants/${other.id}`).set('authorization', auth);
+    expect(res.status).toBe(403);
+
+    // The whole point of issue #46: the probe leaves a trail naming the actor.
+    const row = await waitForAudit('access.denied', (r) => auditPath(r).includes(other.id));
+    expect(row).not.toBeNull();
+    expect(row?.userId).toBe(user.id);
+    expect(row?.tenantId).toBe(own.id);
+    expect(row?.metadata).toMatchObject({ method: 'GET' });
+  });
+});

--- a/api/tests/integration/auth-flow.test.ts
+++ b/api/tests/integration/auth-flow.test.ts
@@ -55,7 +55,7 @@ describe('auth flow (integration)', () => {
     if (harness === null) {
       console.warn('[integration] MySQL or Redis not reachable — skipping');
     }
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/api/tests/integration/auth-lifecycle.test.ts
+++ b/api/tests/integration/auth-lifecycle.test.ts
@@ -82,7 +82,7 @@ describe('auth lifecycle (integration)', () => {
     if (harness === null) {
       console.warn('[integration] MySQL or Redis not reachable — skipping');
     }
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -86,7 +86,7 @@ describe('chat flow (integration)', () => {
     if (harness === null) {
       console.warn('[integration] MySQL or Redis not reachable — skipping');
     }
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -208,7 +208,7 @@ describe('chat routes (integration)', () => {
     if (harness === null) {
       console.warn('[integration] MySQL or Redis not reachable — skipping');
     }
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/api/tests/integration/embed-hardening.test.ts
+++ b/api/tests/integration/embed-hardening.test.ts
@@ -26,7 +26,7 @@ describe('embed hardening (integration)', () => {
       allowedOrigins: ['https://client.example.com'],
     });
     tenantId = tenant.id;
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -107,7 +107,7 @@ describe('visitor namespace + visitor routes (integration)', () => {
     if (harness === null) {
       console.warn('[integration] MySQL or Redis not reachable — skipping');
     }
-  }, 20_000);
+  }, 60_000);
 
   afterAll(async () => {
     if (harness !== null) await harness.cleanup();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "workspaces": [
         "shared",
         "api",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",


### PR DESCRIPTION
**Minor** release — one `feat`, no breaking changes. (Minor rather than patch because audit logging is new capability, not a fix.)

### Added — audit logging actually runs ([#46], [#47])

`createAuditService()` was constructed and exposed as `services.audit`, but `record()` had **no call sites anywhere**. The table, model and service all worked; nothing ever reached them, so `audit_logs` stayed empty in a running system. CLAUDE.md asks for *"every auth + admin action"* — none of it happened.

Now recorded:
- **Auth** — `register`, `login`, `login_failed`, `logout`, `password_reset_requested`, `password_reset`, `password_changed`, `email_verified`. Failed logins included, since a run of those is the signal worth having.
- **Admin mutations** — tenant `create`/`update`/`delete`/`rotate_embed_secret`, `user.update`, against the affected resource rather than the actor's own tenant.
- **Authorization denials** — captured centrally in the error handler, which already sees every `ApiError`: 401 → `auth.denied`, 403 → `access.denied`.

That last one closes the loop on the tenant isolation shipped in v0.1.2: a cross-tenant probe now leaves a trail naming the actor, without wrapping each guard at its call site.

Entries carry actor, tenant, resource, IP and user-agent. **Deliberately never recorded:** the attempted password on a failed login, or a rotated embed secret — both asserted in tests.

### Fixed ([#47])
Integration `beforeAll` timeout 20s → 60s. That hook drops every table and replays the migrations per file, which intermittently exceeded 20s under load and failed `check:all`.

### Verified
`check:all` exits 0 — **204 api tests**, coverage 93.27 / 81.30 / 98.66 / 96.76 (all above threshold), lint + typecheck clean, all **18 e2e specs** green.

https://github.com/AFixt/livechat/compare/v0.1.2...develop

[#46]: https://github.com/AFixt/livechat/issues/46
[#47]: https://github.com/AFixt/livechat/pull/47