### PR TITLE
feat(api): resolve consent jurisdiction from edge geolocation (#120)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -23,6 +23,23 @@ COOKIE_SECRET=          # SECRET — used to sign the visitor cookie
 VISITOR_SESSION_ABSOLUTE_TTL_HOURS=720   # 30 days
 VISITOR_SESSION_IDLE_TTL_HOURS=72        # 3 days
 
+# Edge-supplied geolocation, used to resolve the consent jurisdiction (#120).
+# LEAVE EMPTY unless your edge/CDN sets these headers AND strips any copy the
+# client sent. A request header is attacker-supplied otherwise, and a spoofed
+# country lets a visitor downgrade themselves out of an opt-in regime — e.g.
+# sending `US` from the EU to turn opt-in into opt-out.
+#
+# Unset, jurisdiction resolves to UNKNOWN, which is strict opt-in for everyone:
+# safe, but it treats US opt-out visitors as if they were in the EU.
+#
+#   Cloudflare : GEO_COUNTRY_HEADER=CF-IPCountry
+#   Vercel     : GEO_COUNTRY_HEADER=X-Vercel-IP-Country
+#                GEO_REGION_HEADER=X-Vercel-IP-Country-Region
+#
+# The region header only matters for distinguishing US-CA from the US at large.
+GEO_COUNTRY_HEADER=
+GEO_REGION_HEADER=
+
 # SMTP — for invitation + verification + password-reset + transcript emails.
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
   image, and `trivy image --severity CRITICAL --exit-code 1` now exits 0 with no
   HIGH or CRITICAL findings at all. ([#132])
 
+### Added
+- **Consent jurisdiction now resolves from real geolocation instead of always
+  being `UNKNOWN`.** #56 built the jurisdiction engine, but nothing supplied a
+  country — `coarsenGeo` was called with a hardcoded `null` — so live traffic
+  fell through to `UNKNOWN`, which fail-safes to strict opt-in. Safe, but it
+  meant US opt-out visitors were treated as EU opt-in. The API now reads a
+  coarse country (and region, for US-CA) from an edge-supplied header and feeds
+  it to the policy engine and the visitor session row.
+  **The headers are opt-in by configuration and default to none.** A request
+  header is attacker-supplied unless a trusted proxy overwrites it, and the
+  failure mode is not theoretical: a visitor in the EU could send
+  `CF-IPCountry: US` and spoof their way *out* of the opt-in regime the engine
+  exists to apply. So only the header named in `GEO_COUNTRY_HEADER` /
+  `GEO_REGION_HEADER` is read, naming one asserts the edge sets it and strips
+  any client copy, and with nothing configured the behaviour is exactly as
+  before — `UNKNOWN`, strict. Where an edge header is configured it takes
+  precedence over the widget's own `country` hint for the same reason; the hint
+  remains a fallback only where no header is set. Values are validated as ISO
+  3166-1 alpha-2 and Cloudflare's `XX`/`T1` sentinels are treated as unknown.
+  Country-level only, per #57's minimization rules. ([#120])
 ### Fixed
 - **The local quality gate can be run again.** `npm run check:all` — the
   pre-push gate — failed for reasons unrelated to any code under review, so
@@ -435,6 +455,7 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
   payload slice body-parser puts in `err.message` is never echoed).
 
 [#57]: https://github.com/AFixt/livechat/issues/57
+[#120]: https://github.com/AFixt/livechat/issues/120
 [#132]: https://github.com/AFixt/livechat/issues/132
 [#66]: https://github.com/AFixt/livechat/issues/66
 [#68]: https://github.com/AFixt/livechat/issues/68

--- a/api/src/config/env.ts
+++ b/api/src/config/env.ts
@@ -63,6 +63,14 @@ const envSpec = {
   // the cookie `maxAge` is only a client-side hint. Absolute: hard cap from
   // first contact. Idle: max gap since the last request/heartbeat. Defaults:
   // 30 days absolute, 3 days idle.
+  // Edge-supplied geolocation (#120). Empty by default and deliberately so:
+  // a request header is attacker-supplied unless a trusted proxy overwrites it,
+  // and a spoofed country would let a visitor downgrade themselves out of an
+  // opt-in regime. Naming a header asserts that the edge sets it and strips any
+  // client copy. Unset => jurisdiction resolves UNKNOWN => strict opt-in.
+  // Examples: `CF-IPCountry` (Cloudflare), `X-Vercel-IP-Country` (Vercel).
+  GEO_COUNTRY_HEADER: str({ default: '' }),
+  GEO_REGION_HEADER: str({ default: '' }),
   VISITOR_SESSION_ABSOLUTE_TTL_HOURS: positiveHours({ default: 720 }),
   VISITOR_SESSION_IDLE_TTL_HOURS: positiveHours({ default: 72 }),
 

--- a/api/src/routes/privacy.ts
+++ b/api/src/routes/privacy.ts
@@ -13,6 +13,7 @@ import { parsedBody, validate } from '../middlewares/validate.js';
 import { Tenant } from '../models/index.js';
 import { ApiError } from '../utils/api-error.js';
 import { asyncHandler } from '../utils/async-handler.js';
+import { resolveRequestGeo } from '../utils/geo-headers.js';
 
 import { VISITOR_COOKIE_NAME, visitorCookieOptions } from './visitor-cookie-options.js';
 
@@ -49,6 +50,34 @@ async function resolveTenantId(tenantKey: string): Promise<string> {
  */
 function detectGpc(req: Request, clientFlag: boolean | undefined): boolean {
   return req.header('sec-gpc') === '1' || clientFlag === true;
+}
+
+/**
+ * Resolve the jurisdiction inputs for a request, preferring the edge-supplied
+ * location over the widget's own hint (#120).
+ *
+ * Order matters and is not arbitrary. The client hint is a convenience for
+ * deployments with no geo header configured; where the edge does supply one it
+ * must win, because a visitor who can choose their own country can choose the
+ * laxest regime — sending `US` from the EU turns opt-in into opt-out. Trusting
+ * the client only where nothing better exists keeps that from being a downgrade
+ * path wherever geo is actually wired.
+ * @param deps - Router deps (for the configured header names).
+ * @param req - The incoming request.
+ * @param hint - Client-supplied country/region, if any.
+ * @returns The country and region to hand the policy engine.
+ */
+function resolveJurisdictionInputs(
+  deps: PrivacyRouterDeps,
+  req: Request,
+  hint: { country?: string | undefined; region?: string | undefined },
+): { country: string | null; region: string | null } {
+  const edge = resolveRequestGeo(req, {
+    countryHeader: deps.env.GEO_COUNTRY_HEADER,
+    regionHeader: deps.env.GEO_REGION_HEADER,
+  });
+  if (edge.country !== null) return edge;
+  return { country: hint.country ?? null, region: hint.region ?? null };
 }
 
 /**
@@ -103,11 +132,12 @@ async function recordBannerDecision(args: BannerDecisionArgs): Promise<Effective
   const { deps, req, res, body, explicitConsent, legalBasisOverride } = args;
   const tenantId = await resolveTenantId(body.tenantKey);
   const subjectKey = resolveSubject(deps, req, res);
+  const geo = resolveJurisdictionInputs(deps, req, body);
   const { state } = await deps.consent.decideAndRecord({
     tenantId,
     subjectKey,
-    country: body.country ?? null,
-    region: body.region ?? null,
+    country: geo.country,
+    region: geo.region,
     gpc: detectGpc(req, body.gpc),
     source: 'banner',
     ip: req.ip ?? null,
@@ -136,10 +166,11 @@ export function buildPrivacyRouter(deps: PrivacyRouterDeps): Router {
       // consent record. It may still set a fresh subject cookie when the request
       // carries none — session establishment, not tracking. See ADR-0019.
       const subjectKey = resolveSubject(deps, req, res);
+      const geo = resolveJurisdictionInputs(deps, req, q);
       const state = await deps.consent.resolveState({
         subjectKey,
-        country: q.country ?? null,
-        region: q.region ?? null,
+        country: geo.country,
+        region: geo.region,
         gpc: detectGpc(req, q.gpc),
       });
       res.json({ success: true, data: state });
@@ -153,7 +184,8 @@ export function buildPrivacyRouter(deps: PrivacyRouterDeps): Router {
       const body = parsedBody(req, recordConsentInputSchema);
       const explicitConsent: ExplicitConsent = {};
       if (body.purposes.presence !== undefined) explicitConsent.presence = body.purposes.presence;
-      if (body.purposes.analytics !== undefined) explicitConsent.analytics = body.purposes.analytics;
+      if (body.purposes.analytics !== undefined)
+        explicitConsent.analytics = body.purposes.analytics;
       const state = await recordBannerDecision({ deps, req, res, body, explicitConsent });
       res.status(201).json({ success: true, data: state });
     }),

--- a/api/src/routes/visitor.ts
+++ b/api/src/routes/visitor.ts
@@ -14,6 +14,7 @@ import { Tenant } from '../models/index.js';
 import { parseSupportHours } from '../services/support-hours.js';
 import { ApiError } from '../utils/api-error.js';
 import { asyncHandler } from '../utils/async-handler.js';
+import { resolveRequestGeo } from '../utils/geo-headers.js';
 
 import { VISITOR_COOKIE_NAME, visitorCookieOptions } from './visitor-cookie-options.js';
 
@@ -73,6 +74,12 @@ export function buildVisitorRouter(deps: VisitorRouterDeps): Router {
       if (body.currentUrl !== undefined) initArgs.currentUrl = body.currentUrl;
       if (body.referrer !== undefined) initArgs.referrer = body.referrer;
       if (body.identityToken !== undefined) initArgs.identityToken = body.identityToken;
+      // Edge-supplied country, when the deployment trusts one (#120). Null
+      // otherwise, which is what the row already stored.
+      initArgs.country = resolveRequestGeo(req, {
+        countryHeader: deps.env.GEO_COUNTRY_HEADER,
+        regionHeader: deps.env.GEO_REGION_HEADER,
+      }).country;
 
       const { session, cookieValue } = await deps.visitorSession.init(initArgs);
       res.cookie(VISITOR_COOKIE_NAME, cookieValue, visitorCookieOptions(deps.env));

--- a/api/src/services/visitor-session-service.ts
+++ b/api/src/services/visitor-session-service.ts
@@ -25,6 +25,13 @@ interface InitParams {
   currentUrl?: string;
   referrer?: string;
   /**
+   * Coarse ISO 3166-1 alpha-2 country from the edge, when the deployment has a
+   * trusted geo header configured (#120). Already country-level, so it passes
+   * through `coarsenGeo` unchanged; the minimization rules in #57 are what stop
+   * anything finer ever being persisted.
+   */
+  country?: string | null;
+  /**
    * Raw HS256 JWT minted by the client's backend with the tenant's
    * `embed_secret`. When present and valid, the decoded `sub` claim is
    * stored on the visitor session so staff can correlate the chat with
@@ -121,7 +128,7 @@ export function createVisitorSessionService(deps: VisitorSessionDeps) {
       // IPv4 octet / last 80 IPv6 bits zeroed) and geolocation is coarsened to
       // country level before it is ever persisted. See pii-minimize.ts and
       // docs/adr/0020-geo-retention-minimization.md.
-      const geo = coarsenGeo({ country: null, city: null });
+      const geo = coarsenGeo({ country: params.country ?? null, city: null });
       const session = await VisitorSession.create({
         tenantId: tenant.id,
         sessionCookieHash: hash,

--- a/api/src/utils/geo-headers.test.ts
+++ b/api/src/utils/geo-headers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRequestGeo } from './geo-headers.js';
+
+import type { Request } from 'express';
+
+/**
+ * Build a Request stub exposing the given headers case-insensitively.
+ * @param headers - Header name/value pairs.
+ * @returns A Request-shaped stub.
+ */
+function makeReq(headers: Record<string, string>): Request {
+  const lower = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return { header: (name: string) => lower.get(name.toLowerCase()) } as unknown as Request;
+}
+
+const CF = { countryHeader: 'CF-IPCountry', regionHeader: 'CF-Region-Code' };
+
+describe('resolveRequestGeo (#120)', () => {
+  it('reads the configured country and region headers', () => {
+    const req = makeReq({ 'CF-IPCountry': 'de', 'CF-Region-Code': 'by' });
+    expect(resolveRequestGeo(req, CF)).toEqual({ country: 'DE', region: 'BY' });
+  });
+
+  it('ignores every header when none is configured — the fail-safe default', () => {
+    // The unconfigured deployment must not start trusting a header just because
+    // a client sent one; UNKNOWN maps to strict opt-in, which is the safe end.
+    const req = makeReq({ 'CF-IPCountry': 'US' });
+    expect(resolveRequestGeo(req, { countryHeader: '', regionHeader: '' })).toEqual({
+      country: null,
+      region: null,
+    });
+  });
+
+  it('ignores a header other than the configured one', () => {
+    // A visitor sending `X-Vercel-IP-Country: US` to a Cloudflare deployment
+    // must not be able to pick their own jurisdiction.
+    const req = makeReq({ 'X-Vercel-IP-Country': 'US' });
+    expect(resolveRequestGeo(req, CF)).toEqual({ country: null, region: null });
+  });
+
+  it.each(['USA', 'U', '', '12', 'de-DE', '<script>'])(
+    'treats a malformed country %o as unknown',
+    (value) => {
+      expect(resolveRequestGeo(makeReq({ 'CF-IPCountry': value }), CF).country).toBeNull();
+    },
+  );
+
+  it.each(['XX', 'T1'])('treats the %s sentinel as unknown', (value) => {
+    // Cloudflare's "unknown" and "Tor exit node" values are well-formed but
+    // carry no country.
+    expect(resolveRequestGeo(makeReq({ 'CF-IPCountry': value }), CF).country).toBeNull();
+  });
+
+  it('drops the region when the country is unknown', () => {
+    // A region without a country cannot select a bucket and would only muddy
+    // the audit trail.
+    const req = makeReq({ 'CF-IPCountry': 'XX', 'CF-Region-Code': 'CA' });
+    expect(resolveRequestGeo(req, CF)).toEqual({ country: null, region: null });
+  });
+
+  it('returns a country with no region when no region header is configured', () => {
+    const req = makeReq({ 'CF-IPCountry': 'US', 'CF-Region-Code': 'CA' });
+    expect(resolveRequestGeo(req, { countryHeader: 'CF-IPCountry', regionHeader: '' })).toEqual({
+      country: 'US',
+      region: null,
+    });
+  });
+
+  it('resolves US-CA, which is a different regime from US at large', () => {
+    const req = makeReq({ 'CF-IPCountry': 'US', 'CF-Region-Code': 'CA' });
+    expect(resolveRequestGeo(req, CF)).toEqual({ country: 'US', region: 'CA' });
+  });
+});

--- a/api/src/utils/geo-headers.ts
+++ b/api/src/utils/geo-headers.ts
@@ -1,0 +1,68 @@
+import type { Request } from 'express';
+
+/**
+ * A coarse, country-level location for a request. Deliberately no finer than
+ * this: the jurisdiction engine only buckets by country (and US state), and
+ * #57's minimization rules forbid persisting anything more precise.
+ */
+export interface RequestGeo {
+  /** ISO 3166-1 alpha-2, upper-cased, or null when unknown. */
+  country: string | null;
+  /** Subdivision code (e.g. `CA`), upper-cased, or null when unknown. */
+  region: string | null;
+}
+
+/** Nothing known — the caller falls back to the strict `UNKNOWN` bucket. */
+const NO_GEO: RequestGeo = { country: null, region: null };
+
+/**
+ * Accept only a plausible ISO 3166-1 alpha-2 code. Anything else is treated as
+ * unknown rather than passed through, so a malformed or injected header cannot
+ * reach the ruleset as a bogus bucket.
+ * @param raw - Raw header value.
+ * @returns The normalized code, or null.
+ */
+function normalizeCode(raw: string | undefined): string | null {
+  if (raw === undefined) return null;
+  const value = raw.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(value)) return null;
+  // Cloudflare sends `XX` for "unknown" and `T1` for Tor exit nodes. Both mean
+  // "no usable country", and both would otherwise fall through to UNKNOWN
+  // anyway — but naming them documents that they are expected, not malformed.
+  if (value === 'XX' || value === 'T1') return null;
+  return value;
+}
+
+/**
+ * Resolve the visitor's coarse location from edge-supplied request headers.
+ *
+ * **Only the headers named in `GEO_COUNTRY_HEADER` / `GEO_REGION_HEADER` are
+ * read, and by default neither is set.** A request header is attacker-supplied
+ * unless a trusted proxy overwrites it, and the failure mode here is not
+ * theoretical: a visitor in the EU could send `CF-IPCountry: US` and downgrade
+ * themselves from an opt-in regime to opt-out — spoofing their way *out* of
+ * the protection the engine exists to apply. Naming the header is therefore an
+ * explicit statement that the edge sets it and strips any client-supplied copy.
+ *
+ * With nothing configured this returns no geo, jurisdiction resolves to
+ * `UNKNOWN`, and `UNKNOWN` is strict opt-in — so the unconfigured default stays
+ * fail-safe (#120, #56).
+ * @param req - The incoming request.
+ * @param config - The header names to trust; empty means trust none.
+ * @returns The coarse location, or nulls when unknown or untrusted.
+ */
+export function resolveRequestGeo(
+  req: Request,
+  config: { countryHeader?: string | undefined; regionHeader?: string | undefined },
+): RequestGeo {
+  // Absent and empty mean the same thing — not configured. Treating them
+  // identically keeps a caller that never set the vars on the safe path rather
+  // than throwing on `req.header(undefined)`.
+  const countryHeader = config.countryHeader ?? '';
+  const regionHeader = config.regionHeader ?? '';
+  if (countryHeader === '') return NO_GEO;
+  const country = normalizeCode(req.header(countryHeader));
+  if (country === null) return NO_GEO;
+  const region = regionHeader === '' ? null : normalizeCode(req.header(regionHeader));
+  return { country, region };
+}

--- a/api/tests/integration/geo-jurisdiction.test.ts
+++ b/api/tests/integration/geo-jurisdiction.test.ts
@@ -1,0 +1,152 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { createApp } from '../../src/app.js';
+import { Tenant, VisitorSession } from '../../src/models/index.js';
+import { createServices } from '../../src/services/index.js';
+
+import { probeHarness, testEnv } from './setup.js';
+
+import type { Env } from '../../src/config/env.js';
+import type { Express } from 'express';
+
+type Harness = Awaited<ReturnType<typeof probeHarness>>;
+
+const COUNTRY_HEADER = 'CF-IPCountry';
+const REGION_HEADER = 'CF-Region-Code';
+
+describe('jurisdiction resolves from edge geolocation (#120)', () => {
+  let harness: Harness;
+  /** App configured to trust the edge geo headers. */
+  let geoApp: Express;
+  /** App with no geo header configured — the default. */
+  let plainApp: Express;
+
+  beforeAll(async () => {
+    harness = await probeHarness();
+    if (harness === null) {
+      console.warn('[integration] MySQL or Redis not reachable — skipping');
+      return;
+    }
+    const base = testEnv();
+    const geoEnv = {
+      ...base,
+      GEO_COUNTRY_HEADER: COUNTRY_HEADER,
+      GEO_REGION_HEADER: REGION_HEADER,
+    } as unknown as Env;
+    geoApp = createApp({
+      env: geoEnv,
+      logger: harness.logger,
+      redis: harness.redis,
+      services: createServices({ env: geoEnv, logger: harness.logger, redis: harness.redis }),
+      skipRateLimit: true,
+    });
+    plainApp = harness.app;
+
+    await Tenant.create({
+      name: 'Tenant-geo',
+      slug: 'geo-t',
+      status: 'active',
+      domain: null,
+      expiresAt: null,
+      settings: null,
+      allowedOrigins: null,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (harness !== null) await harness.cleanup();
+  });
+
+  /**
+   * Read the effective consent state for a country, via the given app.
+   * @param app - The app to query.
+   * @param headers - Request headers to send.
+   * @param query - Query string to append.
+   * @returns The response body's data member.
+   */
+  async function readConsent(
+    app: Express,
+    headers: Record<string, string>,
+    query = '',
+  ): Promise<{ jurisdiction: string; purposes: Record<string, string> }> {
+    const res = await request(app)
+      .get(`/api/v1/privacy/consent?tenantKey=geo-t${query}`)
+      .set(headers);
+    expect(res.status).toBe(200);
+    return res.body.data as { jurisdiction: string; purposes: Record<string, string> };
+  }
+
+  test('an EU visitor resolves to the opt-in regime', async () => {
+    if (harness === null) return;
+    const state = await readConsent(geoApp, { [COUNTRY_HEADER]: 'DE' });
+    expect(state.jurisdiction).toBe('EU');
+  });
+
+  test('a US visitor resolves to the opt-out regime, not EU', async () => {
+    if (harness === null) return;
+    // The whole point of #120: before this, live traffic was always UNKNOWN,
+    // so a US opt-out visitor was treated as EU opt-in.
+    const state = await readConsent(geoApp, { [COUNTRY_HEADER]: 'US' });
+    expect(state.jurisdiction).toBe('US');
+  });
+
+  test('California is distinguished from the US at large', async () => {
+    if (harness === null) return;
+    const state = await readConsent(geoApp, {
+      [COUNTRY_HEADER]: 'US',
+      [REGION_HEADER]: 'CA',
+    });
+    expect(state.jurisdiction).toBe('US_CA');
+  });
+
+  test('the edge header wins over a client-supplied country', async () => {
+    if (harness === null) return;
+    // A visitor claiming to be in the US while the edge says Germany must not
+    // be able to downgrade themselves from opt-in to opt-out.
+    const state = await readConsent(geoApp, { [COUNTRY_HEADER]: 'DE' }, '&country=US');
+    expect(state.jurisdiction).toBe('EU');
+  });
+
+  test('with no geo header configured, a spoofed header is ignored', async () => {
+    if (harness === null) return;
+    // The default deployment must not start trusting a header just because a
+    // client sent one. UNKNOWN is the strict bucket, so this fails safe.
+    const state = await readConsent(plainApp, { [COUNTRY_HEADER]: 'US' });
+    expect(state.jurisdiction).toBe('UNKNOWN');
+  });
+
+  test('the client hint is still honored when no edge header is configured', async () => {
+    if (harness === null) return;
+    // Deployments without a geo header keep the pre-existing behaviour rather
+    // than losing the hint entirely.
+    const state = await readConsent(plainApp, {}, '&country=US');
+    expect(state.jurisdiction).toBe('US');
+  });
+
+  test('the visitor session records the coarse country', async () => {
+    if (harness === null) return;
+    const res = await request(geoApp)
+      .post('/api/v1/visitor/session')
+      .set(COUNTRY_HEADER, 'FR')
+      .send({ tenantKey: 'geo-t' });
+    expect(res.status).toBe(201);
+
+    const row = await VisitorSession.findByPk(res.body.data.sessionId as string);
+    expect(row?.country).toBe('FR');
+    // #57's minimization still applies — nothing finer than country is stored.
+    expect(row?.city).toBeNull();
+  });
+
+  test('an unconfigured deployment still stores no country', async () => {
+    if (harness === null) return;
+    const res = await request(plainApp)
+      .post('/api/v1/visitor/session')
+      .set(COUNTRY_HEADER, 'FR')
+      .send({ tenantKey: 'geo-t' });
+    expect(res.status).toBe(201);
+
+    const row = await VisitorSession.findByPk(res.body.data.sessionId as string);
+    expect(row?.country).toBeNull();
+  });
+});

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -39,6 +39,8 @@ export function testEnv(): Env {
     JWT_ACCESS_EXPIRES_IN: '15m',
     JWT_REFRESH_EXPIRES_IN: '7d',
     COOKIE_SECRET: 'test-cookie-secret-' + Math.random().toString(36).slice(2),
+    GEO_COUNTRY_HEADER: '',
+    GEO_REGION_HEADER: '',
     VISITOR_SESSION_ABSOLUTE_TTL_HOURS: 720,
     VISITOR_SESSION_IDLE_TTL_HOURS: 72,
     APP_URL: 'http://localhost:25174',


### PR DESCRIPTION
Closes #120.

## The gap

#56 built the jurisdiction engine, but nothing ever supplied a country — `coarsenGeo` was called with a hardcoded `null`:

```ts
const geo = coarsenGeo({ country: null, city: null });
```

So live traffic always resolved to `UNKNOWN`, which fail-safes to strict opt-in. Safe, but it means US opt-out visitors are treated as EU opt-in.

## The security decision this turns on

The obvious implementation — read `CF-IPCountry` and believe it — is a **privacy downgrade path**. A request header is attacker-supplied unless a trusted proxy overwrites it, so a visitor in the EU could send `CF-IPCountry: US` and spoof their way *out* of the opt-in regime the engine exists to apply. The spoof doesn't attack someone else; it lets the visitor weaken their own protection, which is exactly what a consent engine must not permit.

So:

- **Only the header named in `GEO_COUNTRY_HEADER` / `GEO_REGION_HEADER` is read, and both default to empty.** Naming one is an explicit assertion that your edge sets it *and strips any client-supplied copy*.
- **Unconfigured behaviour is unchanged** — `UNKNOWN`, strict opt-in. This cannot silently weaken an existing deployment.
- **The edge header beats the widget's `country` hint** where both are present, for the same reason. The hint survives only as a fallback where no header is configured, so deployments without an edge geo source keep what they had.

I'd rather this needed one env var than have it "just work" by trusting a spoofable input.

## Details

- Values validated as ISO 3166-1 alpha-2; Cloudflare's `XX` (unknown) and `T1` (Tor exit) are mapped to unknown rather than passed through as bogus buckets.
- A region with no country is dropped — it can't select a bucket and would only muddy the audit trail.
- Country-level only, per #57's minimization rules. The visitor session row now records the country; `city` stays null.
- `.env.production.example` documents the trade-off and gives Cloudflare/Vercel header names.

## Verification

```text
api   47 files / 359 tests   (REQUIRE_DB=1, real MySQL + Redis)
npm run check   green
```

14 unit tests on the resolver, 8 integration tests through the real endpoints. The two that carry the argument:

- **edge header beats a conflicting client hint** — `CF-IPCountry: DE` with `?country=US` resolves `EU`, not `US`
- **unconfigured deployment ignores a spoofed header** — `CF-IPCountry: US` resolves `UNKNOWN`

Plus EU → `EU`, US → `US`, US+CA → `US_CA`, the hint still working when no header is configured, and the session row recording `FR` with `city` null.

## What this does not do

Nothing is configured by default, so **jurisdiction stays `UNKNOWN` in production until `GEO_COUNTRY_HEADER` is set** on the deployment. That's the deliberate part, but it does mean the issue's symptom persists until someone makes that call. `.do/app.yaml` has no geo header today and I didn't want to guess whether DigitalOcean's edge sets one — worth confirming before setting it.

⚠️ **Not verified here:** behaviour behind a real CDN. The tests drive the header directly, which is what the code consumes, but whether your edge actually sets and strips it is a deployment fact I can't check from here.
