### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
-## [Unreleased]
+## [0.3.1] - 2026-08-26
 
 ### Fixed
 
@@ -992,7 +992,9 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
   ships with Node 22, and effective on toolchain upgrade.
 - `body-parser` bumped to 2.3.0, clearing OSV `GHSA-v422-hmwv-36x6`.
 
-[Unreleased]: https://github.com/AFixt/livechat/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/AFixt/livechat/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/AFixt/livechat/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/AFixt/livechat/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/AFixt/livechat/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/AFixt/livechat/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/AFixt/livechat/compare/v0.1.0...v0.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "UNLICENSED",
       "workspaces": [
         "shared",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",


### PR DESCRIPTION
Version bump for the v0.3.1 patch release. No product code.

- `package.json` / `package-lock.json`: 0.3.0 → 0.3.1
- `CHANGELOG.md`: `## [Unreleased]` promoted to `## [0.3.1] - 2026-08-26`

**Patch, not minor:** the 15-commit range since `v0.3.0` contains no `feat`, no
`!` marker, and no `BREAKING CHANGE` footer — it is `fix(ci)`, `fix(test)`,
`test(*)`, `refactor(ci)` and `chore`.

Also repairs the link-reference block, which this release would otherwise have
widened: there was no `[0.3.0]:` entry, so the `## [0.3.0]` heading from the
last release resolved to nothing, and `[Unreleased]` still compared from
`v0.2.0`. Both fixed, and `[0.3.1]` added.

Verified from the commit rather than the working tree (`git show HEAD:package.json`),
since a lint-staged hook can produce a correctly-named commit carrying no changes.
Full `check:all` green on the way in.