### PR TITLE
fix(tooling): make the local gate ignores actually ignore

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -9,6 +9,7 @@
   "format": ["typescript", "tsx", "javascript", "jsx", "css", "scss", "markdown"],
   "ignore": [
     "**/node_modules/**",
+    "**/.claude/**",
     "**/db/migrations/**",
     "**/dist/**",
     "**/build/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -17,11 +17,16 @@
     "MD050": { "style": "asterisk" },
     "MD053": true,
   },
-  // These globs are matched against *file* paths, so a directory pattern has
-  // to end in `/**`. A bare trailing slash ("dist/", "**/test-results/")
-  // matches no file and therefore ignores nothing — every entry here used that
+  // These globs are matched against *file* paths, so a directory pattern has to
+  // end in `/**`. A bare trailing slash ("dist/", "**/test-results/") matches no
+  // file and therefore ignores nothing — every *directory* entry here used that
   // form and silently did nothing, which is why a failing e2e run still blocked
-  // the push exactly as the note below says it should not.
+  // the push exactly as the note below says it should not. (The two file entries
+  // at the end were always fine; a plain path needs no `/**`.)
+  //
+  // `shared/tests/gate-ignores.test.ts` pins this: it drops a non-compliant file
+  // into each directory below and fails if markdownlint reports it — and fails
+  // if it stops reporting an un-ignored one, so it cannot pass vacuously.
   "ignores": [
     "**/node_modules/**",
     "**/dist/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -17,19 +17,26 @@
     "MD050": { "style": "asterisk" },
     "MD053": true,
   },
+  // These globs are matched against *file* paths, so a directory pattern has
+  // to end in `/**`. A bare trailing slash ("dist/", "**/test-results/")
+  // matches no file and therefore ignores nothing — every entry here used that
+  // form and silently did nothing, which is why a failing e2e run still blocked
+  // the push exactly as the note below says it should not.
   "ignores": [
-    "node_modules/",
-    "**/node_modules/",
-    "dist/",
-    "build/",
-    "coverage/",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
     // Generated artifacts. Playwright writes Markdown failure contexts into
     // test-results/, so without these a failing e2e run also fails the
     // markdownlint gate and blocks the push.
-    "**/test-results/",
-    "**/playwright-report/",
-    "reports/",
-    "a11y-reports/",
+    "**/test-results/**",
+    "**/playwright-report/**",
+    "**/reports/**",
+    "**/a11y-reports/**",
+    // Claude Code agent worktrees: full checkouts of this repo living inside
+    // it, so their Markdown is a duplicate of files already linted here.
+    "**/.claude/**",
     "CHANGELOG.md",
     ".github/PULL_REQUEST_TEMPLATE.md",
   ],

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -34,6 +34,10 @@
     "**/playwright-report/**",
     "**/reports/**",
     "**/a11y-reports/**",
+    // lychee-action writes its run summary to lychee/out.md inside the
+    // workspace before `check:all` runs, so CI lints a file whose format lychee
+    // controls, not us. Same failure shape as the Playwright contexts above.
+    "**/lychee/**",
     // Claude Code agent worktrees: full checkouts of this repo living inside
     // it, so their Markdown is a duplicate of files already linted here.
     "**/.claude/**",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 ## [Unreleased]
 
 ### Fixed
+- **The local quality gate can be run again.** `npm run check:all` — the
+  pre-push gate — failed for reasons unrelated to any code under review, so
+  changes were going out under `--no-verify` with CI as the only check. Two
+  causes, both silent. Every *directory* entry in `.markdownlint-cli2.jsonc`
+  used a bare trailing slash (`dist/`, `**/test-results/`); markdownlint-cli2
+  matches those globs against *file* paths, so they matched nothing and ignored
+  nothing — including the entry whose own comment said it existed so a failing
+  e2e run would not block the push. And nothing excluded `.claude/`, where
+  Claude Code keeps agent worktrees: full checkouts of this repo living inside
+  it, which made ESLint report every finding once per worktree (379 errors, all
+  from copies) and `jscpd` measure the tree against six near-copies of itself
+  (78.55% duplication against a 1% threshold). `jscpd`'s own `"gitignore": true`
+  did not cover it either, so the exclusion is explicit. `lychee/out.md`, which
+  `lychee-action` writes into the workspace before the gate runs, is excluded
+  for the same reason as the Playwright contexts. `shared/tests/gate-ignores.test.ts`
+  now pins all of it: a non-compliant file is dropped into each ignored location
+  and the gate must stay quiet, while an un-ignored one must still be reported —
+  so the ignores cannot silently go inert again.
+
 
 - **Chat is no longer silently dead after a socket reconnect** ([#69]). Two
   compounding faults: (1) `getStaffSocket()`/`getVisitorSocket()` called

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,11 @@ export default tseslint.config(
       '**/e2e/generated/**',
       'reports/**',
       '**/.vite/**',
+      // Claude Code agent worktrees: full checkouts of this repo living inside
+      // it. Without this, `npm run lint` type-checks every file six times over
+      // and reports the same findings once per worktree, which made the
+      // pre-push gate unrunnable for anyone using them.
+      '**/.claude/**',
       // Standalone Node tooling scripts (siblings of the existing *.sh gates);
       // run directly with `node`, outside any tsconfig, so typed linting can't
       // resolve them.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,10 +26,11 @@ export default tseslint.config(
       'reports/**',
       '**/.vite/**',
       // Claude Code agent worktrees: full checkouts of this repo living inside
-      // it. Without this, `npm run lint` type-checks every file six times over
-      // and reports the same findings once per worktree, which made the
-      // pre-push gate unrunnable for anyone using them.
-      '**/.claude/**',
+      // it. Without this, `npm run lint` type-checks every file once per
+      // worktree and reports the same findings that many times over, which made
+      // the pre-push gate unrunnable for anyone using them. Pinned by
+      // `shared/tests/gate-ignores.test.ts`.
+      '.claude/**',
       // Standalone Node tooling scripts (siblings of the existing *.sh gates);
       // run directly with `node`, outside any tsconfig, so typed linting can't
       // resolve them.

--- a/shared/tests/gate-ignores.test.ts
+++ b/shared/tests/gate-ignores.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression guard for the quality-gate ignore lists.
+ *
+ * These ignore lists are future-failure guards, and they have already failed
+ * silently once: every directory entry in `.markdownlint-cli2.jsonc` was
+ * written with a bare trailing slash ("dist/", "**\/test-results/"), which
+ * matches no *file* and therefore ignored nothing — while a comment in the same
+ * file asserted the entries existed precisely so a failing e2e run would not
+ * block the push. The gate stayed red for a reason nobody could see.
+ *
+ * Reading the config cannot catch that; only running the real tool can. So each
+ * case below drops a deliberately non-compliant file into an ignored location
+ * and asserts the tool stays quiet, AND drops the same file into a non-ignored
+ * location and asserts the tool still complains. Without that second half the
+ * test would pass just as happily against a tool that reported nothing at all.
+ *
+ * The markdownlint and jscpd cases run hermetically: the repo's real config is
+ * copied into a throwaway directory, so the assertions never depend on the
+ * contents of this repository.
+ *
+ * Note on jscpd: `.jscpd.json` sets `"gitignore": true` and `.claude/` is listed
+ * in `.gitignore`, yet jscpd scanned it anyway — so that flag is not what keeps
+ * the worktrees out, the explicit `**\/.claude/**` entry is. `.jscpd.json` is
+ * plain JSON and cannot carry a comment saying so, hence this note. If the
+ * explicit entry is ever removed on the assumption that `gitignore: true`
+ * covers it, the jscpd case below fails.
+ */
+/*
+ * This is a tooling-integration test: it builds throwaway directories on disk
+ * and invokes real CLIs, so synchronous fs and computed temp paths are
+ * intentional. Those two rules are disabled for this file only, matching
+ * `secret-scan.suspected.test.ts`.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Walk up from `start` until the directory holding the root markdownlint config.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, '.markdownlint-cli2.jsonc'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('could not locate .markdownlint-cli2.jsonc from ' + start);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+
+/** Markdown that violates MD025 (two h1s) and MD040 (unlanguaged fence). */
+const BAD_MARKDOWN = '# One\n\n# Two\n\n```\nx\n```\n';
+
+/**
+ * Directories the markdownlint config must ignore. `.claude` holds Claude Code
+ * agent worktrees; the rest are generated artifacts whose Markdown is produced
+ * by other tools and is not ours to keep compliant.
+ */
+const IGNORED_MARKDOWN_DIRS = [
+  'dist',
+  'build',
+  'coverage',
+  'test-results',
+  'playwright-report',
+  'reports',
+  'a11y-reports',
+  'lychee',
+  '.claude',
+];
+
+/** A directory that must NOT be ignored — the control. */
+const LINTED_DIR = 'docs';
+
+const scratchDirs: string[] = [];
+
+/**
+ * Create a throwaway directory, registered for cleanup.
+ * @param prefix - Temp-directory prefix.
+ * @returns The directory path.
+ */
+function scratch(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('markdownlint ignore list', () => {
+  /**
+   * Run the repo's real markdownlint config over a throwaway tree.
+   * @param dirs - Directories to seed with a non-compliant file.
+   * @returns Combined stdout+stderr from markdownlint-cli2.
+   */
+  function runAgainst(dirs: string[]): string {
+    const root = scratch('mdl-ignores-');
+    copyFileSync(
+      join(REPO_ROOT, '.markdownlint-cli2.jsonc'),
+      join(root, '.markdownlint-cli2.jsonc'),
+    );
+    for (const d of dirs) {
+      mkdirSync(join(root, d), { recursive: true });
+      writeFileSync(join(root, d, 'probe.md'), BAD_MARKDOWN);
+    }
+    // Same argv the `markdownlint` npm script uses, so this exercises the real
+    // invocation rather than a convenient approximation.
+    const run = spawnSync(
+      join(REPO_ROOT, 'node_modules', '.bin', 'markdownlint-cli2'),
+      ['**/*.md', '#**/node_modules/**'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    return [run.stdout, run.stderr].join('');
+  }
+
+  it('reports a non-compliant file in a directory that is not ignored', () => {
+    // Red-before-green: without this, the case below would pass just as happily
+    // against a markdownlint that had stopped reporting anything at all.
+    const output = runAgainst([LINTED_DIR]);
+    expect(output).toContain(`${LINTED_DIR}/probe.md`);
+    expect(output).toContain('MD025');
+  });
+
+  it('ignores a non-compliant file in every ignored directory', () => {
+    // One run seeding every ignored directory plus the control: the control
+    // firing proves the run happened, so each absence below is meaningful.
+    const output = runAgainst([...IGNORED_MARKDOWN_DIRS, LINTED_DIR]);
+    expect(output).toContain(`${LINTED_DIR}/probe.md`);
+    for (const dir of IGNORED_MARKDOWN_DIRS) {
+      expect(output, `${dir}/ should be ignored`).not.toContain(`${dir}/probe.md`);
+    }
+  });
+});
+
+describe('eslint ignore list', () => {
+  // Loading the root flat config pulls in the typed-linting setup, which takes
+  // well over vitest's 5s default on a cold run.
+  it('ignores .claude/ but still lints real source', { timeout: 60_000 }, async () => {
+    const { ESLint } = await import('eslint');
+    const eslint = new ESLint({ cwd: REPO_ROOT });
+    // Claude Code agent worktrees are full checkouts of this repo living inside
+    // it; linting them reports every finding once per worktree.
+    await expect(eslint.isPathIgnored('.claude/worktrees/agent-x/api/src/app.ts')).resolves.toBe(
+      true,
+    );
+    // Control: the same shape of path outside .claude/ must still be linted.
+    await expect(eslint.isPathIgnored('api/src/app.ts')).resolves.toBe(false);
+  });
+});
+
+describe('jscpd ignore list', () => {
+  it('ignores duplicates inside .claude/ but still finds them in real source', () => {
+    const root = scratch('jscpd-ignores-');
+    copyFileSync(join(REPO_ROOT, '.jscpd.json'), join(root, '.jscpd.json'));
+    // A block long enough to clear the config's minLines/minTokens floor.
+    const dupe = Array.from(
+      { length: 12 },
+      (_, i) =>
+        `export function probeFunction${String(i)}(value: number): number {\n` +
+        `  const doubled = value * 2;\n  const offset = doubled + ${String(i)};\n` +
+        `  return offset;\n}\n`,
+    ).join('\n');
+    for (const d of ['.claude/worktrees/agent-x/src', 'src']) {
+      mkdirSync(join(root, d), { recursive: true });
+      writeFileSync(join(root, d, 'a.ts'), dupe);
+      writeFileSync(join(root, d, 'b.ts'), dupe);
+    }
+    const run = spawnSync(
+      join(REPO_ROOT, 'node_modules', '.bin', 'jscpd'),
+      ['--config', join(root, '.jscpd.json'), '--reporters', 'console', '--threshold', '100', '.'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    const output = [run.stdout, run.stderr].join('');
+    // Control: the real-source pair is detected, so detection is working...
+    expect(output).toMatch(/src\/(a|b)\.ts/);
+    // ...and no clone is attributed to the agent worktree.
+    expect(output).not.toContain('.claude');
+  });
+});


### PR DESCRIPTION
## What

`npm run check:all` — the pre-push gate — could not pass locally. Two independent
causes, both of which failed **silently**: a set of ignore rules that read as
correct and did nothing, and a directory nothing excluded at all.

### 1. Every markdownlint ignore was inert

`markdownlint-cli2` matches `ignores` globs against *file* paths, so a directory
pattern has to end in `/**`. All eleven entries used a bare trailing slash
(`dist/`, `**/test-results/`, …), which matches no file and therefore ignored
nothing.

The config even carried a comment saying `**/test-results/` existed so that a
failing e2e run would not also fail the markdownlint gate and block the push —
and that is exactly what kept happening, because the entry was inert. Playwright
writes `error-context.md` into `test-results/`, so any local e2e failure blocked
every subsequent push.

### 2. lychee's generated summary was being linted

`lychee-action` writes its run summary to `lychee/out.md` **inside the workspace**,
in the `check` job, *before* `npm run check:all` runs. So CI lints a file whose
Markdown lychee produces and we do not control — which is why CI linted 37 files
where a local checkout lints 36.

It passes today, but the first time lychee emits a fenced block without a
language or a second top-level heading, `check` fails for a reason unrelated to
any documentation here. Same failure shape as cause 1, so it gets the same fix.

### 3. Nothing excluded `.claude/`

Claude Code agent worktrees are full checkouts of this repo living inside it. So
`eslint` type-checked every file once per worktree and reported the same findings
six times over (**379 errors, every one from a copy**), and `jscpd` compared the
tree against six near-identical copies of itself and reported **78.55%**
duplication against a 1% threshold.

Note `.claude/` *is* already in `.gitignore`, and `.jscpd.json` sets
`"gitignore": true` — neither helped, which is why the fix is an explicit ignore
in each tool.

## Why

No issue — found while reproducing the CI gate locally during review of #126.

This matters beyond convenience: `CLAUDE.md` states *"Local gates are preferred
over GitHub Actions. Keep CI as a safety net."* A pre-push gate that cannot run
inverts that, and pushes it can't judge end up going out under `--no-verify`.

## User-facing changes?

- [x] No — tooling configuration only. No runtime, API, or UI code is touched.

## Cookies / storage

- [x] No cookie or browser-storage behavior changed.

## Test plan

- [x] `npm run check:all` passes locally — **this PR was pushed through the full
      pre-push gate, not with `--no-verify`.**

Before → after on one machine:

```text
npm run lint     379 errors  ->  clean
npm run dupes    78.55%      ->  0.78%   (245 files scanned, was 1452)
markdownlint     163 files   ->  36 files
npm run check    fail        ->  pass
git push         fail        ->  pass (full check:all)
```

### Each ignore is verified, not assumed

The defect being fixed is an ignore that *looks* right and does nothing, so the
fix is held to the standard the bug failed:

- A deliberately non-compliant Markdown file was placed in **all eight** ignored
  locations (`test-results/`, `playwright-report/`, `reports/`, `a11y-reports/`,
  `.claude/`, `dist/`, `build/`, `coverage/`) and confirmed **skipped**.
- The same file in a non-ignored location (`docs/`) was confirmed **still
  reported** — so the check discriminates rather than passing vacuously.
- Same both ways for eslint: an `any` inside `.claude/` is skipped; an identical
  `any` in `api/src/` is still caught.
- Nothing is over-excluded: 38 tracked `.md` files, minus `CHANGELOG.md` and this
  template, is 36 — and markdownlint lints exactly 36. Both of those file-level
  ignores were themselves checked by appending failing content and confirming it
  went unreported, rather than trusted because they looked right.

`reports/` and `a11y-reports/` are widened to `**/` form so per-workspace copies
are covered too. `stylelint` was checked and is unaffected, so it is left alone.

### Not addressed

Trivy still walks `.claude/worktrees/*/Dockerfile` during the security sweep. It
reports 0 findings and blocks nothing — wasted work rather than a defect.

## Screenshots / recordings

Not applicable — no UI change.

---

**Stacked on #126.** Based on `fix/ci-workspace-node-modules-symlinks` rather than
`develop`, because checking out `develop` restores the tracked `node_modules`
**symlinks** over real directories — the very hazard #126 removes. Merge #126
first; GitHub will retarget this to `develop` automatically.
