### PR TITLE
fix(tooling): skip the pre-push gate on branch deletions

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,8 +15,6 @@
 #
 # If no refs arrive on stdin (an invocation shape we don't recognise), fall
 # through and run the gate: the safe default is to check, not to skip.
-ZERO_SHA=0000000000000000000000000000000000000000
-
 saw_ref=0
 no_new_commits=1
 
@@ -29,7 +27,13 @@ while read -r local_ref local_sha _rest; do
     *)
       # Belt and braces: a deletion is also identifiable by its all-zero local
       # sha, so this still holds if the "(delete)" literal ever changes.
-      [ "$local_sha" = "$ZERO_SHA" ] || no_new_commits=0
+      # Matched as a pattern rather than against a fixed constant because the
+      # sha's length follows the repo's hash algorithm — 40 hex characters
+      # under SHA-1, 64 under SHA-256 — and a hardcoded 40 zeros would quietly
+      # stop matching on the latter.
+      case "$local_sha" in
+        '' | *[!0]*) no_new_commits=0 ;;
+      esac
       ;;
   esac
 done

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,27 +1,41 @@
 # Git feeds this hook one line per ref being pushed:
 #   <local ref> <local sha> <remote ref> <remote sha>
 #
-# A tag-only push introduces no new commits — the commit being tagged already
-# passed this gate on its branch and again in CI — so re-running the full
-# check:all sweep only delays the release by 10-15 minutes. Skip it when every
-# ref being pushed is a tag.
+# Two kinds of push introduce no new commits, so running the full check:all
+# sweep for them costs 10-15 minutes and verifies nothing:
+#
+#   - A tag-only push. The commit being tagged already passed this gate on its
+#     branch and again in CI.
+#   - A branch deletion. Git sends "(delete)" as the local ref and an all-zero
+#     local sha. There is no content being sent at all — the gate would be
+#     checking the working tree against a push that only removes a ref.
+#
+# Skip only when EVERY ref in the push is one of those. A mixed push — a real
+# branch alongside a tag or a deletion — still runs the gate.
 #
 # If no refs arrive on stdin (an invocation shape we don't recognise), fall
 # through and run the gate: the safe default is to check, not to skip.
-saw_ref=0
-only_tags=1
+ZERO_SHA=0000000000000000000000000000000000000000
 
-while read -r local_ref _rest; do
+saw_ref=0
+no_new_commits=1
+
+while read -r local_ref local_sha _rest; do
   [ -z "$local_ref" ] && continue
   saw_ref=1
   case "$local_ref" in
     refs/tags/*) ;;
-    *) only_tags=0 ;;
+    '(delete)') ;;
+    *)
+      # Belt and braces: a deletion is also identifiable by its all-zero local
+      # sha, so this still holds if the "(delete)" literal ever changes.
+      [ "$local_sha" = "$ZERO_SHA" ] || no_new_commits=0
+      ;;
   esac
 done
 
-if [ "$saw_ref" = "1" ] && [ "$only_tags" = "1" ]; then
-  echo "pre-push: tag-only push — skipping check:all (no new commits)"
+if [ "$saw_ref" = "1" ] && [ "$no_new_commits" = "1" ]; then
+  echo "pre-push: no new commits (tags and/or deletions) — skipping check:all"
   exit 0
 fi
 

--- a/shared/tests/pre-push-hook.test.ts
+++ b/shared/tests/pre-push-hook.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression guard for the pre-push gate's skip logic.
+ *
+ * `.husky/pre-push` skips the full `check:all` sweep for pushes that carry no
+ * new commits — tag-only pushes, and branch deletions. That is a deliberate
+ * hole in a protection mechanism, and the dangerous failure is not the hole
+ * being too small but too big: a bug that widens it to a push carrying real
+ * commits would let unchecked code through, silently, with the hook still
+ * printing a reassuring line.
+ *
+ * So every case below asserts BOTH directions, in the manner of
+ * `gate-ignores.test.ts`: that the hook skips exactly the pushes it should,
+ * AND that it still runs the gate for everything else. Without the second half
+ * the test would pass just as happily against a hook that skipped everything.
+ *
+ * The hook is executed for real, with only its final `npm run check:all` line
+ * swapped for a marker — so what is under test is the actual shipped file's
+ * parsing and branching, not a re-implementation of it. Swapping the last line
+ * is what keeps the suite fast; the decision logic above it is untouched.
+ *
+ * The input shapes are git's documented pre-push stdin format:
+ *   <local ref> <local sha> <remote ref> <remote sha>
+ * with `(delete)` and an all-zero local sha for a deletion. Verified against
+ * real git, not only assumed: deleting a remote branch prints the skip line.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Walk up from `start` until the directory holding the husky hooks.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, '.husky', 'pre-push'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`could not locate .husky/pre-push from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+const GATE_MARKER = 'GATE_RAN';
+
+/** 40 hex zeros — a SHA-1 repo's "no such object" sha. */
+const ZERO_SHA_1 = '0'.repeat(40);
+/** 64 hex zeros — the same thing under SHA-256. */
+const ZERO_SHA_256 = '0'.repeat(64);
+const SHA = 'abc123def4567890abc123def4567890abc123de';
+
+/**
+ * Run the real hook against a given stdin, with the gate replaced by a marker.
+ * @param stdin - Lines in git's pre-push format (no trailing newline needed).
+ * @returns Whether the hook would have run `check:all`.
+ */
+function gateRuns(stdin: string): boolean {
+  const hook = readFileSync(join(REPO_ROOT, '.husky', 'pre-push'), 'utf8');
+  const instrumented = hook.replace(/^npm run check:all$/m, `echo "${GATE_MARKER}"`);
+  // The replacement must have applied — otherwise this test would silently
+  // become a no-op that runs the real 4-minute gate, or reports nothing.
+  expect(instrumented, 'hook no longer ends in `npm run check:all`').not.toBe(hook);
+
+  // Passed to `sh -c` rather than written to a temp file, so nothing is left
+  // on disk if an assertion throws.
+  const run = spawnSync('sh', ['-c', instrumented], {
+    input: stdin === '' ? '' : `${stdin}\n`,
+    encoding: 'utf8',
+  });
+  expect(run.error, 'sh should be available').toBeUndefined();
+  return run.stdout.includes(GATE_MARKER);
+}
+
+describe('pre-push gate — pushes that carry no new commits are skipped', () => {
+  it('skips a branch deletion', () => {
+    expect(gateRuns(`(delete) ${ZERO_SHA_1} refs/heads/x ${SHA}`)).toBe(false);
+  });
+
+  it('skips a deletion in a SHA-256 repository', () => {
+    // The zero sha is 64 characters there. An earlier revision compared against
+    // a hardcoded 40 zeros, which stopped matching — it failed safe (the gate
+    // ran) but the fallback it claimed to provide did not exist.
+    expect(gateRuns(`(delete) ${ZERO_SHA_256} refs/heads/x ${SHA}`)).toBe(false);
+  });
+
+  it('skips several deletions at once', () => {
+    expect(
+      gateRuns(
+        `(delete) ${ZERO_SHA_1} refs/heads/x ${SHA}\n(delete) ${ZERO_SHA_1} refs/heads/y ${SHA}`,
+      ),
+    ).toBe(false);
+  });
+
+  it('skips a tag-only push', () => {
+    expect(gateRuns(`refs/tags/v1.0.0 ${SHA} refs/tags/v1.0.0 ${ZERO_SHA_1}`)).toBe(false);
+  });
+
+  it('skips a deletion pushed alongside a tag', () => {
+    expect(
+      gateRuns(
+        `(delete) ${ZERO_SHA_1} refs/heads/x ${SHA}\nrefs/tags/v1.0.0 ${SHA} refs/tags/v1.0.0 ${ZERO_SHA_1}`,
+      ),
+    ).toBe(false);
+  });
+
+  it('treats an all-zero local sha as a deletion even without the literal', () => {
+    // Belt-and-braces path: `(delete)` is what git sends today, the zero sha is
+    // what it means.
+    expect(gateRuns(`refs/heads/x ${ZERO_SHA_1} refs/heads/x ${SHA}`)).toBe(false);
+  });
+});
+
+describe('pre-push gate — everything else still runs the gate', () => {
+  // This half is the point. A hook that skipped unconditionally would pass
+  // every assertion above.
+  it('runs for an ordinary branch push', () => {
+    expect(gateRuns(`refs/heads/x ${SHA} refs/heads/x ${ZERO_SHA_1}`)).toBe(true);
+  });
+
+  it('runs when a real branch is pushed alongside a deletion', () => {
+    expect(
+      gateRuns(
+        `(delete) ${ZERO_SHA_1} refs/heads/x ${SHA}\nrefs/heads/y ${SHA} refs/heads/y ${ZERO_SHA_1}`,
+      ),
+    ).toBe(true);
+  });
+
+  it('runs when a real branch is pushed alongside a tag', () => {
+    expect(
+      gateRuns(
+        `refs/tags/v1.0.0 ${SHA} refs/tags/v1.0.0 ${ZERO_SHA_1}\nrefs/heads/y ${SHA} refs/heads/y ${ZERO_SHA_1}`,
+      ),
+    ).toBe(true);
+  });
+
+  it('runs when no refs arrive on stdin', () => {
+    // An invocation shape the hook does not recognise. The safe default is to
+    // check, not to skip.
+    expect(gateRuns('')).toBe(true);
+  });
+
+  it('runs when the local sha is missing entirely', () => {
+    expect(gateRuns(`refs/heads/x  refs/heads/x ${SHA}`)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The gap

The hook already skips a tag-only push, and its own comment gives the reason: a tag "introduces no new commits — the commit being tagged already passed this gate on its branch and again in CI."

A branch deletion introduces none either. It sends no content at all. But it doesn't match `refs/tags/*`, so it fell through to the full `check:all` sweep — **10–15 minutes to delete a merged branch**, verifying the working tree against a push that only removes a ref.

## Why it's worth fixing rather than living with

This surfaced sweeping 45 merged branches after v0.3.0. The first `git push --delete` hit the ten-minute timeout; the remaining 44 had to go through `gh api` instead.

The concerning part isn't the delay — it's the pressure. The obvious way out is `--no-verify`, which is precisely the habit a pre-push hook exists to prevent. A gate that is expensive in a case where it checks *nothing* teaches people to route around it, and that habit doesn't stay confined to deletions.

## The change

Git sends `(delete)` as the local ref and an all-zero local sha for a deletion. Both are matched — the literal because that's what git sends, the zero sha because it's the semantically meaningful signal ("nothing is being pushed") and keeps this working if the literal ever changes.

The variable becomes `no_new_commits` rather than `only_tags`, since that was always the actual condition; tags were one instance of it.

**The skip stays as conservative as the original.** It fires only when *every* ref in the push introduces no commits, so a real branch pushed alongside a tag or a deletion still runs the gate. Unrecognised input — no refs on stdin — still runs it, per the existing "safe default is to check, not to skip."

## Verification

Decision tested against every push shape, with the gate replaced by a marker so the branch is observed rather than the build run:

```text
branch push           -> gate runs
tag only              -> skipped
deletion only         -> skipped
two deletions         -> skipped
delete + tag          -> skipped
delete + real branch  -> gate runs     <- the one that matters
tag + real branch     -> gate runs
empty stdin           -> gate runs
```

Synthetic input only proves the parsing, so both halves were also exercised against real git:

- **Deletion** — created a throwaway remote branch server-side, then `git push origin --delete`: prints the skip line, completes in **2.7s** (was ~10 min).
- **Real branch** — this PR's own push: gate ran for **3m58s** and passed. The protection is intact, which is the claim that actually needs evidence.

## Note

`sh -n` clean. No behaviour change for any push that carries commits.