### PR TITLE
refactor(e2e): share the generated-spec Playwright config across ui and widget

### DIFF
--- a/e2e/support/generated-spec-config.ts
+++ b/e2e/support/generated-spec-config.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared Playwright configuration for the *generated* usecase specs that the
+ * `ui` and `widget` workspaces run.
+ *
+ * Those two configs were byte-identical apart from a port, a projects list and
+ * one env key, which put ~53 duplicated lines through the `jscpd` gate (the
+ * repo's threshold is 1%). They are kept separate from `./config.ts` because
+ * they deliberately target a *different* stack: the generated specs hard-code
+ * the dev ports in their `start_location`, whereas the cross-ends journeys in
+ * `./config.ts` use an isolated high-port range so a journey run never collides
+ * with a dev stack.
+ */
+import { defineConfig } from '@playwright/test';
+
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+/** True when running under CI, which forbids `.only` and enables retries. */
+export const isCI = Boolean(process.env.CI);
+
+/**
+ * Dev-stack ports the generated usecase specs hard-code in their
+ * `start_location`. The api still gets a dedicated `livechat_e2e` database, so
+ * a run never touches dev data.
+ */
+export const DEV_STACK_PORTS = { api: 23001, console: 5174, widget: 5175 } as const;
+
+/**
+ * Build the environment for the api child process the generated specs run
+ * against. `NODE_ENV=test` makes `server.ts` skip the rate limiters, so
+ * repeated logins across a run (and CI retries) never trip the auth limiter.
+ * @param extra - Additional env entries for a specific suite.
+ * @returns A process-env-shaped record for the api child process.
+ */
+export function buildApiEnv(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    NODE_ENV: 'test',
+    PORT: String(DEV_STACK_PORTS.api),
+    DB_HOST: 'localhost',
+    DB_PORT: '23307',
+    DB_NAME: 'livechat_e2e',
+    DB_USER: 'livechat_user',
+    DB_PASS: 'livechat_pass',
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: '26380',
+    JWT_ACCESS_SECRET: 'e2e-access-secret',
+    JWT_REFRESH_SECRET: 'e2e-refresh-secret',
+    COOKIE_SECRET: 'e2e-cookie-secret',
+    APP_URL: `http://localhost:${String(DEV_STACK_PORTS.console)}`,
+    API_URL: `http://localhost:${String(DEV_STACK_PORTS.api)}`,
+    WIDGET_URL: `http://localhost:${String(DEV_STACK_PORTS.widget)}`,
+    SMTP_HOST: 'localhost',
+    SMTP_PORT: '21026',
+    S3_ENDPOINT: 'http://localhost:29000',
+    S3_ACCESS_KEY: 'livechat_minio',
+    S3_SECRET_KEY: 'livechat_minio_pass',
+    S3_BUCKET: 'livechat-attachments',
+    LOG_LEVEL: 'warn',
+    ...extra,
+  };
+}
+
+/** Options for {@link defineGeneratedSpecConfig}. */
+export interface GeneratedSpecConfigOptions {
+  /** Port the workspace's own vite dev server listens on (its `baseURL`). */
+  port: number;
+  /** The workspace's Playwright projects. */
+  projects: NonNullable<PlaywrightTestConfig['projects']>;
+  /** Extra api env entries beyond {@link buildApiEnv}'s defaults. */
+  apiEnvExtra?: Record<string, string>;
+}
+
+/**
+ * Build the Playwright config a workspace uses to run its generated usecase
+ * specs: the shared run settings, the api web server (which brings up infra and
+ * seeds the database before serving), and the workspace's own vite server.
+ * @param options - Per-workspace settings (see {@link GeneratedSpecConfigOptions}).
+ * @returns The Playwright config to default-export.
+ */
+export function defineGeneratedSpecConfig(
+  options: GeneratedSpecConfigOptions,
+): PlaywrightTestConfig {
+  const baseUrl = `http://localhost:${String(options.port)}`;
+  return defineConfig({
+    testDir: './e2e',
+    fullyParallel: false,
+    workers: 1,
+    forbidOnly: isCI,
+    retries: isCI ? 2 : 0,
+    reporter: isCI ? [['github'], ['list']] : [['list']],
+    use: { baseURL: baseUrl, trace: 'on-first-retry' },
+
+    projects: options.projects,
+
+    webServer: [
+      {
+        command: 'bash e2e/setup-and-serve-api.sh',
+        cwd: '..',
+        env: buildApiEnv(options.apiEnvExtra),
+        url: `http://localhost:${String(DEV_STACK_PORTS.api)}/api/v1/health`,
+        timeout: 120_000,
+        reuseExistingServer: !isCI,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+      {
+        command: `../node_modules/.bin/vite --port ${String(options.port)} --strictPort`,
+        url: baseUrl,
+        timeout: 60_000,
+        reuseExistingServer: !isCI,
+      },
+    ],
+  });
+}

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,47 +1,12 @@
-import { defineConfig, devices } from '@playwright/test';
+import { devices } from '@playwright/test';
 
-const isCI = Boolean(process.env['CI']);
+import {
+  defineGeneratedSpecConfig,
+  DEV_STACK_PORTS,
+} from '../e2e/support/generated-spec-config.js';
 
-/**
- * Env for the api the generated specs run against — the dev ports the
- * usecase `start_location`s hard-code (console 5174, api 23001), but a
- * dedicated `livechat_e2e` database so it never touches dev data. NODE_ENV
- * `test` skips rate limiting; the startup script seeds before serving.
- */
-const apiEnv: Record<string, string> = {
-  NODE_ENV: 'test',
-  PORT: '23001',
-  DB_HOST: 'localhost',
-  DB_PORT: '23307',
-  DB_NAME: 'livechat_e2e',
-  DB_USER: 'livechat_user',
-  DB_PASS: 'livechat_pass',
-  REDIS_HOST: 'localhost',
-  REDIS_PORT: '26380',
-  JWT_ACCESS_SECRET: 'e2e-access-secret',
-  JWT_REFRESH_SECRET: 'e2e-refresh-secret',
-  COOKIE_SECRET: 'e2e-cookie-secret',
-  APP_URL: 'http://localhost:5174',
-  API_URL: 'http://localhost:23001',
-  WIDGET_URL: 'http://localhost:5175',
-  SMTP_HOST: 'localhost',
-  SMTP_PORT: '21026',
-  S3_ENDPOINT: 'http://localhost:29000',
-  S3_ACCESS_KEY: 'livechat_minio',
-  S3_SECRET_KEY: 'livechat_minio_pass',
-  S3_BUCKET: 'livechat-attachments',
-  LOG_LEVEL: 'warn',
-};
-
-export default defineConfig({
-  testDir: './e2e',
-  fullyParallel: false,
-  workers: 1,
-  forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
-  reporter: isCI ? [['github'], ['list']] : [['list']],
-  use: { baseURL: 'http://localhost:5174', trace: 'on-first-retry' },
-
+export default defineGeneratedSpecConfig({
+  port: DEV_STACK_PORTS.console,
   projects: [
     { name: 'setup', testMatch: /auth\.setup\.ts/ },
     {
@@ -94,25 +59,6 @@ export default defineConfig({
       name: 'support-anon',
       testMatch: /generated\/support-login.*\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
-    },
-  ],
-
-  webServer: [
-    {
-      command: 'bash e2e/setup-and-serve-api.sh',
-      cwd: '..',
-      env: apiEnv,
-      url: 'http://localhost:23001/api/v1/health',
-      timeout: 120_000,
-      reuseExistingServer: !isCI,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-    {
-      command: '../node_modules/.bin/vite --port 5174 --strictPort',
-      url: 'http://localhost:5174',
-      timeout: 60_000,
-      reuseExistingServer: !isCI,
     },
   ],
 });

--- a/widget/playwright.config.ts
+++ b/widget/playwright.config.ts
@@ -1,50 +1,16 @@
-import { defineConfig, devices } from '@playwright/test';
+import { devices } from '@playwright/test';
 
-const isCI = Boolean(process.env['CI']);
+import {
+  defineGeneratedSpecConfig,
+  DEV_STACK_PORTS,
+} from '../e2e/support/generated-spec-config.js';
 
-/**
- * Env for the api the widget specs run against — the dev ports the usecase
- * `start_location`s hard-code (widget 5175, api 23001) but a dedicated
- * `livechat_e2e` database. The startup script seeds before serving.
- */
-const apiEnv: Record<string, string> = {
-  NODE_ENV: 'test',
-  PORT: '23001',
-  DB_HOST: 'localhost',
-  DB_PORT: '23307',
-  DB_NAME: 'livechat_e2e',
-  DB_USER: 'livechat_user',
-  DB_PASS: 'livechat_pass',
-  REDIS_HOST: 'localhost',
-  REDIS_PORT: '26380',
-  JWT_ACCESS_SECRET: 'e2e-access-secret',
-  JWT_REFRESH_SECRET: 'e2e-refresh-secret',
-  COOKIE_SECRET: 'e2e-cookie-secret',
-  APP_URL: 'http://localhost:5174',
-  API_URL: 'http://localhost:23001',
-  WIDGET_URL: 'http://localhost:5175',
-  SMTP_HOST: 'localhost',
-  SMTP_PORT: '21026',
-  S3_ENDPOINT: 'http://localhost:29000',
-  S3_ACCESS_KEY: 'livechat_minio',
-  S3_SECRET_KEY: 'livechat_minio_pass',
-  S3_BUCKET: 'livechat-attachments',
-  LOG_LEVEL: 'warn',
+export default defineGeneratedSpecConfig({
+  port: DEV_STACK_PORTS.widget,
   // These standalone widget specs have no agent socket, so seed one available
   // staff placeholder — otherwise a visitor-initiated chat lands in no_support
   // and the customer-initiates happy path can't reach the active state.
-  SEED_STAFF_AVAILABLE: '1',
-};
-
-export default defineConfig({
-  testDir: './e2e',
-  fullyParallel: false,
-  workers: 1,
-  forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
-  reporter: isCI ? [['github'], ['list']] : [['list']],
-  use: { baseURL: 'http://localhost:5175', trace: 'on-first-retry' },
-
+  apiEnvExtra: { SEED_STAFF_AVAILABLE: '1' },
   projects: [
     {
       // Only the self-contained specs run standalone. `widget-close` and
@@ -54,25 +20,6 @@ export default defineConfig({
       name: 'chromium',
       testMatch: /generated\/widget-(initial|customer-initiates)\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
-    },
-  ],
-
-  webServer: [
-    {
-      command: 'bash e2e/setup-and-serve-api.sh',
-      cwd: '..',
-      env: apiEnv,
-      url: 'http://localhost:23001/api/v1/health',
-      timeout: 120_000,
-      reuseExistingServer: !isCI,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-    {
-      command: '../node_modules/.bin/vite --port 5175 --strictPort',
-      url: 'http://localhost:5175',
-      timeout: 60_000,
-      reuseExistingServer: !isCI,
     },
   ],
 });


### PR DESCRIPTION
`ui/playwright.config.ts` and `widget/playwright.config.ts` were copy-pasted: identical apart from a port, a projects list, and one env key. jscpd counted three clones totalling **53 duplicated lines** between them — a third of the repo's entire duplication budget.

This extracts the shared parts into `e2e/support/generated-spec-config.ts`, next to the `e2e/support/config.ts` that already does exactly this for the journey suite. Those two configs simply never adopted the pattern.

## Why a separate module from `e2e/support/config.ts`

They target different stacks, and merging them would have silently repointed the generated specs:

- **Generated usecase specs** (`ui`, `widget`) must use the dev ports their `start_location`s hard-code — api 23001, console 5174, widget 5175.
- **Cross-ends journeys** (`e2e/`) use an isolated high-port range (23901/5274/5275) so a run never collides with a manually-running dev stack.

Both still get a dedicated `livechat_e2e` database.

## Why now

The `dupes` gate has a 1% threshold. `develop` sat at **0.79%** — only 0.21 points of headroom, thin enough that the gate trips on unrelated work. Both #115 and #116 currently fail `check` on `jscpd found too many duplicates (1.07%)`.

Worth being precise about that, because it is **not** what it looks like: those branches carry the *same* ~160 duplicated lines `develop` does. They read higher only because they are ~132 commits behind, so the same duplication is measured against a 15,254-line tree instead of today's 20,329-line one. Rebasing alone already puts them at 0.85%. This change is about restoring headroom so the gate stops being a tripwire — not about fixing anything those PRs did.

| Tree | Before | After |
|---|---|---|
| `develop` | 0.79% (15 clones, 160 lines) | **0.54%** (12 clones, 110 lines) |
| #115 rebased onto `develop` | 0.85% | **0.60%** |

## No behaviour change

Both configs resolve to objects **byte-identical** to the originals, verified by deep-comparing the imported config objects with `CI` both set and unset (it drives `forbidOnly`, `retries`, `reporter`, and `reuseExistingServer`):

```
ui     CI=''      IDENTICAL      widget CI=''      IDENTICAL
ui     CI='true'  IDENTICAL      widget CI='true'  IDENTICAL
```

And because that check uses `tsx` while Playwright uses its own loader, `playwright test --list` was run through the real runner: the same **11 tests (ui)** and **2 tests (widget)** as before.

## Verification

- `tsc --noEmit` clean on all five workspaces, including `e2e` (which covers the new module).
- `eslint . --max-warnings=0` — exit 0 across the repo.
- `prettier --check` clean.
- `jscpd` — exit 0 at 0.54%.
- trufflehog verified tier — clean on the changed files.

## Left deliberately

The remaining 12 clones (110 lines) are mostly Sequelize model boilerplate (~70 lines), which is reducible but touches runtime models and deserves its own PR. `ui/src/components/live-region.tsx` ↔ `widget/src/components/live-region.tsx` should arguably *stay* duplicated: `ui` is React/MUI, `widget` is Preact under a hard `size-limit` budget with shadow-DOM isolation, and sharing it would couple the widget to the console's stack.

No usecase changes: this touches no `(ui|widget)/src/(pages|states|components|layouts)/` path, so the ADR-0002 gate does not apply.

---

## ✅ Unblocked — CI green

This PR was previously red at `npm ci` (`ENOTDIR ... mkdir api/node_modules`), because `develop` still tracked four committed `node_modules` symlinks. **#126 has since merged**, untracking them, and this PR's checks re-ran against the new base.

`check` now passes, and the `dupes` step — the one this PR exists to affect — ran for real on the runner:

```
Total:  247 files  20468 lines  12 clones  110 duplicated lines (0.54%)
Found 12 clones.
```

That matches the local measurement exactly: **0.79% -> 0.54%**, 15 clones -> 12.

`e2e`, `lhci`, `codeql`, `usecases-diff-gate`, `usecases-specs-in-sync`, Hadolint, KICS, Checkov, Trivy (IaC) and the secret scan all pass.

Two checks remain red, both pre-existing and repo-wide rather than anything in this diff — they fail identically on `develop` and failed on #126 when it merged:

- **Trivy (built-image)** — the image build runs `npm ci` without `NODE_AUTH_TOKEN`, so the private `@afixt/usecase-runner` 404s in `ui/Dockerfile`.
- **zap-pr** — 9 `WARN-NEW` missing-header findings against the ui nginx config (`FAIL-NEW: 0`).
