### PR TITLE
chore: merge main back into develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,3 +274,43 @@ Whenever I ask to review a PR (pull request), use the `pr-review` skill.
 - Before adding any new dependency, verify with `npm ls axe-core` that it does
   not introduce axe-core into the tree. If it does, do not add it.
 - Use `@afixt/a11y-assert` for accessibility checks instead.
+
+## CI policy: no scheduled GitHub Actions
+
+**No GitHub Actions workflow in this repository may use a `schedule:` (cron)
+trigger, and no scheduled workflow that has been removed may be added back.**
+This is a standing constraint, not a default to be traded away for convenience.
+
+A timer-triggered check reports a problem hours or days after it entered the
+codebase, attributes it to no one, and gets ignored. The same check run against a
+pull request blocks the defect at the point of introduction.
+
+### Rules
+
+- No `on: schedule:` and no `- cron:` in any file under `.github/workflows/`.
+- No `.github/dependabot.yml` — Dependabot is a scheduled updater and is covered
+  by this policy. GitHub **security alerts** are event-driven notifications, not
+  scheduled jobs, and remain enabled.
+- Every check a scheduled job would have performed runs as a step in the
+  pull-request pipeline instead:
+  - Dependency vulnerability and freshness checks (`npm audit`, `npm outdated`,
+    OWASP Dependency-Check) run on `pull_request`.
+  - Static analysis (CodeQL and equivalents) runs on `pull_request`.
+  - Link checking, docs linting, and content checks run on `pull_request`,
+    path-filtered to the files that can break them.
+  - SBOM generation runs in the release/publish pipeline — an SBOM is a build
+    output, not a periodic report.
+  - DAST scans (ZAP and equivalents) run against the PR preview environment or
+    as a post-deploy gate, not against a static URL on a timer.
+  - End-to-end suites run as a smoke subset on `pull_request` and as the full
+    matrix on merge to the default branch — never nightly.
+- `workflow_dispatch` is allowed. A manual, on-demand run is not a scheduled run.
+- Event-driven triggers (`push`, `pull_request`, `release`, `repository_dispatch`,
+  `workflow_call`) are allowed and preferred.
+- Genuinely periodic *product* work — batch jobs, data pipelines, report
+  generation — does not belong in GitHub Actions at all. Run it on real
+  infrastructure with its own scheduler, alerting, and retries.
+
+### If you think you need an exception
+
+You do not add the cron. Raise it with the repository owner first.


### PR DESCRIPTION
Back-merge so the release tags on `main` are reachable from `develop`.

**This was skipped after v0.2.0.** `git describe --tags origin/develop` returns `v0.1.0` while the newest tag is `v0.2.0` — `v0.2.0` sits on `019907c` (the #48 promotion merge) and is not an ancestor of develop. Without this, the next release computes its bump against a range reaching back past work that already shipped.

**It also carries one real content change.** `33f1ecc chore: forbid scheduled GitHub Actions in CLAUDE.md` was committed directly to `main` and never reached develop — a 40-line "no scheduled GitHub Actions" policy section. Worth knowing it existed only on main; it lines up with the #50 work that removed the crons, so bringing it across is the intent, not a surprise.

Merges cleanly (verified with `git merge-tree`). Merge commit only — squash or rebase would replay main's commits as new ones and leave the tags still unreachable, which is the whole point of this PR.