### PR TITLE
feat(tooling): upgrade @afixt/usecase-runner to 2.0.1, dropping the zod override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "e2e"
       ],
       "devDependencies": {
-        "@afixt/usecase-runner": "1.3.2",
+        "@afixt/usecase-runner": "2.0.1",
         "@commitlint/cli": "19.6.1",
         "@commitlint/config-conventional": "19.6.0",
         "@double-great/stylelint-a11y": "3.4.10",
@@ -446,44 +446,84 @@
       }
     },
     "node_modules/@afixt/test-utils": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/@afixt/test-utils/-/test-utils-2.9.7.tgz",
-      "integrity": "sha512-dct+VB9cCEbsW9GwueIIwWstcuH9XCTNiCVg3STf0psoECXJbcyOF5kvIIsbIc/UfEuXFHLCo79dN+98fsdJkA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@afixt/test-utils/-/test-utils-2.23.0.tgz",
+      "integrity": "sha512-rTKe44s52mn5oOdOTy12tgN3Vqk7q1mYEhA/5ORk+ZyQGdhmumWjxFrfEcvHw6zmtfxfDV46fWV3kQ4V2xT7Jw==",
       "dev": true,
+      "license": "UNLICENSED",
       "dependencies": {
         "franc": "^6.2.0",
-        "tesseract.js": "^6.0.0"
+        "tesseract.js": "^7.0.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
       }
     },
-    "node_modules/@afixt/usecase-runner": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-1.3.2.tgz",
-      "integrity": "sha512-pAYOn4BDYM3WC9bsvlBi0iikI2K5Qm3x349//k5MBWBsl0k5MijaHtj8FRe0A8RTNv23RV91PieFE/EAQD4B2Q==",
+    "node_modules/@afixt/test-utils/node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
       "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/@afixt/test-utils/node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@afixt/usecase-runner": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-2.0.1.tgz",
+      "integrity": "sha512-lw6RsofU7FxvubqSENXPLP/xst8rqCN/oOPAu40sphWh0tTfJrRcGY4k2PSrSN0OXTOmQ3MDvWYI6YL+Sc2FJA==",
+      "dev": true,
+      "license": "UNLICENSED",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
-        "glob": "^11.0.0",
+        "glob": "^13.0.6",
         "handlebars": "^4.7.8",
-        "yaml": "^2.6.1",
-        "zod": "^3.24.1"
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "usecase-runner": "bin/usecase-runner.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@afixt/afixt-engine": ">=1.0.0",
+        "@afixt/afixt-engine": ">=1.9.0",
+        "@afixt/test-utils": ">=2.10.0",
+        "@guidepup/guidepup": ">=0.21.0",
+        "@guidepup/virtual-screen-reader": ">=0.27.0",
         "@playwright/test": ">=1.40.0",
         "playwright": ">=1.40.0"
       },
       "peerDependenciesMeta": {
         "@afixt/afixt-engine": {
+          "optional": true
+        },
+        "@afixt/test-utils": {
+          "optional": true
+        },
+        "@guidepup/guidepup": {
+          "optional": true
+        },
+        "@guidepup/virtual-screen-reader": {
           "optional": true
         },
         "@playwright/test": {
@@ -492,15 +532,6 @@
         "playwright": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@afixt/usecase-runner/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2444,15 +2475,6 @@
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4146,6 +4168,7 @@
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5831,16 +5854,6 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
-      }
-    },
-    "node_modules/chromium-bidi/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/ci-info": {
@@ -9149,24 +9162,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10474,21 +10481,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jiti": {
@@ -13394,6 +13386,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   "overrides": {
     "zod": "4.3.6",
     "vite": "7.3.6",
-    "@afixt/usecase-runner": {
-      "zod": "3.25.76"
-    },
     "@afixt/a11y-assert": "2.1.3",
     "@babel/core": "^7.29.6",
     "basic-ftp": "^5.3.1",
@@ -122,7 +119,7 @@
     "test:e2e:journeys": "npm --workspace @livechat/e2e run test"
   },
   "devDependencies": {
-    "@afixt/usecase-runner": "1.3.2",
+    "@afixt/usecase-runner": "2.0.1",
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",
     "@double-great/stylelint-a11y": "3.4.10",

--- a/ui/e2e/generated/support-initiate-chat.spec.ts
+++ b/ui/e2e/generated/support-initiate-chat.spec.ts
@@ -17,16 +17,11 @@ test.describe('Operator starts a chat with a visitor from the presence list', ()
     // Step 2: Locate heading "Visitors on site" (initiate-chat.uc.yaml:1)
     await expect(page.getByRole('heading', { name: 'Visitors on site' })).toBeVisible();
 
-    // Step 3: Note Each visitor row is a button whose accessible name is
-"Start a chat with visitor <id>"; activating it emits chat:initiate for
-that visitor. The per-visitor name and the socket round trip are covered
-by the cross-ends journey suite.
- (initiate-chat.uc.yaml:2)
+    // Step 3: Note Each visitor row is a button whose accessible name is "Start a chat with visitor <id>"; activating it emits chat:initiate for that visitor. The per-visitor name and the socket round trip are covered by the cross-ends journey suite. (initiate-chat.uc.yaml:2)
     // Note: Each visitor row is a button whose accessible name is
-"Start a chat with visitor <id>"; activating it emits chat:initiate for
-that visitor. The per-visitor name and the socket round trip are covered
-by the cross-ends journey suite.
-
+    // "Start a chat with visitor <id>"; activating it emits chat:initiate for
+    // that visitor. The per-visitor name and the socket round trip are covered
+    // by the cross-ends journey suite.
 
   });
 });

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*", "vite.config.ts", "vitest.config.ts", "playwright.config.ts", "e2e/**/*"],
-  "exclude": ["node_modules", "dist", "coverage", "e2e/generated"]
+  "exclude": ["node_modules", "dist", "coverage"]
 }


### PR DESCRIPTION
Closes [#163](https://github.com/AFixt/livechat/issues/163). Also closes the **cause** of [#161](https://github.com/AFixt/livechat/issues/161), which [#162](https://github.com/AFixt/livechat/pull/162) only treated the symptom of.

## Why

The root `overrides` pulled zod two ways at once — `zod: 4.3.6` globally, with
`@afixt/usecase-runner: { zod: 3.25.76 }` clawing that subtree back, because
1.3.2 needs `zod@^3.24.1`. `chromium-bidi`, four levels down via
`afixt-engine` → `puppeteer`, wants `^3.24.1` too, and npm had two defensible
resolutions for it — alternating between them on every install.

2.x depends on `zod@^4.4.3`, so the scoped override is unnecessary and the
ambiguity goes with it.

## Acceptance criteria

| criterion | result |
|---|---|
| On 2.x, scoped override removed | ✅ 2.0.1 |
| `npm ls zod --all` invalid resolutions | ⚠️ 0 as reported — **but that check is inadequate, see below** |
| Lockfile idempotent across two runs | ✅ **byte-identical** — this failed before |
| All 39 use cases validate | ✅ stricter parser rejected none |
| Specs regenerated, `check-generated-specs.sh` clean | ✅ |
| `check:all` | ✅ green, on Node 22.23.2 **and** 26.7.0 |

The idempotency check is the one nothing else in the gate covers, and it is the
point of the exercise.

### Correction: the "0 invalid" figure does not mean what it looks like

Review caught this. npm reports an **overridden** edge as satisfied-by-fiat — it
is never counted as `invalid` — so `npm ls | grep invalid` structurally cannot
see an override forcing a package off its declared range. Checking with semver
instead:

```
@afixt/usecase-runner  needs ^4.4.3   got 4.3.6    VIOLATED
chromium-bidi          needs ^3.24.1  got 4.3.6    VIOLATED (forced across a major)
```

Both are masked by the root `overrides.zod: "4.3.6"`, which this PR does not
touch. Four configurations measured:

| config | invalid | overridden | zod versions |
|---|---|---|---|
| develop today | 3 | 3 | 3.25.76, 4.3.6 |
| **this PR** | **0** | **1** | 4.3.6 |
| this PR − root override | 2 | 0 | 3.25.76, 4.3.6, 4.4.3 |
| this PR + scoped `chromium-bidi` override, pins bumped | 2 | 5 | three versions |

This PR is the best of the four and a real improvement on develop, and the
primary goal — lockfile idempotency — is genuinely met. But no configuration is
fully clean: there are two `chromium-bidi` copies under different parents (one
via `estimo`) whose constraints cannot both be satisfied by one hoisted zod.

**`@afixt/usecase-runner@2.0.1` therefore runs against zod 4.3.6 while declaring
`^4.4.3`.** It works today — 39 use cases validate, `generate` is correct — but
that is a fact about the paths we exercise, not about the contract. Tracked in
[#165](https://github.com/AFixt/livechat/issues/165), along with the fact that
this repo needs a check capable of detecting override-induced violations, since
`npm ls` will not.

## The risks that did not materialise

`1.3.2 → 2.0.1` skips `1.3.3` through `1.7.0` as well as the major boundary. No
`BREAKING CHANGE` footers exist in `v1.7.0..v2.0.0`, but three commits could have
bitten:

- **parser now rejects trailing input** instead of discarding it — nothing here
  relied on that leniency; all 39 still validate
- **`keyboard` rejects non-key tokens** — no use case here uses `keyboard:`
- **live-region codegen matches every region**, not one by role priority — one
  spec changed

## The one that did: a committed spec that never compiled

The single changed spec turned out to have been **syntactically invalid
TypeScript all along**. A multi-line `note` broke out of its comment, leaving
bare prose in a `.ts` file:

```ts
// Step 3: Note Each visitor row is a button whose accessible name is
"Start a chat with visitor <id>"; activating it emits chat:initiate for
that visitor.
```

`tsc` on the committed file: six errors, TS1434 and TS1005.

It survived because it was invisible from **both** directions:

- `ui/tsconfig.json` excluded `e2e/generated`, so it was never compiled
- no Playwright project's `testMatch` names `support-initiate-chat`, so it was
  never run

2.0.1 emits it correctly. The second commit drops the tsconfig exclusion so the
compile half can never hide a generator bug again — verified in both directions:
clean on the current specs, **37 `error TS` lines** when the old broken spec is
restored.

### Checked against #130 before touching tsconfig

That issue was a tsconfig change dragging an uncopied file into the ui image
build, so:

- `ui/Dockerfile` does `COPY ui ./ui` — `ui/e2e/generated` is in the build
  context, and no `.dockerignore` excludes it
- the specs import `@playwright/test`, which `playwright.config.ts` (already in
  `include`) imports too, and which is a ui devDependency at 1.59.1, installed in
  the build stage

No new resolution requirement enters the image build. `npm run build:ui`
(`tsc -b` + vite build) passes.

## Deliberately not in this PR

- **The widget tsconfig.** It has no `e2e/**` in `include` at all, so covering
  its 16 generated specs means adding one — which drags in its
  `playwright.config.ts` and is precisely the #130 shape. Worth doing, not as a
  rider on this.
- **Proving the regenerated spec *passes*.** It cannot be shown, because nothing
  runs it — roughly 12 of the 39 generated specs are named by a `testMatch`, the
  rest deliberately deferred to the journey suite per the config's own comments.
  What can be shown, and is: it now parses where before it did not.
