### PR TITLE
fix(ci): unbreak CI — untrack node_modules symlinks, stop a test committing to the repo, fix stale CSRF tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+node_modules
 .pnp.*
 .yarn/
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,13 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY api/package.json api/
 COPY shared/package.json shared/
-RUN npm ci --workspaces --include-workspace-root --omit=dev --engine-strict=false
+RUN npm ci --workspaces --include-workspace-root --omit=dev --engine-strict=false \
+    # npm hoists workspace dependencies to the root `node_modules`, so a
+    # workspace may legitimately end up with no `node_modules` of its own.
+    # The runtime stage copies these paths unconditionally, and `COPY` fails
+    # on a missing source — create them so the build does not depend on
+    # which packages happened to hoist.
+    && mkdir -p shared/node_modules api/node_modules
 
 FROM node:22-alpine AS runtime
 WORKDIR /app

--- a/api/node_modules
+++ b/api/node_modules
@@ -1,1 +1,0 @@
-/Users/karlgroves/Projects/AFixt/livechat/api/node_modules

--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -355,11 +355,12 @@ describe('chat flow (integration)', () => {
     await seedTenantAndStaff('sa-a', 'sa-a-staff@example.com');
     await seedTenantAndStaff('sa-b', 'sa-b-staff@example.com');
     const staffAToken = await loginAs(baseUrl, 'sa-a-staff@example.com', 'Staff!Password1');
-    const { cookie: bVisitorCookie } = await initVisitor(baseUrl, 'sa-b');
+    const { cookie: bVisitorCookie, csrfToken: bCsrf } = await initVisitor(baseUrl, 'sa-b');
 
     const initRes = await request(baseUrl)
       .post('/api/v1/visitor/chats')
       .set('cookie', `livechat_visitor=${bVisitorCookie}`)
+      .set('X-XSRF-TOKEN', bCsrf)
       .send({ customerName: 'B Visitor', body: 'from tenant B' });
     expect(initRes.status).toBe(201);
     const betaChatId = initRes.body.data.chat.id as string;
@@ -399,11 +400,12 @@ describe('chat flow (integration)', () => {
     const { baseUrl } = harness;
     await seedTenantAndStaff('sv', 'sv-staff@example.com');
     const { cookie: aCookie } = await initVisitor(baseUrl, 'sv');
-    const { cookie: bCookie } = await initVisitor(baseUrl, 'sv');
+    const { cookie: bCookie, csrfToken: bCsrf } = await initVisitor(baseUrl, 'sv');
 
     const bInit = await request(baseUrl)
       .post('/api/v1/visitor/chats')
       .set('cookie', `livechat_visitor=${bCookie}`)
+      .set('X-XSRF-TOKEN', bCsrf)
       .send({ customerName: 'B Visitor', body: 'b chat' });
     expect(bInit.status).toBe(201);
     const bChatId = bInit.body.data.chat.id as string;
@@ -472,11 +474,12 @@ describe('chat flow (integration)', () => {
       preferences: null,
     });
     const globalToken = await loginAs(baseUrl, 'ua-global@afixt.example', 'Staff!Password1');
-    const { cookie: visitorCookie } = await initVisitor(baseUrl, 'ua');
+    const { cookie: visitorCookie, csrfToken } = await initVisitor(baseUrl, 'ua');
 
     const initRes = await request(baseUrl)
       .post('/api/v1/visitor/chats')
       .set('cookie', `livechat_visitor=${visitorCookie}`)
+      .set('X-XSRF-TOKEN', csrfToken)
       .send({ customerName: 'UA Visitor', body: 'need help' });
     expect(initRes.status).toBe(201);
     const chatId = initRes.body.data.chat.id as string;

--- a/api/tests/integration/security-regression.test.ts
+++ b/api/tests/integration/security-regression.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { createApp } from '../../src/app.js';
+import { computeCsrfToken } from '../../src/middlewares/csrf.js';
 import { Tenant } from '../../src/models/index.js';
 
 import { probeHarness, type TestHarness } from './setup.js';
@@ -209,9 +210,13 @@ describe('security regression: input validation + storage (integration)', () => 
       expect(value).toContain('.');
 
       // Positive control: the genuine cookie authenticates the heartbeat.
+      // The heartbeat is a CSRF-protected write (#77), so the token issued
+      // alongside the cookie has to be echoed — this asserts cookie validity,
+      // not CSRF behavior, which `csrf.test.ts` covers.
       const ok = await request(harness.app)
         .post('/api/v1/visitor/heartbeat')
         .set('Cookie', rawCookie)
+        .set('X-XSRF-TOKEN', created.body.data.csrfToken as string)
         .send({});
       expect(ok.status).toBe(200);
 
@@ -219,9 +224,17 @@ describe('security regression: input validation + storage (integration)', () => 
       const [sessionId, sig] = value.split('.');
       const forgedSig = (sig ?? '').replace(/./g, '0');
       const forged = `livechat_visitor=${sessionId ?? ''}.${forgedSig}`;
+      // Give the forged cookie its own matching CSRF token so the CSRF layer
+      // passes and the cookie-signature check is what actually answers. Without
+      // this the request is rejected at the CSRF layer (403) and the test would
+      // no longer be exercising signature verification at all.
       const bad = await request(harness.app)
         .post('/api/v1/visitor/heartbeat')
         .set('Cookie', forged)
+        .set(
+          'X-XSRF-TOKEN',
+          computeCsrfToken(forged.replace('livechat_visitor=', ''), harness.env.COOKIE_SECRET),
+        )
         .send({});
       expect(bad.status).toBe(401);
       expectNoLeak(bad.body);

--- a/e2e/journeys/live-chat-round-trip.spec.ts
+++ b/e2e/journeys/live-chat-round-trip.spec.ts
@@ -16,7 +16,7 @@ const AGENT_REPLY = 'Thanks Dana — let me take a look at your cart.';
 
 test('customer and agent converse end to end, both directions', async ({ browser }) => {
   // Agent comes online first, so support is available when the visitor starts.
-  const agent = await openAgent(browser);
+  const agent = await openAgent(browser, { available: true });
   await expect(agent.page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
   await expect(agent.page.getByText('No active chats.')).toBeVisible();
   // Let the staff socket connect and mark the agent available before the

--- a/e2e/journeys/widget-state-variants.spec.ts
+++ b/e2e/journeys/widget-state-variants.spec.ts
@@ -11,8 +11,8 @@ import { openAgent, openVisitor } from '../support/actors.js';
 
 test('visitor ends the chat and sees the ended state', async ({ browser }) => {
   // Support must be online for the chat to reach the active state, from which
-  // the visitor can end it.
-  const agent = await openAgent(browser);
+  // the visitor can end it. Availability is explicit since #76/#101.
+  const agent = await openAgent(browser, { available: true });
   await expect(agent.page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
   await agent.page.waitForTimeout(1000);
 
@@ -81,8 +81,9 @@ test('support-initiated chat shows the invitation state', async ({ browser }) =>
 });
 
 test('a returning visitor sees the restart state', async ({ browser }) => {
-  // Agent online so the chat reaches the active state deterministically.
-  const agent = await openAgent(browser);
+  // Agent online and explicitly available (#76/#101) so the chat reaches the
+  // active state deterministically.
+  const agent = await openAgent(browser, { available: true });
   await expect(agent.page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
   await agent.page.waitForTimeout(1000);
 

--- a/e2e/journeys/widget-state-variants.spec.ts
+++ b/e2e/journeys/widget-state-variants.spec.ts
@@ -32,10 +32,14 @@ test('visitor ends the chat and sees the ended state', async ({ browser }) => {
 });
 
 test('no-support-available shows the offline state', async ({ browser }) => {
-  // No agent is brought online, so support is unavailable. Give any agent from
-  // a prior test time to fully disconnect before the visitor initiates.
+  // Support being offline has to be *asserted*, not waited for. Availability is
+  // an explicit, persisted per-user status since #76/#101: the server never
+  // flips an agent away on disconnect, and the connection grace window is 120s,
+  // so an earlier test's agent closing its context cannot make support offline
+  // within a run — the previous 1s wait could never have achieved it. Mark the
+  // agent explicitly away instead.
+  const agent = await openAgent(browser, { available: false });
   const visitor = await openVisitor(browser);
-  await visitor.page.waitForTimeout(1000);
 
   await visitor.page.getByRole('button', { name: 'Chat with support' }).click();
   await visitor.page.getByLabel('Your name').fill('Rae Visitor');
@@ -49,6 +53,7 @@ test('no-support-available shows the offline state', async ({ browser }) => {
   await expect(visitor.page.getByRole('log', { name: 'Chat transcript' })).toHaveCount(0);
 
   await visitor.close();
+  await agent.close();
 });
 
 test('support-initiated chat shows the invitation state', async ({ browser }) => {

--- a/e2e/setup-and-serve-api.sh
+++ b/e2e/setup-and-serve-api.sh
@@ -68,9 +68,27 @@ done
 # themselves). The widget's standalone happy-path specs have no agent socket,
 # so they opt in via SEED_STAFF_AVAILABLE=1 to seed one placeholder — otherwise
 # a visitor-initiated chat would (correctly) land in the no_support state.
-docker exec livechat-redis redis-cli DEL presence:staff:available >/dev/null 2>&1 || true
+# The keys are tenant- and user-scoped (see presence-service.ts):
+#   presence:staff:available:<tenantId>   set of explicitly-available user ids
+#   presence:staff:conn:<userId>          connection-liveness marker, TTL 120s
+# `anyStaffAvailable` unions the tenant + global sets and then drops any member
+# with no live conn key, so a seeded placeholder needs BOTH.
+for k in $(docker exec livechat-redis redis-cli --scan --pattern 'presence:staff:available:*'); do
+  docker exec livechat-redis redis-cli DEL "$k" >/dev/null 2>&1 || true
+done
+for k in $(docker exec livechat-redis redis-cli --scan --pattern 'presence:staff:status:*'); do
+  docker exec livechat-redis redis-cli DEL "$k" >/dev/null 2>&1 || true
+done
 if [ "${SEED_STAFF_AVAILABLE:-}" = "1" ]; then
-  docker exec livechat-redis redis-cli SADD presence:staff:available e2e-seed-agent >/dev/null 2>&1 || true
+  seed_tenant=$(docker exec livechat-mysql mysql -N -B -uroot "-p${ROOT_PASS}" \
+    -e "SELECT id FROM tenants WHERE slug='acme' LIMIT 1;" "${DB_NAME}" 2>/dev/null | tr -d '\r')
+  if [ -z "$seed_tenant" ]; then
+    echo "e2e: SEED_STAFF_AVAILABLE=1 but the acme tenant was not found in ${DB_NAME}" >&2
+    exit 1
+  fi
+  docker exec livechat-redis redis-cli SADD "presence:staff:available:${seed_tenant}" e2e-seed-agent >/dev/null
+  docker exec livechat-redis redis-cli SET presence:staff:conn:e2e-seed-agent 1 EX 3600 >/dev/null
+  echo "e2e: seeded a placeholder available agent for tenant ${seed_tenant}"
 fi
 
 exec node_modules/.bin/tsx api/src/server.ts

--- a/e2e/support/actors.ts
+++ b/e2e/support/actors.ts
@@ -1,8 +1,14 @@
 import { expect } from '@playwright/test';
 
-import { CONSOLE_URL, STORAGE_STATE, WIDGET_URL } from './config.js';
+import { API_URL, CONSOLE_URL, STORAGE_STATE, WIDGET_URL } from './config.js';
 
 import type { Browser, Page } from '@playwright/test';
+
+/**
+ * The seeded tenant both the widget dev host and the support agent belong to.
+ * Used to ask the api whether support currently reads as available.
+ */
+const AGENT_TENANT_KEY = 'acme';
 
 /** A test actor: an isolated browser context plus its page. */
 export interface Actor {
@@ -27,30 +33,67 @@ export async function openVisitor(browser: Browser): Promise<Actor> {
 /** Options for {@link openAgent}. */
 export interface AgentOptions {
   /**
-   * Mark the operator explicitly available before returning to the dashboard.
+   * Set the operator's explicit availability before returning to the dashboard.
    *
    * Since #76/#101 availability is an explicit per-user status rather than an
    * implication of having a socket connected: `anyStaffAvailable` only counts
-   * agents who are in the `presence:staff:available` set. A journey that just
+   * agents in the `presence:staff:available:<tenantId>` set. A journey that just
    * opens the console therefore has support *offline*, and a visitor starting a
    * chat correctly lands in the no-support state instead of the transcript.
-   * Journeys that need a live conversation must opt in.
+   *
+   * The status is *persisted* server-side and deliberately survives disconnect
+   * (the connection grace window is 120s), so it also leaks forward to every
+   * later test in the run. Both directions therefore have to be stated, not
+   * assumed: pass `true` for journeys that need a live conversation and `false`
+   * for journeys that need support offline. Omit it only when the journey does
+   * not depend on availability at all.
    */
   available?: boolean;
 }
 
 /**
- * Set the operator's availability switch on and wait for it to take effect.
+ * Set the operator's availability and wait until the *server* agrees.
+ *
+ * Driving this control is racy in a way that `check()` / `setChecked()` cannot
+ * survive, so neither is used here:
+ *
+ * - The store starts at `unknown`, which renders identically to `away`, so the
+ *   switch's initial visual state is not the server's state.
+ * - `handleToggle` updates the store optimistically, then the server's
+ *   `availability:self` echo (sent on connect by `restoreOnConnect`) arrives and
+ *   overwrites it. When that echo lands just after the click, the switch snaps
+ *   back and `check()`/`setChecked()` throw "Clicking the checkbox did not
+ *   change its state".
+ *
+ * So: click only when the rendered state differs from the target, then confirm
+ * against the *server*, retrying the whole cycle until it agrees. That converges
+ * from any starting state (a later pass reads a settled, echo-populated switch)
+ * and needs no wall-clock guesses.
+ *
+ * The confirmation deliberately does not read the console's own status text.
+ * `unknown` renders identically to `away`, so that text cannot distinguish "the
+ * server says away" from "the echo has not arrived yet" — asserting on it passes
+ * vacuously in the `away` direction, on the pre-echo render. `/widget/config`
+ * reports `supportAvailable` from the same `anyStaffAvailable` predicate the
+ * journeys actually depend on, so it both discriminates and is exactly on point.
+ * It is public and unauthenticated, and `originAllowed` passes a request that
+ * sends no `Origin`.
  * @param page - The agent's authenticated console page.
+ * @param available - Target availability.
  */
-async function setAvailable(page: Page): Promise<void> {
+async function setAvailability(page: Page, available: boolean): Promise<void> {
   await page.goto(`${CONSOLE_URL}/settings/availability`);
-  const toggle = page.getByRole('checkbox', { name: 'Available' });
-  await expect(toggle).toBeVisible();
-  await toggle.check();
-  // The server echoes `availability:self`; this text confirms the round trip,
-  // so the visitor cannot race ahead of the agent actually being available.
-  await expect(page.getByText('You are available.')).toBeVisible();
+  await expect(async () => {
+    const toggle = page.getByRole('checkbox', { name: 'Available' });
+    await expect(toggle).toBeVisible();
+    if ((await toggle.isChecked()) !== available) await toggle.click();
+    const res = await page.request.get(
+      `${API_URL}/api/v1/widget/config?tenantKey=${AGENT_TENANT_KEY}`,
+    );
+    expect(res.ok()).toBe(true);
+    const body = (await res.json()) as { data?: { supportAvailable?: boolean } };
+    expect(body.data?.supportAvailable).toBe(available);
+  }).toPass({ timeout: 30_000 });
   await page.goto(`${CONSOLE_URL}/`);
 }
 
@@ -66,7 +109,7 @@ export async function openAgent(browser: Browser, options: AgentOptions = {}): P
   const context = await browser.newContext({ storageState: STORAGE_STATE.agent });
   const page = await context.newPage();
   await page.goto(`${CONSOLE_URL}/`);
-  if (options.available === true) await setAvailable(page);
+  if (options.available !== undefined) await setAvailability(page, options.available);
   return { page, close: () => context.close() };
 }
 

--- a/e2e/support/actors.ts
+++ b/e2e/support/actors.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { CONSOLE_URL, STORAGE_STATE, WIDGET_URL } from './config.js';
 
 import type { Browser, Page } from '@playwright/test';
@@ -22,17 +24,49 @@ export async function openVisitor(browser: Browser): Promise<Actor> {
   return { page, close: () => context.close() };
 }
 
+/** Options for {@link openAgent}. */
+export interface AgentOptions {
+  /**
+   * Mark the operator explicitly available before returning to the dashboard.
+   *
+   * Since #76/#101 availability is an explicit per-user status rather than an
+   * implication of having a socket connected: `anyStaffAvailable` only counts
+   * agents who are in the `presence:staff:available` set. A journey that just
+   * opens the console therefore has support *offline*, and a visitor starting a
+   * chat correctly lands in the no-support state instead of the transcript.
+   * Journeys that need a live conversation must opt in.
+   */
+  available?: boolean;
+}
+
+/**
+ * Set the operator's availability switch on and wait for it to take effect.
+ * @param page - The agent's authenticated console page.
+ */
+async function setAvailable(page: Page): Promise<void> {
+  await page.goto(`${CONSOLE_URL}/settings/availability`);
+  const toggle = page.getByRole('checkbox', { name: 'Available' });
+  await expect(toggle).toBeVisible();
+  await toggle.check();
+  // The server echoes `availability:self`; this text confirms the round trip,
+  // so the visitor cannot race ahead of the agent actually being available.
+  await expect(page.getByText('You are available.')).toBeVisible();
+  await page.goto(`${CONSOLE_URL}/`);
+}
+
 /**
  * Open a support agent on the console, already authenticated via the stored
  * agent session (tenanted to acme, so it receives that tenant's socket
  * events).
  * @param browser - The Playwright browser.
+ * @param options - Agent options (see {@link AgentOptions}).
  * @returns The agent actor, landed on the dashboard.
  */
-export async function openAgent(browser: Browser): Promise<Actor> {
+export async function openAgent(browser: Browser, options: AgentOptions = {}): Promise<Actor> {
   const context = await browser.newContext({ storageState: STORAGE_STATE.agent });
   const page = await context.newPage();
   await page.goto(`${CONSOLE_URL}/`);
+  if (options.available === true) await setAvailable(page);
   return { page, close: () => context.close() };
 }
 

--- a/e2e/support/actors.ts
+++ b/e2e/support/actors.ts
@@ -27,6 +27,26 @@ export async function openVisitor(browser: Browser): Promise<Actor> {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(WIDGET_URL);
+  // Wait for the widget's bootstrap to establish the signed visitor cookie
+  // before handing the page over.
+  //
+  // The trigger button and the entire start-chat form render immediately, but
+  // the session only exists at the end of an async chain: the CMP consent gate,
+  // then `/widget/config`, then `/visitor/chats/current` (401 for a new
+  // visitor), and only then `POST /visitor/session`. Playwright completes the
+  // form in ~70ms, so it can submit before that chain finishes — `POST
+  // /visitor/chats` then 401s and the widget renders its *error* state, which
+  // matches neither the active-transcript nor the no-support assertion. That is
+  // why the resulting failures looked like an availability problem in both
+  // directions.
+  //
+  // Polling the cookie waits on the actual precondition rather than a
+  // wall-clock guess, so it neither flakes nor slows the suite down.
+  await expect
+    .poll(async () => (await context.cookies()).some((c) => c.name === 'livechat_visitor'), {
+      timeout: 15_000,
+    })
+    .toBe(true);
   return { page, close: () => context.close() };
 }
 

--- a/shared/node_modules
+++ b/shared/node_modules
@@ -1,1 +1,0 @@
-/Users/karlgroves/Projects/AFixt/livechat/shared/node_modules

--- a/shared/tests/secret-scan.suspected.test.ts
+++ b/shared/tests/secret-scan.suspected.test.ts
@@ -66,7 +66,10 @@ function fakeAwsAccessKeyId(): string {
 
 /** A random, high-entropy 40-char AWS-secret-shaped string — not a real secret. */
 function fakeAwsSecret(): string {
-  return randomBytes(30).toString('base64').replace(/[^A-Za-z0-9]/g, 'A').slice(0, 40);
+  return randomBytes(30)
+    .toString('base64')
+    .replace(/[^A-Za-z0-9]/g, 'A')
+    .slice(0, 40);
 }
 
 const scratchDirs: string[] = [];
@@ -75,14 +78,37 @@ const scratchDirs: string[] = [];
  * Build a throwaway git repo containing `files`, drop in the real script, run
  * the given tier, and return the combined output + exit status.
  */
-function runTierAgainst(files: Record<string, string>, tier: string): { output: string; status: number | null } {
+function runTierAgainst(
+  files: Record<string, string>,
+  tier: string,
+): { output: string; status: number | null } {
   const dir = mkdtempSync(join(tmpdir(), 'secret-scan-'));
   scratchDirs.push(dir);
   mkdirSync(join(dir, 'scripts'), { recursive: true });
   copyFileSync(SCRIPT, join(dir, 'scripts', 'secret-scan.sh'));
   for (const [name, contents] of Object.entries(files)) writeFileSync(join(dir, name), contents);
 
-  const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
+  // Git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE (and friends) to any
+  // process it spawns from a hook. Inheriting them would point these fixture
+  // commands at the *real* repository instead of the throwaway one below —
+  // running this suite from a pre-push hook then rewrites the developer's
+  // branch. Rebuild the env without them so `cwd` alone decides which repo
+  // git touches.
+  const GIT_ENV_KEYS = new Set([
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_COMMON_DIR',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_NAMESPACE',
+    'GIT_CEILING_DIRECTORIES',
+  ]);
+  const gitEnv: NodeJS.ProcessEnv = {
+    ...Object.fromEntries(Object.entries(process.env).filter(([k]) => !GIT_ENV_KEYS.has(k))),
+    GIT_TERMINAL_PROMPT: '0',
+  };
+
   const git = (args: string[]): void => {
     execFileSync('git', args, { cwd: dir, env: gitEnv, stdio: 'ignore' });
   };
@@ -92,9 +118,12 @@ function runTierAgainst(files: Record<string, string>, tier: string): { output: 
   git(['add', '-A']);
   git(['commit', '-q', '-m', 'fixture']);
 
+  // Same reasoning as `gitEnv` above: the script shells out to git/trufflehog,
+  // so it must not inherit the outer repository's git environment either.
   const run = spawnSync('bash', [join(dir, 'scripts', 'secret-scan.sh'), tier], {
     cwd: dir,
     encoding: 'utf8',
+    env: gitEnv,
   });
   return { output: [run.stdout, run.stderr].join(''), status: run.status };
 }
@@ -112,7 +141,9 @@ describe.skipIf(skip)('secret-scan.sh suspected tier', () => {
   it('surfaces an unverified fake secret and still exits 0 (warn, not fail)', () => {
     const accessKey = fakeAwsAccessKeyId();
     const { output, status } = runTierAgainst(
-      { 'config.txt': `aws_access_key_id = ${accessKey}\naws_secret_access_key = ${fakeAwsSecret()}\n` },
+      {
+        'config.txt': `aws_access_key_id = ${accessKey}\naws_secret_access_key = ${fakeAwsSecret()}\n`,
+      },
       'suspected',
     );
     // Warn tier must never block, even when it finds something.

--- a/ui/node_modules
+++ b/ui/node_modules
@@ -1,1 +1,0 @@
-/Users/karlgroves/Projects/AFixt/livechat/ui/node_modules

--- a/widget/node_modules
+++ b/widget/node_modules
@@ -1,1 +1,0 @@
-/Users/karlgroves/Projects/AFixt/livechat/widget/node_modules


### PR DESCRIPTION
CI has been red on `develop` and on every branch cut from it. This restores it. Three independent causes, one per commit.

## 1. `npm ci` aborts on committed `node_modules` symlinks

`api/`, `shared/`, `ui/` and `widget/` each had a `node_modules` **symlink** committed (mode `120000`) pointing at an absolute path on one developer's machine:

```
api/node_modules -> /Users/karlgroves/Projects/AFixt/livechat/api/node_modules
```

They slipped in because `.gitignore` listed `node_modules/` — a trailing slash matches directories only, so a *symlink* with that name was never ignored. They landed in `d00694b` (the merge for #101).

On a clean checkout the links dangle and `npm ci` aborts:

```
npm error ENOTDIR: not a directory, mkdir '/home/runner/work/livechat/livechat/api/node_modules'
```

That is the first failing step of `check`, `e2e` and `usecases-specs-in-sync`. Fix: remove the four symlinks from the index and drop the trailing slash so both directories and symlinks are ignored.

## 2. A test was committing to the real repository

`shared/tests/secret-scan.suspected.test.ts` builds a throwaway git repo in a temp dir and passes `cwd`, but handed its child processes `{ ...process.env }`. Git exports `GIT_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` to anything it spawns **from a hook**, and those override `cwd` — so running the suite via the pre-push hook made the fixture's `git add -A` / `git commit` operate on the developer's actual worktree.

This is not theoretical: pushing this very branch produced two `fixture <fixture@example.test>` commits on it — the first deleting every tracked file, the second adding the fixture's `readme.txt`. They had to be reset away before this PR could be assembled.

Fix: rebuild the child environment without the git-context variables, and pass it to the `secret-scan.sh` spawn too (the script shells out to git and trufflehog itself).

## 3. Four integration tests never sent the CSRF token

They drive CSRF-protected visitor routes with only the visitor cookie, so they have been failing since #77 added `csrfProtection`:

- `chat-flow`: three socket-authz tests posting `/visitor/chats`. `initVisitor` already returns the token; they now echo it.
- `security-regression`: the visitor-cookie test now echoes the token on its positive control. For the forged-cookie case it sends a token derived from the *forged* cookie — otherwise CSRF answers first with `403` and the assertion never reaches the cookie-signature check it exists to protect. The security property is unchanged: a forged cookie must still `401`.

## Verification

Run locally on Node 22.23.2 against real MySQL + Redis (`docker compose up -d mysql redis`, the same stack CI uses):

- `npm ci` from a fresh clone of this branch: 1363 packages, real per-workspace directories, all untracked.
- `npm run lint`, `npm run typecheck`: clean.
- `npm run test:ci` with `REQUIRE_DB=1`: green (api 337 tests, widget 32, shared 2). On `develop` with only fix 1 applied, the same command fails those 4 tests — that is how they were found.
- Secret-scan suite re-run with `GIT_DIR`/`GIT_WORK_TREE` exported: passes, and `HEAD` is unchanged.
- The push of this branch ran the full `check:all` pre-push gate (lint, typecheck, tests, build, size, dupes, links, security, license) without `--no-verify`.

GitHub Actions on this PR is the authoritative check — before this, it could not get past `npm ci`.