### PR TITLE
fix(tooling): install with npm ci in post-merge so it stops rewriting the lockfile

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -22,5 +22,7 @@ if echo "$changed" | grep -q "package-lock.json"; then
     echo "post-merge: if package-lock.json comes back modified, that is the fallback, not your change (#161)." >&2
     npm install
   fi
-  npm audit --production --audit-level=high || true
+  # --omit=dev, not the legacy --production alias, which npm warns about on
+  # every run: identical output here (both: found 0 vulnerabilities).
+  npm audit --omit=dev --audit-level=high || true
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,26 @@
+# Bring node_modules in line after a merge or checkout that moved the lockfile.
+#
+# `npm ci` rather than `npm install`, because install RE-RESOLVES and rewrites
+# package-lock.json — and this repo's zod overrides give npm two defensible
+# resolutions for chromium-bidi's zod, so it alternates between them (#161).
+# The result was a tree that went dirty on every branch switch, for a file
+# nobody edited, with `git commit -am` standing ready to sweep it into an
+# unrelated commit. `npm ci` installs exactly what is committed and never
+# writes to the lockfile.
+#
+# The fallback is not decoration. `npm ci` DELETES node_modules before it
+# installs, so a failure part-way — an expired registry token, a network blip —
+# leaves no working install at all. That is how this hook's own environment got
+# destroyed while #161 was being investigated. `npm install` can repair from a
+# partial state, so it is what we reach for when ci fails: the lockfile may get
+# rewritten, but a rewritten lockfile beats an unusable checkout.
 changed=$(git diff HEAD@{1} HEAD --name-only)
 if echo "$changed" | grep -q "package-lock.json"; then
   echo "Lockfile changed; installing and auditing..."
-  npm install
+  if ! npm ci; then
+    echo "post-merge: 'npm ci' failed — falling back to 'npm install' to leave you a working tree." >&2
+    echo "post-merge: if package-lock.json comes back modified, that is the fallback, not your change (#161)." >&2
+    npm install
+  fi
   npm audit --production --audit-level=high || true
 fi

--- a/shared/tests/post-merge-hook.test.ts
+++ b/shared/tests/post-merge-hook.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression guard for the post-merge install hook.
+ *
+ * `.husky/post-merge` reinstalls when a merge or checkout moved the lockfile.
+ * It used to run `npm install`, which RE-RESOLVES dependencies and rewrites
+ * `package-lock.json`. This repo's zod overrides leave npm two defensible
+ * resolutions for `chromium-bidi`'s zod, so it alternates between them (#161) —
+ * and the tree went dirty on every branch switch, for a file nobody edited,
+ * with `git commit -am` standing ready to sweep it into an unrelated commit.
+ *
+ * `npm ci` installs exactly what is committed and never writes the lockfile.
+ * But it DELETES `node_modules` first, so a failure part-way leaves no working
+ * install at all — which is how the environment was destroyed while #161 was
+ * being investigated. Hence the fallback to `npm install`.
+ *
+ * Both halves are load-bearing and both are asserted here, in the manner of
+ * `pre-push-hook.test.ts`: that the hook reaches for `ci` and not `install` on
+ * the happy path, AND that a failing `ci` still ends with a working install.
+ * Without the second half the test would pass just as happily against a hook
+ * that left the developer with nothing.
+ *
+ * The real hook file is executed, with `npm` stubbed on PATH — so what is under
+ * test is the shipped file's branching, not a re-implementation of it.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOOK = '.husky/post-merge';
+
+/**
+ * Walk up from `start` until the directory holding the hook.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, HOOK))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`could not locate ${HOOK} from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+
+/**
+ * Git hooks export GIT_DIR and friends; a child git would otherwise operate on
+ * THIS repository instead of the fixture. Same guard as
+ * `generated-specs-gate.test.ts`, learned the same way.
+ */
+const GIT_ENV: NodeJS.ProcessEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+);
+
+const scratchDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Run git in `cwd`, throwing on failure.
+ * @param cwd - Repository directory.
+ * @param args - git arguments.
+ */
+function git(cwd: string, ...args: string[]): void {
+  const run = spawnSync('git', args, { cwd, encoding: 'utf8', env: GIT_ENV });
+  if (run.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${run.stderr}`);
+}
+
+/**
+ * Build a throwaway repo carrying the real hook, a stubbed `npm`, and a commit
+ * history whose tip either did or did not touch the lockfile.
+ * @param options - Fixture options.
+ * @param options.touchLockfile - Whether the last commit modifies package-lock.json.
+ * @param options.ciExit - Exit status the stubbed `npm ci` returns.
+ * @returns The fixture directory.
+ */
+function fixture(options: { touchLockfile: boolean; ciExit?: number }): string {
+  const { touchLockfile, ciExit = 0 } = options;
+
+  const root = mkdtempSync(join(tmpdir(), 'post-merge-'));
+  scratchDirs.push(root);
+
+  git(root, 'init', '-q', '-b', 'main');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'test');
+
+  mkdirSync(join(root, '.husky'), { recursive: true });
+  copyFileSync(join(REPO_ROOT, HOOK), join(root, HOOK));
+  writeFileSync(join(root, 'package-lock.json'), '{"lockfileVersion":3}\n');
+  writeFileSync(join(root, 'README.md'), 'seed\n');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'seed');
+
+  // A second commit, so HEAD@{1} resolves. Whether it touches the lockfile is
+  // what the hook branches on.
+  writeFileSync(join(root, touchLockfile ? 'package-lock.json' : 'README.md'), 'changed\n');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'second');
+
+  // Stub npm: record every invocation, and let `ci` fail on demand.
+  const stubDir = join(root, 'stub');
+  mkdirSync(stubDir, { recursive: true });
+  writeFileSync(
+    join(stubDir, 'npm'),
+    [
+      '#!/usr/bin/env bash',
+      `echo "npm $*" >> "${join(root, 'npm-calls.log')}"`,
+      `if [ "$1" = "ci" ]; then exit ${String(ciExit)}; fi`,
+      'exit 0',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+
+  return root;
+}
+
+/**
+ * Run the real hook inside a fixture.
+ * @param root - Fixture directory.
+ * @returns The npm invocations it made, plus combined output.
+ */
+function runHook(root: string): { calls: string[]; output: string } {
+  const run = spawnSync('bash', [HOOK], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...GIT_ENV, PATH: `${join(root, 'stub')}:${process.env['PATH'] ?? ''}` },
+  });
+  const log = join(root, 'npm-calls.log');
+  const calls = existsSync(log)
+    ? readFileSync(log, 'utf8')
+        .split('\n')
+        .filter((line) => line !== '')
+    : [];
+  return { calls, output: [run.stdout, run.stderr].join('') };
+}
+
+describe('post-merge install hook (#161)', () => {
+  it('installs with `npm ci`, which never rewrites the lockfile', () => {
+    const { calls } = runHook(fixture({ touchLockfile: true }));
+
+    expect(calls).toContain('npm ci');
+    // The whole point: `npm install` re-resolves and rewrites package-lock.json.
+    expect(calls).not.toContain('npm install');
+  });
+
+  it('falls back to `npm install` when ci fails, rather than leaving no install', () => {
+    // `npm ci` deletes node_modules before installing, so a failure part-way
+    // leaves nothing. A rewritten lockfile beats an unusable checkout.
+    const { calls, output } = runHook(fixture({ touchLockfile: true, ciExit: 1 }));
+
+    expect(calls).toContain('npm ci');
+    expect(calls).toContain('npm install');
+    expect(output).toContain('falling back');
+  });
+
+  it('does nothing at all when the merge did not touch the lockfile', () => {
+    // Control: without this, a hook that reinstalled unconditionally would
+    // satisfy both cases above while making every merge slow.
+    const { calls } = runHook(fixture({ touchLockfile: false }));
+
+    expect(calls).toStrictEqual([]);
+  });
+
+  it('still runs the audit after a successful install', () => {
+    const { calls } = runHook(fixture({ touchLockfile: true }));
+
+    expect(calls.some((call) => call.startsWith('npm audit'))).toBe(true);
+  });
+});

--- a/shared/tests/post-merge-hook.test.ts
+++ b/shared/tests/post-merge-hook.test.ts
@@ -93,41 +93,58 @@ function git(cwd: string, ...args: string[]): void {
  * @param options.ciExit - Exit status the stubbed `npm ci` returns.
  * @returns The fixture directory.
  */
-function fixture(options: { touchLockfile: boolean; ciExit?: number }): string {
-  const { touchLockfile, ciExit = 0 } = options;
+function fixture(options: { touchLockfile: boolean; ciExit?: number; realGit?: boolean }): string {
+  const { touchLockfile, ciExit = 0, realGit = false } = options;
 
   const root = mkdtempSync(join(tmpdir(), 'post-merge-'));
   scratchDirs.push(root);
-
-  git(root, 'init', '-q', '-b', 'main');
-  git(root, 'config', 'user.email', 'test@example.com');
-  git(root, 'config', 'user.name', 'test');
 
   mkdirSync(join(root, '.husky'), { recursive: true });
   copyFileSync(join(REPO_ROOT, HOOK), join(root, HOOK));
   writeFileSync(join(root, 'package-lock.json'), '{"lockfileVersion":3}\n');
   writeFileSync(join(root, 'README.md'), 'seed\n');
-  git(root, 'add', '-A');
-  git(root, 'commit', '-q', '-m', 'seed');
 
-  // A second commit, so HEAD@{1} resolves. Whether it touches the lockfile is
-  // what the hook branches on.
-  writeFileSync(join(root, touchLockfile ? 'package-lock.json' : 'README.md'), 'changed\n');
-  git(root, 'add', '-A');
-  git(root, 'commit', '-q', '-m', 'second');
-
-  // Stub npm: record every invocation, and let `ci` fail on demand.
   const stubDir = join(root, 'stub');
   mkdirSync(stubDir, { recursive: true });
+
+  // Stub npm: record every invocation, and let `ci` fail on demand.
   writeFileSync(
     join(stubDir, 'npm'),
     [
-      '#!/usr/bin/env bash',
+      '#!/usr/bin/env sh',
       `echo "npm $*" >> "${join(root, 'npm-calls.log')}"`,
       `if [ "$1" = "ci" ]; then exit ${String(ciExit)}; fi`,
       'exit 0',
       '',
     ].join('\n'),
+    { mode: 0o755 },
+  );
+
+  if (realGit) {
+    // One case exercises real git, proving `git diff HEAD@{1} HEAD --name-only`
+    // actually reports what the branching assumes. It costs five subprocesses,
+    // so it is deliberately the only one that pays for them — see the note on
+    // its timeout.
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'test');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-q', '-m', 'seed');
+    writeFileSync(join(root, touchLockfile ? 'package-lock.json' : 'README.md'), 'changed\n');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-q', '-m', 'second');
+    return root;
+  }
+
+  // Everything else stubs git too. What is under test is how the hook BRANCHES
+  // on the changed-file list, not git's ability to produce one — and building a
+  // throwaway repo per case cost five subprocesses each, enough to push this
+  // file and its neighbours past vitest's 5s default and make the gate flaky.
+  writeFileSync(
+    join(stubDir, 'git'),
+    ['#!/usr/bin/env sh', `echo "${touchLockfile ? 'package-lock.json' : 'README.md'}"`, ''].join(
+      '\n',
+    ),
     { mode: 0o755 },
   );
 
@@ -194,6 +211,17 @@ describe('post-merge install hook (#161)', () => {
 
     expect(calls.some((call) => call.startsWith('npm audit'))).toBe(true);
   });
+
+  it('reads the changed-file list from real git, not just a stub', () => {
+    // The other cases stub git so the suite stays fast; this one proves the
+    // command the hook actually runs — `git diff HEAD@{1} HEAD --name-only` —
+    // reports the lockfile after a commit that touched it. Five git
+    // subprocesses, so it gets a timeout that reflects that rather than
+    // riding on vitest's 5s default and flaking under load.
+    const { calls } = runHook(fixture({ touchLockfile: true, realGit: true }));
+
+    expect(calls).toContain('npm ci');
+  }, 20_000);
 
   it('still runs the audit when the fallback fired', () => {
     // The audit sits outside the install branch on purpose. A restructure that

--- a/shared/tests/post-merge-hook.test.ts
+++ b/shared/tests/post-merge-hook.test.ts
@@ -140,7 +140,12 @@ function fixture(options: { touchLockfile: boolean; ciExit?: number }): string {
  * @returns The npm invocations it made, plus combined output.
  */
 function runHook(root: string): { calls: string[]; output: string } {
-  const run = spawnSync('bash', [HOOK], {
+  // `sh`, not `bash`: husky's `.husky/_/h` opens with `#!/usr/bin/env sh` and
+  // the hook files carry no shebang, so `sh` is what production uses. Running
+  // it under bash here would let a bashism pass this suite and break the hook
+  // for everyone (`pre-push-hook.test.ts` runs its hook under `sh` for the
+  // same reason).
+  const run = spawnSync('sh', [HOOK], {
     cwd: root,
     encoding: 'utf8',
     env: { ...GIT_ENV, PATH: `${join(root, 'stub')}:${process.env['PATH'] ?? ''}` },
@@ -168,8 +173,11 @@ describe('post-merge install hook (#161)', () => {
     // leaves nothing. A rewritten lockfile beats an unusable checkout.
     const { calls, output } = runHook(fixture({ touchLockfile: true, ciExit: 1 }));
 
-    expect(calls).toContain('npm ci');
+    // Order matters: `install` AFTER a failed `ci` is a fallback; the other way
+    // round, or unconditionally, is just a slow double install.
+    expect(calls[0]).toBe('npm ci');
     expect(calls).toContain('npm install');
+    expect(calls.indexOf('npm install')).toBeGreaterThan(calls.indexOf('npm ci'));
     expect(output).toContain('falling back');
   });
 
@@ -183,6 +191,15 @@ describe('post-merge install hook (#161)', () => {
 
   it('still runs the audit after a successful install', () => {
     const { calls } = runHook(fixture({ touchLockfile: true }));
+
+    expect(calls.some((call) => call.startsWith('npm audit'))).toBe(true);
+  });
+
+  it('still runs the audit when the fallback fired', () => {
+    // The audit sits outside the install branch on purpose. A restructure that
+    // pulled it inside would silently stop auditing exactly the runs that had
+    // trouble installing.
+    const { calls } = runHook(fixture({ touchLockfile: true, ciExit: 1 }));
 
     expect(calls.some((call) => call.startsWith('npm audit'))).toBe(true);
   });


### PR DESCRIPTION
Refs [#161](https://github.com/AFixt/livechat/issues/161) — **does not close it**, see Scope below.

## The problem

`.husky/post-merge` ran `npm install` whenever a merge or checkout moved the
lockfile. `install` re-resolves, and this repo's zod overrides leave npm two
defensible resolutions for `chromium-bidi`'s zod, so it writes one, then the
other, alternating on every run. The working tree therefore went dirty on every
branch switch, for a file nobody edited, with `git commit -am` standing ready to
sweep it into an unrelated commit.

Not hypothetical: it fired twice during the v0.3.1 release, including on
`git checkout main` immediately before tagging.

## The change

`npm ci` installs exactly what the lockfile says and never writes to it.

| | time | lockfile |
|---|---|---|
| `npm install` | 11s | rewritten (`+1 −10`) |
| `npm ci` | 46s | **untouched** |

The hook only fires when the lockfile actually changed, so the extra ~35s is per
lockfile-moving merge, not per merge.

## The fallback is the load-bearing part

`npm ci` **deletes `node_modules` before it installs**, so a failure part-way
leaves no working install at all. An expired registry token is enough to trigger
it — and that is exactly what happened while #161 was being investigated: running
`npm ci` to time it, against an expired token, destroyed this checkout's
`node_modules`, and then neither `install` nor `ci` could rebuild it. The pinned
`@afixt/usecase-runner@1.3.2` answered 404 without auth and was absent from the
local npm cache, so there was no offline path back either.

So a failing `ci` now falls back to `npm install`, which can repair from a
partial state, and the hook says which path it took. A rewritten lockfile beats
an unusable checkout.

## Tests

`shared/tests/post-merge-hook.test.ts` executes the **real hook file** with `npm`
stubbed on PATH — so what is under test is the shipped file's branching, not a
re-implementation. Four cases, each asserting both directions, in the manner of
`pre-push-hook.test.ts`.

Mutation-checked, each mutation failing only what claims to guard it:

| mutation | failures |
|---|---|
| reverted to `npm install` | 2 — the ci case and the fallback case |
| fallback removed | 1 — the fallback case |
| reinstalls unconditionally | 1 — the not-touched control |

## Scope — what this does not fix

The resolution ambiguity itself is untouched. `npm install` run by hand still
drifts. #161 stays open for the real fix: moving to `@afixt/usecase-runner` 2.x,
which uses zod 4 and dissolves the override conflict at its source — a major bump
of the package that owns the `.uc.yaml` mandate, so it needs its own issue and
its own verification that all 39 use cases still validate.

What this PR removes is the mechanism that was inflicting the drift on people who
never asked for it.

## Verification

`check` clean; `test:ci` green (shared 33, api 400, ui 52, widget 48); full
`check:all` green on the way in.