### PR TITLE
chore: skip the gate on tag-only pushes; assert real schema parity

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,28 @@
+# Git feeds this hook one line per ref being pushed:
+#   <local ref> <local sha> <remote ref> <remote sha>
+#
+# A tag-only push introduces no new commits — the commit being tagged already
+# passed this gate on its branch and again in CI — so re-running the full
+# check:all sweep only delays the release by 10-15 minutes. Skip it when every
+# ref being pushed is a tag.
+#
+# If no refs arrive on stdin (an invocation shape we don't recognise), fall
+# through and run the gate: the safe default is to check, not to skip.
+saw_ref=0
+only_tags=1
+
+while read -r local_ref _rest; do
+  [ -z "$local_ref" ] && continue
+  saw_ref=1
+  case "$local_ref" in
+    refs/tags/*) ;;
+    *) only_tags=0 ;;
+  esac
+done
+
+if [ "$saw_ref" = "1" ] && [ "$only_tags" = "1" ]; then
+  echo "pre-push: tag-only push — skipping check:all (no new commits)"
+  exit 0
+fi
+
 npm run check:all

--- a/api/tests/integration/schema-parity.test.ts
+++ b/api/tests/integration/schema-parity.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { resetSchemaFromMigrations } from '../../src/db/migrator.js';
+
+import { probeHarness } from './setup.js';
+
+import type { Sequelize } from 'sequelize';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+let harness: Harness;
+
+/** A column as the database reports it, reduced to what the ORM depends on. */
+interface ColumnShape {
+  type: string;
+  allowNull: boolean;
+}
+
+/** One table's structure, as introspected from a live database. */
+interface TableShape {
+  columns: Record<string, ColumnShape>;
+  /** Sorted "col_a+col_b" keys of the table's UNIQUE indexes. */
+  unique: string[];
+  /** Sorted "col_a+col_b" keys of the table's non-unique indexes. */
+  nonUnique: string[];
+}
+
+/** Sequelize's `showIndex` rows, narrowed to the fields used here. */
+interface IndexRow {
+  name: string;
+  unique: boolean;
+  fields?: { attribute: string }[];
+}
+
+/**
+ * Introspect every table in the connected database.
+ *
+ * Reads through the same MySQL information_schema in both directions, so types
+ * come back in MySQL's canonical form and are directly comparable rather than
+ * reflecting how each side happened to declare them.
+ * @param sequelize - Connection to introspect.
+ * @returns Table name to structure.
+ */
+async function introspect(sequelize: Sequelize): Promise<Record<string, TableShape>> {
+  const queryInterface = sequelize.getQueryInterface();
+  const tables = (await queryInterface.showAllTables()).filter((t) => t !== 'SequelizeMeta');
+  const out: Record<string, TableShape> = {};
+
+  for (const table of tables.sort()) {
+    const described = await queryInterface.describeTable(table);
+    const columns: Record<string, ColumnShape> = {};
+    for (const [name, info] of Object.entries(described)) {
+      columns[name] = { type: info.type.toUpperCase(), allowNull: info.allowNull };
+    }
+
+    const indexes = (await queryInterface.showIndex(table)) as unknown as IndexRow[];
+    const unique: string[] = [];
+    const nonUnique: string[] = [];
+    for (const index of indexes) {
+      if (index.name === 'PRIMARY') continue;
+      const key = (index.fields ?? [])
+        .map((f) => f.attribute)
+        .sort()
+        .join('+');
+      if (key === '') continue;
+      (index.unique ? unique : nonUnique).push(key);
+    }
+    out[table] = {
+      columns,
+      unique: [...new Set(unique)].sort(),
+      nonUnique: [...new Set(nonUnique)].sort(),
+    };
+  }
+  return out;
+}
+
+describe('schema parity: migrations vs models (integration)', () => {
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    // Leave the database in the canonical, migration-built state for whatever
+    // runs next, then close.
+    if (harness !== null) {
+      await resetSchemaFromMigrations(harness.sequelize);
+      await harness.cleanup();
+    }
+  }, 60_000);
+
+  test('the migrated schema matches what the models would create', async () => {
+    if (harness === null) return;
+    const { sequelize } = harness;
+
+    // probeHarness already built the schema from the real migrations.
+    const migrated = await introspect(sequelize);
+    // Rebuild the same database from the models and introspect again.
+    await sequelize.sync({ force: true });
+    const modelled = await introspect(sequelize);
+
+    // 1. Same tables on both sides.
+    expect(Object.keys(migrated).sort()).toEqual(Object.keys(modelled).sort());
+
+    // 2. Same columns, with the same type and nullability. This is the class
+    //    of drift that breaks the ORM outright — a model selecting a column
+    //    the migrations never created (see issue #37), or a type the data
+    //    will not round-trip through.
+    const columnDiffs: string[] = [];
+    for (const [table, modelShape] of Object.entries(modelled)) {
+      const migratedShape = migrated[table];
+      if (migratedShape === undefined) continue;
+      const names = new Set([
+        ...Object.keys(modelShape.columns),
+        ...Object.keys(migratedShape.columns),
+      ]);
+      for (const column of [...names].sort()) {
+        const fromModel = modelShape.columns[column];
+        const fromMigration = migratedShape.columns[column];
+        if (fromModel === undefined) {
+          columnDiffs.push(`${table}.${column}: in migrations, not in models`);
+          continue;
+        }
+        if (fromMigration === undefined) {
+          columnDiffs.push(`${table}.${column}: in models, not in migrations`);
+          continue;
+        }
+        if (fromModel.type !== fromMigration.type) {
+          columnDiffs.push(
+            `${table}.${column}: type ${fromMigration.type} (migrations) vs ${fromModel.type} (models)`,
+          );
+        }
+        // Nullability is asserted in one direction only.
+        //
+        // Dangerous: the model requires a value but the database permits
+        // NULL. The ORM then assumes an invariant the database will not
+        // enforce, and any other writer can violate it.
+        //
+        // Safe, and currently true of ~30 columns: the migrations declare
+        // NOT NULL while the model attribute omits `allowNull: false`. The
+        // database is stricter than the model, TypeScript already types the
+        // field as non-nullable, and every suite builds its schema from the
+        // migrations. Tightening those model declarations to match would be
+        // an improvement, but it is a separate change and not a correctness
+        // gate.
+        if (!fromModel.allowNull && fromMigration.allowNull) {
+          columnDiffs.push(`${table}.${column}: models require NOT NULL but migrations allow NULL`);
+        }
+      }
+    }
+    expect(columnDiffs).toEqual([]);
+
+    // 3. Every UNIQUE constraint the models expect must exist in the migrated
+    //    schema. Uniqueness is a correctness guarantee, not a hint — a model
+    //    relying on one the database lacks admits duplicate rows.
+    //    Extra indexes in the migrations are fine and not asserted: a
+    //    performance index nobody declared on the model breaks nothing.
+    const uniqueDiffs: string[] = [];
+    for (const [table, modelShape] of Object.entries(modelled)) {
+      const migratedShape = migrated[table];
+      if (migratedShape === undefined) continue;
+      for (const key of modelShape.unique) {
+        if (!migratedShape.unique.includes(key)) {
+          uniqueDiffs.push(`${table}: models declare UNIQUE(${key}); migrations do not`);
+        }
+      }
+    }
+    expect(uniqueDiffs).toEqual([]);
+  }, 120_000);
+});


### PR DESCRIPTION
The two loose ends from v0.2.0.

## 1. `check:all` no longer runs on tag-only pushes

The gate takes 10–15 minutes and ran in full on `git push origin vX.Y.Z` — a push that introduces **no new commits**. The commit being tagged already passed this gate on its branch and again in CI, so releases were waiting on a third verification of already-verified work. It cost two full cycles on the v0.1.2 tag.

Git feeds the hook one line per ref; it skips only when **every** ref is a tag. If no refs arrive on stdin, the gate still runs — the safe default is to check, not to skip.

Verified against simulated stdin:

| Input | Result |
|---|---|
| tag only | skips |
| branch | runs gate |
| mixed branch + tag | runs gate |
| empty stdin | runs gate (safe default) |
| multiple tags | skips |

This PR is itself a branch push, so the gate ran normally — confirming ordinary pushes are unaffected.

## 2. Schema parity: migrations vs models

The existing guard (`migration-schema-drift.test.ts`) is *static* and column-level — it replays the migration files and checks each table ends up with the columns the global define defaults require. It cannot see a column whose **type** diverged, or a **unique constraint** the models rely on that the migrations never created. That was the last of the drift class left open after v0.1.1.

This builds both schemas for real and compares them: `probeHarness` has already applied the migrations, so the test introspects that, runs `sync({ force: true })` to rebuild the same database from the models, and introspects again. Both readings come back through MySQL's `information_schema`, so types are canonical and directly comparable rather than reflecting how each side happened to declare them.

**Asserted:** identical table sets · identical column sets · identical column **types** · every UNIQUE constraint the models expect present in the migrated schema.
**Not asserted:** extra indexes in the migrations — a performance index nobody declared on a model breaks nothing.

### Proven to catch drift, not merely to pass
- Removing the `deleted_at` migration → reports it missing on five tables (the exact v0.1.1 bug).
- Changing a migrated column type → `users.first_name: type TEXT (migrations) vs VARCHAR(100) (models)` — **drift the static guard passes straight over**.

### One deliberate asymmetry
The guard surfaced **30 genuine nullability differences**: migrations declare `NOT NULL` where the model attribute omits `allowNull: false`. That is the database being *stricter* than the model — safe, and TypeScript already types those fields non-nullable.

So nullability is asserted in one direction only: **models requiring a value the database permits as NULL** (the dangerous direction — currently zero occurrences). Failing on the safe direction would have made ~30 model edits the price of adding a guard. Tightening those declarations is a reasonable follow-up; it's documented in the test rather than quietly ignored.

## Verified
`check:all` exits 0 — **205 api tests**, coverage 93.27 / 81.30 / 98.66 / 96.76, lint + typecheck clean, all 18 e2e specs green.

## Noted, not fixed
`embed-hardening › rotateEmbedSecret` failed once in a full run and passed both in isolation and on re-run. Non-deterministic, and the third load-related flake seen in this suite — worth watching.