### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
-## [Unreleased]
+## [0.3.0] - 2026-08-22
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,8 +282,8 @@ trigger, and no scheduled workflow that has been removed may be added back.**
 This is a standing constraint, not a default to be traded away for convenience.
 
 A timer-triggered check reports a problem hours or days after it entered the
-codebase, attributes it to no one, and gets ignored. The same check run against a
-pull request blocks the defect at the point of introduction.
+codebase, attributes it to no one, and gets ignored. The same check run against
+a pull request blocks the defect at the point of introduction.
 
 ### Rules
 
@@ -304,10 +304,11 @@ pull request blocks the defect at the point of introduction.
     as a post-deploy gate, not against a static URL on a timer.
   - End-to-end suites run as a smoke subset on `pull_request` and as the full
     matrix on merge to the default branch — never nightly.
-- `workflow_dispatch` is allowed. A manual, on-demand run is not a scheduled run.
-- Event-driven triggers (`push`, `pull_request`, `release`, `repository_dispatch`,
-  `workflow_call`) are allowed and preferred.
-- Genuinely periodic *product* work — batch jobs, data pipelines, report
+- `workflow_dispatch` is allowed. A manual, on-demand run is not a scheduled
+  run.
+- Event-driven triggers (`push`, `pull_request`, `release`,
+  `repository_dispatch`, `workflow_call`) are allowed and preferred.
+- Genuinely periodic _product_ work — batch jobs, data pipelines, report
   generation — does not belong in GitHub Actions at all. Run it on real
   infrastructure with its own scheduler, alerting, and retries.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "UNLICENSED",
       "workspaces": [
         "shared",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",


### PR DESCRIPTION
Version bump and changelog promotion for v0.3.0.

**Minor**, from the commit range since `v0.2.0`: 206 commits, 12 `feat`, no `BREAKING CHANGE` footer and no `feat!`/`fix!`.

The baseline needed repairing first — `git describe` on develop returned `v0.1.0` because the back-merge after v0.2.0 was skipped, so the range would otherwise have reached back past work that already shipped. Fixed in #144.

Also carries one incidental fix: the "no scheduled GitHub Actions" section that #144 brought across from `main` was committed directly there, so it never went through the pre-push gate and carried an MD049 violation that blocked every push once develop had it.