### PR TITLE
fix(api): drop npm, npx, corepack and yarn from the runtime image

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -106,7 +106,10 @@ jobs:
     kind: PRE_DEPLOY
     dockerfile_path: api/Dockerfile
     source_dir: /
-    run_command: npm --workspace @livechat/api run migrate
+    # Invoked from node_modules/.bin rather than via npm: the image no longer
+    # ships a package manager (#132). WORKDIR is /app/api, which is what
+    # api/.sequelizerc resolves its paths against.
+    run_command: /app/node_modules/.bin/sequelize-cli db:migrate
     envs:
       - { key: DB_HOST, value: "${db.HOSTNAME}" }
       - { key: DB_PORT, value: "${db.PORT}" }
@@ -120,7 +123,8 @@ jobs:
     kind: POST_DEPLOY
     dockerfile_path: api/Dockerfile
     source_dir: /
-    run_command: npx tsx api/src/scripts/seed-first-tenant.ts
+    # Absolute paths — no npx in the image (#132).
+    run_command: /app/node_modules/.bin/tsx /app/api/src/scripts/seed-first-tenant.ts
     instance_count: 0
     envs:
       - { key: DB_HOST, value: "${db.HOSTNAME}" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
 ## [Unreleased]
 
+### Security
+- **The api image no longer ships a package manager, clearing a CRITICAL CVE.**
+  `trivy image` was failing the gate on `CVE-2026-59873` (node-tar DoS via a
+  crafted gzip bomb) plus seven HIGHs in `brace-expansion`, `ip-address`,
+  `picomatch` and `sigstore`. None of them were ours — `tar` does not appear in
+  `package-lock.json` at all; every one came from the dependency tree vendored
+  inside the npm that ships in `node:22-alpine`, so no dependency bump in this
+  repo could have fixed them and Dependabot would never have seen them. npm,
+  npx, corepack and yarn are now removed from the runtime stage, and the things
+  that actually ran through them are invoked from `node_modules/.bin` directly:
+  `CMD` execs `tsx` instead of `npm run start` (one fewer process in the
+  container), and the migrate/seed jobs in `.do/app.yaml` and the migrate
+  service in `docker-compose.prod.yml` call `sequelize-cli` / `tsx` by path.
+  `WORKDIR` is now `/app/api` so cwd-relative config still resolves as it did
+  under `npm --workspace` — notably `api/.sequelizerc`. Deleting rather than
+  upgrading npm removes the whole class of finding instead of resetting its
+  clock. Verified: image builds, container reaches `healthy` and serves
+  `/api/v1/health`, `sequelize-cli db:migrate` applies all 13 tables from the
+  image, and `trivy image --severity CRITICAL --exit-code 1` now exits 0 with no
+  HIGH or CRITICAL findings at all. ([#132])
+
 ### Fixed
 - **The local quality gate can be run again.** `npm run check:all` — the
   pre-push gate — failed for reasons unrelated to any code under review, so
@@ -414,6 +435,7 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
   payload slice body-parser puts in `err.message` is never echoed).
 
 [#57]: https://github.com/AFixt/livechat/issues/57
+[#132]: https://github.com/AFixt/livechat/issues/132
 [#66]: https://github.com/AFixt/livechat/issues/66
 [#68]: https://github.com/AFixt/livechat/issues/68
 [#69]: https://github.com/AFixt/livechat/issues/69

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -34,9 +34,37 @@ COPY api/src api/src
 COPY shared/package.json shared/
 COPY shared/src shared/src
 
+# Remove npm and corepack from the runtime image (#132). The base image's
+# bundled npm carries its own vendored dependency tree, which is where every
+# vulnerability `trivy image` reports against this image comes from — a
+# CRITICAL in `tar` (CVE-2026-59873) plus seven HIGHs in `brace-expansion`,
+# `ip-address`, `picomatch` and `sigstore`. None are ours: `tar` does not
+# appear in package-lock.json at all.
+#
+# Nothing in the running container needs a package manager — the dependencies
+# are already installed and copied in, and `tsx` / `sequelize-cli` are invoked
+# from node_modules/.bin directly (see CMD below, .do/app.yaml jobs, and the
+# migrate service in docker-compose.prod.yml). Deleting rather than upgrading
+# removes the whole class of finding instead of resetting its clock.
+#
+# yarn goes too. The base image ships it at /opt/yarn-* with its own vendored
+# tree; it scans clean today, but it is the same shape of risk and nothing here
+# uses it. Removing every package manager means a future advisory in any of
+# their bundled dependencies cannot reach this image at all.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+    /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    /opt/yarn-* /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
 # Drop to the unprivileged user the node images ship with. Everything above
 # is copied read-only, so no chown is needed.
 USER node
+
+# The api workspace is the working directory, because that is the cwd
+# `npm --workspace @livechat/api` established and some config is resolved
+# against it — notably api/.sequelizerc, which does `path.resolve('src', ...)`.
+# Keeping it identical means the migrate job and any `docker exec` behave as
+# before, now that the npm indirection is gone.
+WORKDIR /app/api
 
 EXPOSE 3000
 
@@ -49,4 +77,6 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["wget", "--quiet", "--output-document=/dev/null", "http://127.0.0.1:3000/api/v1/health"]
 
-CMD ["npm", "--workspace", "@livechat/api", "run", "start"]
+# Exec `tsx` directly rather than via `npm run start` (#132) — same command the
+# `start` script runs, one fewer process, and no package manager in the image.
+CMD ["/app/node_modules/.bin/tsx", "src/server.ts"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,7 +50,9 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
-    command: ["npm", "--workspace", "@livechat/api", "run", "migrate"]
+    # No package manager in the image (#132); WORKDIR is /app/api, which is
+    # what api/.sequelizerc resolves against.
+    command: ["/app/node_modules/.bin/sequelize-cli", "db:migrate"]
 
   api:
     build:


### PR DESCRIPTION
Closes #132.

`trivy image` has been failing the CRITICAL gate on the api image. The finding is real, but it is not in our code:

| Package | CVE | Severity | Installed | Fixed in |
|---|---|---|---|---|
| `tar` | CVE-2026-59873 | **CRITICAL** | 7.5.11 | 7.5.19 |
| `tar` | CVE-2026-59874 | HIGH | 7.5.11 | 7.5.18 |
| `brace-expansion` | CVE-2026-13149 / -14257 / -69152 | HIGH | 2.0.2 | 2.1.2 / 2.1.3 / 2.1.4 |
| `ip-address` | CVE-2026-69192 | HIGH | 10.1.0 | 10.3.1 |
| `picomatch` | CVE-2026-33671 | HIGH | 4.0.3 | 4.0.4 |
| `sigstore` | CVE-2026-48815 | HIGH | 3.1.0 | 4.1.1 |

`tar` does not appear in `package-lock.json` and `npm ls tar` is empty. All six are npm internals, vendored inside the npm that ships in `node:22-alpine` (npm 10.9.8 bundles `tar` 7.5.11). No dependency bump here could have fixed them, and Dependabot would never have surfaced them.

## Approach

Nothing in the *running* container needs a package manager — dependencies are installed at build time and copied in. So remove rather than upgrade: upgrading npm also clears it today (npm 12.0.2 bundles `tar` 7.5.19, confirmed), but it resets the clock rather than retiring the class.

npm, npx, corepack and **yarn** are deleted from the runtime stage. yarn scans clean today but is the same shape of risk: a vendored tree nothing here uses.

The things that actually ran through npm are now invoked directly:

- **`CMD`** execs `tsx` instead of `npm run start` — which is exactly what the `start` script does. One fewer process, and signals reach the server without an npm wrapper in between.
- **`WORKDIR` is now `/app/api`** — the cwd `npm --workspace @livechat/api` established. This matters: `api/.sequelizerc` does `path.resolve('src', ...)`, so migrations resolve their paths against cwd.
- **`.do/app.yaml`** `migrate` (PRE_DEPLOY) and `seed-first-tenant` (POST_DEPLOY), and the **`docker-compose.prod.yml`** `migrate` service, call `sequelize-cli` / `tsx` by path.

That last group is the part worth reviewing closely. Those were the only npm invocations against this image, and removing npm without updating them would have broken **every deploy** at the pre-deploy migration step.

## Verification

Against the local docker-compose stack:

- Image builds; `npm`, `npx`, `corepack`, `yarn`, `yarnpkg` and `/opt/yarn-*` all absent; `node` still present.
- Container reaches `healthy` and serves `/api/v1/health` → `{"success":true,"data":{"status":"ok","socketAdapter":"ready"}}`.
- `PID 1` is `node /app/node_modules/.bin/tsx src/server.ts` — no npm wrapper.
- **Migrations run from inside the image**: `sequelize-cli db:migrate` against a fresh database applied every migration and created all 13 tables.
- `trivy config` — 0 misconfigurations across all three Dockerfiles.
- The exact gate from `scripts/trivy-image.sh` — `trivy image --scanners vuln --severity CRITICAL --exit-code 1` — **exits 0**, with no HIGH or CRITICAL findings at all.

## Caveats

- **The DigitalOcean deploy path is not something I can exercise locally.** The `.do/app.yaml` `run_command` changes are verified only insofar as the same binary invocation works inside the image. The migrate job is PRE_DEPLOY, so if it is wrong the deploy halts there rather than serving broken code — but it deserves a real deploy before being trusted.
- Deleting in a later layer leaves the files in the *base* layer blob; Trivy scans the squashed filesystem, so the gate is satisfied and nothing is reachable in a running container, but the bytes still exist in the image history. Getting rid of that entirely means a distroless/scratch runtime, which is a much larger change.
- `hadolint` and `checkov` are not installed locally, so those two Dockerfile gates are **not verified** here — CI covers them.
- This does not fix #130. `ui` and `widget` still fail to build on the private-registry 404, so they are still never scanned and may carry findings of their own.