### PR TITLE
docs(changelog): record the three v0.3.1 changes that shipped undocumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
 ### Fixed
 
+- **A CI gate that could never fail, now can.** `usecases-specs-in-sync` ran
+  `git diff --quiet -- '**/e2e/generated/'`. Without `:(glob)` magic, git's `*`
+  does not cross `/`, so the pathspec matched no file and the check was
+  structurally incapable of failing; and `git diff` never reports untracked
+  files, so a freshly generated spec was invisible under any pathspec at all.
+  Replaced with `scripts/check-generated-specs.sh`, which runs
+  `git status --porcelain` over the literal output directories of the
+  `usecases:generate:*` scripts and so catches modified, untracked **and**
+  deleted specs. `shared/tests/generated-specs-gate.test.ts` runs the real
+  script in a throwaway git repo and asserts each kind of drift fails — and
+  that a clean tree passes, so the test cannot be satisfied by a script that
+  always exits 1. Three specs that `usecases:generate` had produced since
+  v0.3.0, and that the broken gate never noticed were untracked, are now
+  committed. ([#149])
+
+- **Deleting a merged branch no longer runs the full pre-push gate.** The hook
+  already skipped a tag-only push on the reasoning that it introduces no new
+  commits. A branch deletion introduces none either and sends no content at
+  all, but it did not match `refs/tags/*`, so it fell through to the whole
+  `check:all` sweep — 10–15 minutes to remove a ref. It surfaced sweeping 45
+  merged branches after v0.3.0: the first deletion timed out at ten minutes and
+  the rest had to go through `gh api`. The alternative on offer was
+  `--no-verify`, which is the habit a pre-push hook exists to prevent. Git
+  sends `(delete)` as the local ref and an all-zero local sha; both are
+  matched, and the zero check is by length rather than a hardcoded 40, since a
+  sha is 64 characters under SHA-256. The skip stays conservative — it fires
+  only when *every* ref in the push introduces no commits, so a real branch
+  pushed alongside a tag or a deletion still runs the gate, and unrecognised
+  input still runs it. `shared/tests/pre-push-hook.test.ts` pins eleven cases
+  against the real shipped hook. ([#148])
+
+- **`osv-scanner` and `.lighthouseci` are ignored.** Reproducing the CI security
+  step locally leaves a 57 MB `osv-scanner` binary in the repo root, and
+  `lhci autorun` leaves `.lighthouseci/`. Neither was tracked; both are now
+  ignored, so a stray `git add -A` cannot commit them. ([#150])
+
 - **A slow link no longer blocks pushes for two days.** The `links` step of
   `check:all` failed on a `web.archive.org` URL in `README.md` that was
   healthy — the host answered in 9.8s, then timed out past 60s, then answered
@@ -1020,4 +1056,7 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
 [#39]: https://github.com/AFixt/livechat/pull/39
 [#40]: https://github.com/AFixt/livechat/pull/40
 [#153]: https://github.com/AFixt/livechat/issues/153
+[#149]: https://github.com/AFixt/livechat/issues/149
+[#150]: https://github.com/AFixt/livechat/issues/150
+[#148]: https://github.com/AFixt/livechat/pull/148
 [#155]: https://github.com/AFixt/livechat/issues/155

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,21 +26,23 @@ Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
   v0.3.0, and that the broken gate never noticed were untracked, are now
   committed. ([#149])
 
-- **Deleting a merged branch no longer runs the full pre-push gate.** The hook
-  already skipped a tag-only push on the reasoning that it introduces no new
-  commits. A branch deletion introduces none either and sends no content at
-  all, but it did not match `refs/tags/*`, so it fell through to the whole
-  `check:all` sweep — 10–15 minutes to remove a ref. It surfaced sweeping 45
-  merged branches after v0.3.0: the first deletion timed out at ten minutes and
-  the rest had to go through `gh api`. The alternative on offer was
-  `--no-verify`, which is the habit a pre-push hook exists to prevent. Git
-  sends `(delete)` as the local ref and an all-zero local sha; both are
-  matched, and the zero check is by length rather than a hardcoded 40, since a
-  sha is 64 characters under SHA-256. The skip stays conservative — it fires
-  only when *every* ref in the push introduces no commits, so a real branch
-  pushed alongside a tag or a deletion still runs the gate, and unrecognised
-  input still runs it. `shared/tests/pre-push-hook.test.ts` pins eleven cases
-  against the real shipped hook. ([#148])
+- **Deleting a merged branch no longer runs the full pre-push gate.** The
+  hook already skipped a tag-only push on the reasoning that it introduces
+  no new commits. A branch deletion introduces none either and sends no
+  content at all, but it did not match `refs/tags/*`, so it fell through to
+  the whole `check:all` sweep — 10–15 minutes to remove a ref. It surfaced
+  sweeping 45 merged branches after v0.3.0: the first deletion timed out at
+  ten minutes and the rest had to go through `gh api`. The alternative on
+  offer was `--no-verify`, which is the habit a pre-push hook exists to
+  prevent. Git sends `(delete)` as the local ref and an all-zero local sha;
+  both are matched, and the zero sha is recognised by pattern — any non-zero
+  character disqualifies it — rather than by comparison against a hardcoded
+  40 zeros, which would have stopped matching under SHA-256's 64-character
+  shas. The skip stays conservative — it fires only when *every* ref in the
+  push introduces no commits, so a real branch pushed alongside a tag or a
+  deletion still runs the gate, and unrecognised input still runs it.
+  `shared/tests/pre-push-hook.test.ts` pins eleven cases against the real
+  shipped hook. ([#148])
 
 - **`osv-scanner` and `.lighthouseci` are ignored.** Reproducing the CI security
   step locally leaves a 57 MB `osv-scanner` binary in the repo root, and


### PR DESCRIPTION
Found reviewing the release PR ([#158](https://github.com/AFixt/livechat/pull/158)): the `[0.3.1]` section documented **2 of the 5** changes in the release.

| PR | Had a CHANGELOG entry? |
|---|---|
| [#148](https://github.com/AFixt/livechat/pull/148) — pre-push ran on branch deletions | ❌ → added |
| [#151](https://github.com/AFixt/livechat/pull/151) — gitignore tool artifacts ([#150]) | ❌ → added |
| [#152](https://github.com/AFixt/livechat/pull/152) — `usecases-specs-in-sync` could never fail ([#149]) | ❌ → added |
| [#154](https://github.com/AFixt/livechat/pull/154) ([#153]) | ✅ |
| [#156](https://github.com/AFixt/livechat/pull/156) ([#155]) | ✅ |

A reader of the v0.3.1 notes would have concluded this release was two link/Node
fixes. The largest omission is #149: a CI gate that was structurally incapable
of failing, and three Playwright specs that shipped **untracked in v0.3.0** while
the job stayed green. That is precisely what a changelog is for.

Fixed now rather than after the tag, because once v0.3.1 is cut the CHANGELOG is
the durable in-repo record — the release PR body and the GitHub release notes
are not — and correcting it later means a commit apologising for the notes.

Entries are written from each PR's own commit message, so they carry the
reasoning rather than a restatement of the diff. Link references for `[#148]`,
`[#149]` and `[#150]` added and verified reachable (`npm run links`: 113 links,
0 errors).

Docs only — no code, no behaviour change.

[#148]: https://github.com/AFixt/livechat/pull/148
[#149]: https://github.com/AFixt/livechat/issues/149
[#150]: https://github.com/AFixt/livechat/issues/150
[#153]: https://github.com/AFixt/livechat/issues/153
[#155]: https://github.com/AFixt/livechat/issues/155