### PR TITLE
fix(ci): stop a slow link poisoning the pre-push link cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
 ### Fixed
 
+- **A slow link no longer blocks pushes for two days.** The `links` step of
+  `check:all` failed on a `web.archive.org` URL in `README.md` that was
+  healthy — the host answered in 9.8s, then timed out past 60s, then answered
+  in 29.8s, all inside a minute. Worse than the flake was what followed: lychee
+  writes a timeout into `.lycheecache` with an **empty** status field, and
+  `--cache-exclude-status` only accepts codes between 100 and 999, so a timeout
+  cannot be excluded from the cache by configuration at all. With
+  `max_cache_age = "2d"` every later run then failed instantly with
+  `Error (cached)` — reported as a hard error rather than the timeout it was —
+  until the row was deleted by hand. `npm run links` now runs through
+  `scripts/link-check.sh`, which drops undecided (status-less) rows from the
+  cache before and after each run, so a transient failure costs one extra
+  request instead of a blocked gate; 5xx responses are excluded natively via
+  `cache_exclude_status`, which lychee *can* express. `web.archive.org` joins
+  `output.jsbin.com` in the exclusion list, on the same reasoning: a snapshot is
+  immutable by design, so checking one buys no signal. Raising `timeout` was
+  measured and rejected — no value makes that host reliable. ([#155])
+
 - **The pre-push gate no longer fails on a Node newer than the pinned one.**
   Node 22.4+ ships its own Web Storage globals, and its `localStorage` is inert
   unless the process was started with `--localstorage-file`. Vitest's jsdom
@@ -1000,3 +1018,4 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
 [#39]: https://github.com/AFixt/livechat/pull/39
 [#40]: https://github.com/AFixt/livechat/pull/40
 [#153]: https://github.com/AFixt/livechat/issues/153
+[#155]: https://github.com/AFixt/livechat/issues/155

--- a/lychee.toml
+++ b/lychee.toml
@@ -31,6 +31,12 @@ exclude = [
   # subdomain is unreliable and answers 503 to the checker (fine in a browser).
   # Not our content to fix — exclude the host rather than block every PR on it.
   "^https?://output\\.jsbin\\.com",
+  # web.archive.org is chronically slow and wildly variable — measured at 9.8s,
+  # then a timeout past 60s, then 29.8s for the same URL within a minute. No
+  # timeout value makes it reliable, and a snapshot is immutable by design, so
+  # checking one buys no signal and costs blocked pushes. Same reasoning as the
+  # jsbin entry above.
+  "^https://web\\.archive\\.org/",
   # CHANGELOG "compare" links name the tag being released, which does not exist
   # until the release is tagged — so they 404 on the pre-push that ships the
   # release commit itself. Only the compare form is excluded; the per-version
@@ -44,5 +50,11 @@ accept = ["200..=299", "403", "429"]
 
 cache = true
 max_cache_age = "2d"
+
+# A 5xx is the far end having a bad minute; caching it would block every push
+# until the entry expires. Timeouts and connection errors cannot be expressed
+# here — lychee only accepts status codes — so scripts/link-check.sh drops
+# those rows instead.
+cache_exclude_status = ["500..=599"]
 max_retries = 2
 timeout = 20

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "markdownlint": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules/**\"",
     "markdownlint:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules/**\"",
     "dupes": "jscpd",
-    "links": "lychee --no-progress '**/*.md'",
+    "links": "bash scripts/link-check.sh",
     "test": "npm-run-all -s test:shared test:api test:ui test:widget",
     "test:shared": "npm --workspace shared run test",
     "test:api": "npm --workspace api run test",

--- a/scripts/link-check.sh
+++ b/scripts/link-check.sh
@@ -36,8 +36,11 @@ prune_undecided_rows() {
   # status is addressed from the end of the row, never as field 2.
   local pruned
   pruned=$(mktemp)
-  # shellcheck disable=SC2064  # expand $pruned now: it is gone by the time the trap fires
-  trap "rm -f '$pruned'" RETURN
+  # Single-quoted so $pruned is expanded when the trap fires, not now: quoting
+  # a path from $TMPDIR into the trap body would break on an exotic one. The
+  # trap only has work to do if awk fails — on success the mv below has already
+  # consumed the file.
+  trap 'rm -f "$pruned"' RETURN
 
   awk -F, 'NF >= 3 && $(NF - 1) != ""' "$CACHE" >"$pruned"
 
@@ -45,7 +48,7 @@ prune_undecided_rows() {
   before=$(wc -l <"$CACHE" | tr -d ' ')
   after=$(wc -l <"$pruned" | tr -d ' ')
 
-  cp "$pruned" "$CACHE"
+  mv "$pruned" "$CACHE"
 
   if [ "$before" != "$after" ]; then
     echo "link-check: dropped $((before - after)) undecided (timeout/connection) row(s) from $CACHE"

--- a/scripts/link-check.sh
+++ b/scripts/link-check.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# link-check.sh — run the Markdown link check, then keep only decided results
+# in lychee's cache.
+#
+# lychee caches every result it reaches, including failures. That is fine for a
+# 404, which stays a 404 — but a timeout or a connection error is written with
+# an EMPTY status field (`url,,timestamp`, verified against lychee 0.23), and
+# `--cache-exclude-status` only understands status codes between 100 and 999.
+# So there is no way to tell lychee "do not cache a timeout".
+#
+# The consequence is worse than the flake itself. One slow response from a
+# perfectly healthy host poisons `.lycheecache` for `max_cache_age`, and every
+# later run then fails INSTANTLY with `Error (cached)` — with a generous
+# `--timeout` and a live, working link. Observed 2026-08-26: web.archive.org
+# answered in 9.8s, then timed out past 60s, then answered in 29.8s; the one
+# timeout blocked every subsequent push until the row was deleted by hand.
+#
+# A pre-push gate that blocks pushes for reasons unrelated to the change being
+# pushed teaches contributors to reach for --no-verify, and then it stops
+# catching what it exists for. Issue #153 was the same failure mode from a
+# different cause.
+#
+# Dropping the status-less rows costs one extra request on the next run and
+# leaves the cache doing its job for the ~100 links that are fine. Coded
+# failures are left to lychee's own `cache_exclude_status` in lychee.toml.
+set -euo pipefail
+
+CACHE=".lycheecache"
+
+# Prune first: an earlier interrupted run can leave a poisoned row behind, and
+# a stale one must not decide this run.
+prune_undecided_rows() {
+  [ -f "$CACHE" ] || return 0
+
+  # Rows are `url,status,timestamp`. A URL may itself contain commas, so the
+  # status is addressed from the end of the row, never as field 2.
+  local pruned
+  pruned=$(mktemp)
+  awk -F, 'NF >= 3 && $(NF - 1) != ""' "$CACHE" >"$pruned"
+
+  local before after
+  before=$(wc -l <"$CACHE" | tr -d ' ')
+  after=$(wc -l <"$pruned" | tr -d ' ')
+
+  mv "$pruned" "$CACHE"
+
+  if [ "$before" != "$after" ]; then
+    echo "link-check: dropped $((before - after)) undecided (timeout/connection) row(s) from $CACHE"
+  fi
+}
+
+prune_undecided_rows
+
+status=0
+lychee --no-progress '**/*.md' || status=$?
+
+# Prune again, so a timeout in THIS run cannot decide the next one.
+prune_undecided_rows
+
+if [ "$status" -ne 0 ]; then
+  echo "link-check: lychee reported unreachable links (exit $status)." >&2
+  echo "link-check: timeouts are not cached, so re-running re-checks them live." >&2
+fi
+
+exit "$status"

--- a/scripts/link-check.sh
+++ b/scripts/link-check.sh
@@ -27,8 +27,8 @@ set -euo pipefail
 
 CACHE=".lycheecache"
 
-# Prune first: an earlier interrupted run can leave a poisoned row behind, and
-# a stale one must not decide this run.
+# Drop the rows lychee could not decide — a timeout or a connection failure is
+# the case it writes with an empty status field.
 prune_undecided_rows() {
   [ -f "$CACHE" ] || return 0
 
@@ -36,30 +36,43 @@ prune_undecided_rows() {
   # status is addressed from the end of the row, never as field 2.
   local pruned
   pruned=$(mktemp)
+  # shellcheck disable=SC2064  # expand $pruned now: it is gone by the time the trap fires
+  trap "rm -f '$pruned'" RETURN
+
   awk -F, 'NF >= 3 && $(NF - 1) != ""' "$CACHE" >"$pruned"
 
   local before after
   before=$(wc -l <"$CACHE" | tr -d ' ')
   after=$(wc -l <"$pruned" | tr -d ' ')
 
-  mv "$pruned" "$CACHE"
+  cp "$pruned" "$CACHE"
 
   if [ "$before" != "$after" ]; then
     echo "link-check: dropped $((before - after)) undecided (timeout/connection) row(s) from $CACHE"
   fi
 }
 
+# Prune before the run, not only after it: the cache is shared with anyone who
+# invokes lychee directly, and with any cache written before this script existed
+# — which is exactly how the poisoned row that prompted #155 got there. A stale
+# undecided row must never decide this run.
 prune_undecided_rows
 
+# "$@" so `npm run links -- --verbose` still reaches lychee. lychee's own
+# output points at that flag ("Run lychee in verbose mode ... to see details
+# about the redirections"), and wrapping the command silently swallowed it.
 status=0
-lychee --no-progress '**/*.md' || status=$?
+lychee --no-progress '**/*.md' "$@" || status=$?
 
 # Prune again, so a timeout in THIS run cannot decide the next one.
 prune_undecided_rows
 
+# lychee answers 2 for a broken link AND for a usage error, and 1 for a missing
+# input file, so the exit code alone cannot say which happened. Report what is
+# actually known and let lychee's own output above name the cause.
 if [ "$status" -ne 0 ]; then
-  echo "link-check: lychee reported unreachable links (exit $status)." >&2
-  echo "link-check: timeouts are not cached, so re-running re-checks them live." >&2
+  echo "link-check: lychee exited $status — see its output above." >&2
+  echo "link-check: no timeout was cached, so re-running re-checks live." >&2
 fi
 
 exit "$status"

--- a/shared/tests/link-check-gate.test.ts
+++ b/shared/tests/link-check-gate.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Regression guard for `scripts/link-check.sh`, the wrapper the `links` gate
+ * runs (#155).
+ *
+ * lychee writes a timeout to `.lycheecache` with an EMPTY status field
+ * (`url,,timestamp`), and `--cache-exclude-status` only understands codes
+ * between 100 and 999 — so no configuration can keep a timeout out of the
+ * cache. With `max_cache_age = "2d"`, one slow response from a healthy host
+ * then failed every later run instantly with `Error (cached)` until the row was
+ * deleted by hand. The wrapper drops those undecided rows around each run.
+ *
+ * That pruning is silent by construction: if it stops working — lychee changes
+ * the cache format, the field arithmetic drifts — nothing fails loudly, the
+ * gate just quietly starts blocking pushes again. Same lesson as
+ * `generated-specs-gate.test.ts`: reading the script cannot catch that, only
+ * running the real one can. So these cases run the actual script with a stubbed
+ * `lychee` on PATH, and assert both that undecided rows go AND that decided
+ * rows survive — a script that simply emptied the cache would pass half of this
+ * and fail the other half.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = 'scripts/link-check.sh';
+const CACHE = '.lycheecache';
+
+/**
+ * Walk up from `start` until the directory holding the gate script.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, SCRIPT))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`could not locate ${SCRIPT} from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+
+const scratchDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A decided row: lychee reached the URL and recorded a status. */
+const OK_ROW = 'https://example.com/reachable,200,1787776000';
+/** A decided failure. It stays cached on purpose — a 404 is not a flake. */
+const NOT_FOUND_ROW = 'https://example.com/gone,404,1787776001';
+/** What a timeout looks like: no status at all. This is what must be dropped. */
+const TIMEOUT_ROW = 'https://example.com/slow,,1787776002';
+/** The same, for a URL that itself contains commas — `$2` would miss this. */
+const TIMEOUT_ROW_COMMA_URL = 'https://example.com/a,b,c/slow,,1787776003';
+/** A decided row whose URL contains commas, which must NOT be dropped. */
+const OK_ROW_COMMA_URL = 'https://example.com/x,y/page,200,1787776004';
+
+/**
+ * Build a throwaway working directory holding the real script, a stub `lychee`,
+ * and an optional seeded cache.
+ * @param options - Fixture options.
+ * @param options.cacheRows - Rows to seed `.lycheecache` with, or null for no cache file.
+ * @param options.lycheeExit - Exit status the stubbed lychee returns.
+ * @param options.lycheeWritesRows - Rows the stub appends to the cache, as a real run would.
+ * @returns The fixture directory.
+ */
+function fixture(options: {
+  cacheRows?: string[] | null;
+  lycheeExit?: number;
+  lycheeWritesRows?: string[];
+}): string {
+  const { cacheRows = [], lycheeExit = 0, lycheeWritesRows = [] } = options;
+
+  const root = mkdtempSync(join(tmpdir(), 'link-check-'));
+  scratchDirs.push(root);
+
+  mkdirSync(join(root, 'scripts'), { recursive: true });
+  copyFileSync(join(REPO_ROOT, SCRIPT), join(root, SCRIPT));
+
+  if (cacheRows !== null) writeFileSync(join(root, CACHE), cacheRows.join('\n') + '\n');
+
+  // Stub lychee: append whatever rows this case says a run would produce, echo
+  // the arguments it was handed (so argument forwarding is observable), exit
+  // with the given status.
+  const stubDir = join(root, 'stub');
+  mkdirSync(stubDir, { recursive: true });
+  const appends = lycheeWritesRows.map(
+    (row) => `printf '%s\\n' ${JSON.stringify(row)} >> ${CACHE}`,
+  );
+  writeFileSync(
+    join(stubDir, 'lychee'),
+    [
+      '#!/usr/bin/env bash',
+      'echo "STUB ARGS: $*"',
+      ...appends,
+      `exit ${String(lycheeExit)}`,
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+
+  return root;
+}
+
+/**
+ * Run the real gate script inside a fixture.
+ * @param root - Fixture directory.
+ * @param args - Extra arguments, as `npm run links -- …` would supply.
+ * @returns Exit status, combined output, and the resulting cache rows.
+ */
+function runGate(
+  root: string,
+  ...args: string[]
+): { status: number | null; output: string; rows: string[] } {
+  const run = spawnSync('bash', [SCRIPT, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${join(root, 'stub')}:${process.env['PATH'] ?? ''}` },
+  });
+  const cachePath = join(root, CACHE);
+  const rows = existsSync(cachePath)
+    ? readFileSync(cachePath, 'utf8')
+        .split('\n')
+        .filter((row) => row !== '')
+    : [];
+  return { status: run.status, output: [run.stdout, run.stderr].join(''), rows };
+}
+
+describe('link-check gate (#155)', () => {
+  it('drops a cached timeout before the run, so it cannot decide this run', () => {
+    // The poisoning that prompted #155: the row is already there when the gate
+    // starts, put there by a direct lychee invocation or an older cache.
+    const root = fixture({ cacheRows: [OK_ROW, TIMEOUT_ROW, NOT_FOUND_ROW] });
+    const { status, output, rows } = runGate(root);
+
+    expect(status).toBe(0);
+    expect(rows).not.toContain(TIMEOUT_ROW);
+    expect(output).toContain('dropped 1 undecided');
+    // Decided rows survive, or the cache would be useless and every run slow.
+    expect(rows).toContain(OK_ROW);
+    expect(rows).toContain(NOT_FOUND_ROW);
+  });
+
+  it('drops a timeout written by the run itself, so it cannot decide the next one', () => {
+    const root = fixture({ cacheRows: [OK_ROW], lycheeExit: 2, lycheeWritesRows: [TIMEOUT_ROW] });
+    const { status, rows } = runGate(root);
+
+    // The run still fails — a link really did not answer.
+    expect(status).toBe(2);
+    // But the next run re-checks it live instead of replaying `Error (cached)`.
+    expect(rows).not.toContain(TIMEOUT_ROW);
+    expect(rows).toContain(OK_ROW);
+  });
+
+  it('addresses the status from the end of the row, so a URL containing commas is handled', () => {
+    // `awk -F, '$2 != ""'` keeps TIMEOUT_ROW_COMMA_URL and re-poisons the cache.
+    const root = fixture({ cacheRows: [OK_ROW_COMMA_URL, TIMEOUT_ROW_COMMA_URL] });
+    const { rows } = runGate(root);
+
+    expect(rows).not.toContain(TIMEOUT_ROW_COMMA_URL);
+    expect(rows).toContain(OK_ROW_COMMA_URL);
+  });
+
+  it('passes a clean cache through untouched and stays quiet', () => {
+    // Control: without this, a script that always reported "dropped" or always
+    // rewrote the cache would satisfy the cases above.
+    const root = fixture({ cacheRows: [OK_ROW, NOT_FOUND_ROW] });
+    const { status, output, rows } = runGate(root);
+
+    expect(status).toBe(0);
+    expect(output).not.toContain('dropped');
+    expect(rows).toStrictEqual([OK_ROW, NOT_FOUND_ROW]);
+  });
+
+  it('propagates lychee failure, so the gate can still fail', () => {
+    // The #149 lesson: a gate that cannot fail is worse than no gate.
+    const root = fixture({ cacheRows: [OK_ROW], lycheeExit: 2 });
+    const { status, output } = runGate(root);
+
+    expect(status).toBe(2);
+    expect(output).toContain('lychee exited 2');
+  });
+
+  it('forwards extra arguments to lychee', () => {
+    // `npm run links -- --verbose` must still reach lychee; wrapping the
+    // command in a script silently swallowed it until this was fixed.
+    const { output } = runGate(fixture({}), '--verbose');
+
+    expect(output).toContain('STUB ARGS: --no-progress **/*.md --verbose');
+  });
+
+  it('runs without a cache file at all', () => {
+    const root = fixture({ cacheRows: null });
+    const { status } = runGate(root);
+
+    expect(status).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #155.

## The problem

The `links` step of `check:all` failed on a `web.archive.org` URL in
`README.md`, on a branch that touched no Markdown. Re-running made it worse: it
failed **instantly** with `Error (cached)`.

Two causes compound, and both were measured rather than assumed.

**The host is erratic, not slow by a fixed margin.** Three `curl` runs of that
URL inside one minute:

| attempt | result |
|---|---|
| 1 | 200 in **9.8s** |
| 2 | **timed out past 60s** |
| 3 | 200 in **29.8s** |

`lychee.toml` sets `timeout = 20`. Raising it was the obvious move, and the
measurement rejects it — no value makes this host reliable.

**lychee cannot be configured not to cache the flake.** A timeout is written to
`.lycheecache` with an *empty* status field (`url,,timestamp`), and
`--cache-exclude-status` only accepts status codes between 100 and 999. Verified
the asymmetry against lychee 0.23:

| failure | cached? |
|---|---|
| `404` with `--cache-exclude-status 404` | no — excluded |
| timeout, with `--cache-exclude-status '100..=999'` | **yes, regardless** |

`'0..=599'` is rejected outright as an invalid range. So with
`max_cache_age = "2d"`, one slow response blocks every push for two days until
someone edits `.lycheecache` by hand — and the replay is reported as a hard
`Error`, not the `Timeout` it actually was.

## The fix

`npm run links` now runs through `scripts/link-check.sh`, which drops
status-less rows from the cache **before** the run (an interrupted run can leave
one behind) and **after** it (so a timeout in this run cannot decide the next).
A transient failure now costs one extra request instead of a blocked gate, while
the cache still does its job for the ~100 links that are fine.

Coded server errors are left to lychee's own mechanism —
`cache_exclude_status = ["500..=599"]`, which it *can* express — so the script
handles only the case lychee cannot.

`web.archive.org` joins `output.jsbin.com` in the exclusion list, on the
reasoning already recorded there: a snapshot is immutable by design, so checking
one buys no signal and costs blocked pushes.

## Verification

A/B on an identical poisoned cache — a status-less row injected for a live URL
already in the docs:

| | result |
|---|---|
| the command the gate used to run | `[ERROR] …/issues/82 \| Error (cached)` — **1 Error**, gate blocked |
| via `scripts/link-check.sh` | `dropped 1 undecided row` → re-checked live → **98 OK, 0 Errors** |

A forced timeout under the wrapper still fails the run, as it must, and leaves
the cache clean, so the next run re-checks rather than replaying. `shellcheck`
clean; markdownlint, prettier and the full `check:all` pre-push gate green.

Cold-cache runtime dropped from ~41s to ~5s as a side effect — archive.org was
most of the wait.

## Why this was worth fixing rather than working around

A pre-push gate that blocks pushes for reasons unrelated to the change teaches
contributors to reach for `--no-verify`, and then it stops catching what it
exists for. #153 was the same failure mode from a different cause. Link checking
stays in the local gate — CI is not a fallback here.
