### PR TITLE
fix(deps): stop usecase-runner running below its required zod, and detect the class

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -51,7 +51,7 @@
     "swagger-ui-express": "5.0.1",
     "tsx": "4.21.0",
     "uuid": "14.0.0",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/compression": "1.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@double-great/stylelint-a11y": "3.4.10",
         "@eslint/js": "9.39.4",
         "@total-typescript/ts-reset": "0.6.1",
+        "@types/semver": "7.8.0",
         "@typescript-eslint/parser": "8.59.0",
         "eslint": "9.39.4",
         "eslint-config-prettier": "9.1.0",
@@ -88,7 +89,7 @@
         "swagger-ui-express": "5.0.1",
         "tsx": "4.21.0",
         "uuid": "14.0.0",
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@types/compression": "1.8.1",
@@ -4061,6 +4062,13 @@
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
       "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -15060,6 +15068,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -18158,9 +18167,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18197,9 +18207,10 @@
       "name": "@livechat/shared",
       "version": "0.0.0",
       "dependencies": {
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "devDependencies": {
+        "semver": "7.7.4",
         "typescript": "5.7.2",
         "vite": "7.3.6",
         "vitest": "4.1.5"
@@ -18226,7 +18237,7 @@
         "react-i18next": "17.0.4",
         "react-router-dom": "7.18.2",
         "socket.io-client": "4.8.3",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
         "zustand": "5.0.12"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "e2e"
   ],
   "overrides": {
-    "zod": "4.3.6",
+    "zod": "4.4.3",
     "vite": "7.3.6",
     "@afixt/a11y-assert": "2.1.3",
     "@babel/core": "^7.29.6",
@@ -125,6 +125,7 @@
     "@double-great/stylelint-a11y": "3.4.10",
     "@eslint/js": "9.39.4",
     "@total-typescript/ts-reset": "0.6.1",
+    "@types/semver": "7.8.0",
     "@typescript-eslint/parser": "8.59.0",
     "eslint": "9.39.4",
     "eslint-config-prettier": "9.1.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -11,9 +11,10 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
+    "semver": "7.7.4",
     "typescript": "5.7.2",
     "vite": "7.3.6",
     "vitest": "4.1.5"

--- a/shared/tests/dependency-ranges.test.ts
+++ b/shared/tests/dependency-ranges.test.ts
@@ -14,8 +14,9 @@
  * minimum, which is the one direction that can break at runtime on any code
  * path we do not happen to exercise.
  *
- * So this walks the installed tree, compares every declared range against the
- * version actually resolvable from that package, and classifies what it finds:
+ * So this walks the installed tree, compares every declared `dependencies` and
+ * non-optional `peerDependencies` range against the version actually resolvable
+ * from that package, and classifies what it finds:
  *
  *   OLDER-THAN-REQUIRED  the resolved version is below the range's minimum.
  *                        Always a failure. A package cannot call an API that
@@ -72,6 +73,15 @@ const ACCEPTED_MAJOR_JUMPS: Record<string, string> = {
   'sequelize:uuid': 'forced 8.x -> 11.x for advisories; only uuid.v4() is used (#165)',
 };
 
+interface PackageManifest {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  /** An optional peer that is absent is not a violation — npm treats it as satisfied. */
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
 interface Violation {
   kind: 'OLDER-THAN-REQUIRED' | 'MAJOR-JUMP';
   parent: string;
@@ -86,15 +96,9 @@ interface Violation {
  * @param dir - Directory holding the manifest.
  * @returns The parsed manifest, or null.
  */
-function readPkg(
-  dir: string,
-): { name?: string; version?: string; dependencies?: Record<string, string> } | null {
+function readPkg(dir: string): PackageManifest | null {
   try {
-    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
-      name?: string;
-      version?: string;
-      dependencies?: Record<string, string>;
-    };
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as PackageManifest;
   } catch {
     return null;
   }
@@ -119,16 +123,28 @@ function resolveFrom(fromDir: string, name: string): { version?: string } | null
 }
 
 /**
+ * How deep a nested node_modules chain this walk will follow. The tree bottoms
+ * out at 2 today, measured; the cap is a runaway guard, not a budget. It is
+ * reported rather than silently applied — a detector that quietly stops looking
+ * is the failure this whole test exists to prevent.
+ */
+const MAX_NESTING = 12;
+
+/** Deepest nesting actually reached, so the cap can be asserted against it. */
+let deepestSeen = 0;
+
+/**
  * Yield every installed package under a node_modules directory.
  * @param nmDir - A node_modules directory.
- * @param depth - Current nesting depth, bounded to keep the walk cheap.
+ * @param depth - Current nesting depth.
  * @yields Directory and manifest for each package found.
  */
 function* walkInstalled(
   nmDir: string,
   depth = 0,
 ): Generator<[string, NonNullable<ReturnType<typeof readPkg>>]> {
-  if (depth > 6 || !existsSync(nmDir)) return;
+  if (depth > MAX_NESTING || !existsSync(nmDir)) return;
+  if (depth > deepestSeen) deepestSeen = depth;
   for (const entry of readdirSync(nmDir)) {
     if (entry === '.bin' || entry.startsWith('.')) continue;
     const full = join(nmDir, entry);
@@ -150,7 +166,16 @@ function findViolations(): Violation[] {
   const found = new Map<string, Violation>();
 
   for (const [dir, pkg] of walkInstalled(join(REPO_ROOT, 'node_modules'))) {
-    for (const [dep, range] of Object.entries(pkg.dependencies ?? {})) {
+    const declared = [
+      ...Object.entries(pkg.dependencies ?? {}),
+      // Peers break at runtime just as hard, and cost nothing to include: there
+      // are none violated today, so this is coverage against tomorrow.
+      ...Object.entries(pkg.peerDependencies ?? {}).filter(
+        ([dep]) => pkg.peerDependenciesMeta?.[dep]?.optional !== true,
+      ),
+    ];
+
+    for (const [dep, range] of declared) {
       if (!semver.validRange(range)) continue;
 
       const resolved = resolveFrom(dir, dep)?.version;
@@ -217,6 +242,15 @@ describe('dependency ranges under the root overrides (#165)', () => {
       `major-version overrides with no entry in ACCEPTED_MAJOR_JUMPS:\n${describeAll(unexplained)}\n` +
         'Add one with the reason it is safe, or change the override.',
     ).toStrictEqual([]);
+  });
+
+  it('walked the whole tree rather than stopping at the nesting cap', () => {
+    // Without this the cap could truncate the scan and every other case here
+    // would still pass, reporting a clean tree it never finished reading.
+    expect(
+      deepestSeen,
+      `the walk reached the ${String(MAX_NESTING)} level cap, so packages below it went unchecked — raise MAX_NESTING`,
+    ).toBeLessThan(MAX_NESTING);
   });
 
   it('has no stale entries in the accepted list', () => {

--- a/shared/tests/dependency-ranges.test.ts
+++ b/shared/tests/dependency-ranges.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Guard for override-induced dependency-range violations (#165).
+ *
+ * The root `overrides` block forces versions on transitive dependencies —
+ * mostly to pull in patched releases ahead of what a parent declares. That is
+ * what overrides are for. The hazard is that npm reports an overridden edge as
+ * satisfied-by-fiat: `npm ls` marks it `overridden`, never `invalid`, so
+ * `npm ls | grep invalid` returns zero however far an override drags a package
+ * off its declared range. That check was in this repo's own acceptance criteria
+ * for #163 and could not have failed.
+ *
+ * Discovered the hard way: `@afixt/usecase-runner@2.0.1` declares `zod@^4.4.3`
+ * and was silently running on `4.3.6` — a package older than its stated
+ * minimum, which is the one direction that can break at runtime on any code
+ * path we do not happen to exercise.
+ *
+ * So this walks the installed tree, compares every declared range against the
+ * version actually resolvable from that package, and classifies what it finds:
+ *
+ *   OLDER-THAN-REQUIRED  the resolved version is below the range's minimum.
+ *                        Always a failure. A package cannot call an API that
+ *                        does not exist yet.
+ *   MAJOR-JUMP           resolved across a major boundary. Allowed only with an
+ *                        entry in ACCEPTED_MAJOR_JUMPS explaining why.
+ *   ahead-in-line        newer, same major. This is the intended effect of a
+ *                        security override; not reported.
+ *
+ * It reads what is on disk rather than the lockfile, because the lockfile is
+ * what we intend and node_modules is what actually gets imported.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import semver from 'semver';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Walk up from `start` to the directory holding the root package.json.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, 'package-lock.json'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`could not locate the repository root from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+
+/**
+ * Major-version overrides we have looked at and decided to keep. Each entry is
+ * a promise that someone checked the consequence, so leave the reason attached.
+ */
+const ACCEPTED_MAJOR_JUMPS: Record<string, string> = {
+  // puppeteer's BiDi layer, four levels down under @afixt/usecase-runner. The
+  // root override moves the whole tree to zod 4; pinning chromium-bidi back to
+  // zod 3 was measured and made things worse (invalid=2, overridden=5, three
+  // zod copies). We never call chromium-bidi directly — puppeteer drives it.
+  'chromium-bidi:zod': 'forced 3.x -> 4.x by the root zod override; not called directly (#165)',
+  // sequelize 6 declares uuid ^8; the override lifts it to 11 to clear
+  // advisories against the 8.x line. Sequelize uses uuid only to generate v4
+  // ids, an API stable across all three majors.
+  'sequelize:uuid': 'forced 8.x -> 11.x for advisories; only uuid.v4() is used (#165)',
+};
+
+interface Violation {
+  kind: 'OLDER-THAN-REQUIRED' | 'MAJOR-JUMP';
+  parent: string;
+  dep: string;
+  range: string;
+  resolved: string;
+  key: string;
+}
+
+/**
+ * Read a package.json, or null when absent or unparseable.
+ * @param dir - Directory holding the manifest.
+ * @returns The parsed manifest, or null.
+ */
+function readPkg(
+  dir: string,
+): { name?: string; version?: string; dependencies?: Record<string, string> } | null {
+  try {
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      name?: string;
+      version?: string;
+      dependencies?: Record<string, string>;
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve `name` the way Node would from `fromDir`: nearest `node_modules`
+ * walking upward. Reading the tree, not the lockfile, is the point.
+ * @param fromDir - Directory of the package doing the requiring.
+ * @param name - Package being required.
+ * @returns The resolved manifest, or null when nothing is installed.
+ */
+function resolveFrom(fromDir: string, name: string): { version?: string } | null {
+  let dir = fromDir;
+  for (;;) {
+    const candidate = join(dir, 'node_modules', name);
+    if (existsSync(join(candidate, 'package.json'))) return readPkg(candidate);
+    const parent = dirname(dir);
+    if (parent === dir || !dir.startsWith(REPO_ROOT)) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Yield every installed package under a node_modules directory.
+ * @param nmDir - A node_modules directory.
+ * @param depth - Current nesting depth, bounded to keep the walk cheap.
+ * @yields Directory and manifest for each package found.
+ */
+function* walkInstalled(
+  nmDir: string,
+  depth = 0,
+): Generator<[string, NonNullable<ReturnType<typeof readPkg>>]> {
+  if (depth > 6 || !existsSync(nmDir)) return;
+  for (const entry of readdirSync(nmDir)) {
+    if (entry === '.bin' || entry.startsWith('.')) continue;
+    const full = join(nmDir, entry);
+    if (entry.startsWith('@')) {
+      yield* walkInstalled(full, depth);
+      continue;
+    }
+    const pkg = readPkg(full);
+    if (pkg) yield [full, pkg];
+    yield* walkInstalled(join(full, 'node_modules'), depth + 1);
+  }
+}
+
+/**
+ * Collect every declared range the installed tree does not satisfy.
+ * @returns Violations, deduplicated by parent/dep/resolved.
+ */
+function findViolations(): Violation[] {
+  const found = new Map<string, Violation>();
+
+  for (const [dir, pkg] of walkInstalled(join(REPO_ROOT, 'node_modules'))) {
+    for (const [dep, range] of Object.entries(pkg.dependencies ?? {})) {
+      if (!semver.validRange(range)) continue;
+
+      const resolved = resolveFrom(dir, dep)?.version;
+      if (resolved === undefined || semver.satisfies(resolved, range)) continue;
+
+      const min = semver.minVersion(range);
+      if (min === null) continue;
+
+      const kind = semver.lt(resolved, min)
+        ? 'OLDER-THAN-REQUIRED'
+        : semver.major(resolved) === semver.major(min)
+          ? null // ahead within the same major: the intended effect of an override
+          : 'MAJOR-JUMP';
+      if (kind === null) continue;
+
+      const key = `${pkg.name ?? dir}:${dep}`;
+      found.set(`${key}@${resolved}`, {
+        kind,
+        parent: `${pkg.name ?? dir}@${pkg.version ?? '?'}`,
+        dep,
+        range,
+        resolved,
+        key,
+      });
+    }
+  }
+
+  return [...found.values()];
+}
+
+/**
+ * Render violations for an assertion message.
+ * @param violations - The violations to describe.
+ * @returns One line per violation.
+ */
+function describeAll(violations: Violation[]): string {
+  return violations
+    .map((v) => `  [${v.kind}] ${v.parent} needs ${v.dep}@${v.range} -> resolved ${v.resolved}`)
+    .join('\n');
+}
+
+describe('dependency ranges under the root overrides (#165)', () => {
+  const violations = findViolations();
+
+  it('resolves nothing OLDER than the version its parent requires', () => {
+    // The dangerous direction, and the one npm will never call invalid while an
+    // override is responsible. `usecase-runner` spent this repo's whole 2.x
+    // upgrade running on a zod below its declared minimum.
+    const older = violations.filter((v) => v.kind === 'OLDER-THAN-REQUIRED');
+
+    expect(
+      older,
+      `packages resolved below their required minimum:\n${describeAll(older)}`,
+    ).toStrictEqual([]);
+  });
+
+  it('crosses a major boundary only where that has been accepted in writing', () => {
+    const unexplained = violations.filter(
+      (v) => v.kind === 'MAJOR-JUMP' && !(v.key in ACCEPTED_MAJOR_JUMPS),
+    );
+
+    expect(
+      unexplained,
+      `major-version overrides with no entry in ACCEPTED_MAJOR_JUMPS:\n${describeAll(unexplained)}\n` +
+        'Add one with the reason it is safe, or change the override.',
+    ).toStrictEqual([]);
+  });
+
+  it('has no stale entries in the accepted list', () => {
+    // Control: without this the allowlist only ever grows, and an entry that
+    // stopped applying would keep vouching for a condition that no longer
+    // exists — the same shape of dead reassurance as a gate that cannot fail.
+    const live = new Set(violations.filter((v) => v.kind === 'MAJOR-JUMP').map((v) => v.key));
+    const stale = Object.keys(ACCEPTED_MAJOR_JUMPS).filter((key) => !live.has(key));
+
+    expect(
+      stale,
+      `ACCEPTED_MAJOR_JUMPS entries no longer matching anything: ${stale.join(', ')}`,
+    ).toStrictEqual([]);
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
     "react-i18next": "17.0.4",
     "react-router-dom": "7.18.2",
     "socket.io-client": "4.8.3",
-    "zod": "4.3.6",
+    "zod": "4.4.3",
     "zustand": "5.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes [#165](https://github.com/AFixt/livechat/issues/165).

## The measurement was the bug

`npm ls | grep invalid` cannot answer the question it was being asked. npm
reports an overridden edge as **satisfied-by-fiat** — `overridden`, never
`invalid` — so the count stays at zero however far an override drags a package
off its declared range.

That check was in this repo's own acceptance criteria for
[#163](https://github.com/AFixt/livechat/issues/163), where it could not have
failed. It is how `@afixt/usecase-runner@2.0.1` came to be running on
`zod@4.3.6` while declaring `^4.4.3`, through an upgrade whose entire purpose
was to tidy the zod resolution.

## Three problems, not twelve

Checking with semver instead turns up 12 range violations, all override-induced.
Reporting that as "12 violations" would be as useless as reporting zero:

| kind | n | assessment |
|---|---|---|
| **OLDER-THAN-REQUIRED** | 1 | `usecase-runner` below its zod minimum. **The only kind that can break at runtime** on a path we do not happen to exercise |
| **MAJOR-JUMP** | 3 | `chromium-bidi` ×2 (zod 3→4), `sequelize` (uuid 8→11). Deliberate, but they need a written reason |
| **ahead-in-line** | 8 | newer within the same major — precisely what a security override is *for*. Not a defect, not reported |

## The fix

zod → **4.4.3** in the root override and in `shared`, `api` and `ui`. That
satisfies `usecase-runner`; typecheck is clean and all 535 tests pass on Node
22.23.2 and 26.7.0.

The three major jumps stay. Nothing measured removes them — pinning
`chromium-bidi` back to zod 3 was tried during the #164 review and made the tree
worse (invalid=2, overridden=5, three zod copies).

## The detector

`shared/tests/dependency-ranges.test.ts` walks the **installed tree** — what
actually gets imported, not what the lockfile intends — and fails on:

- any `OLDER-THAN-REQUIRED`, unconditionally
- any `MAJOR-JUMP` without an entry in `ACCEPTED_MAJOR_JUMPS` giving the reason

Both live entries carry theirs: `chromium-bidi` is driven by puppeteer and never
called directly; `sequelize` uses `uuid` only for v4 ids, an API unchanged across
8 through 11.

A third case asserts the allowlist has **no stale entries**. Without it the list
only ever grows, and an entry that stopped applying would go on vouching for a
condition that no longer exists — the same dead reassurance as a gate that cannot
fail ([#149](https://github.com/AFixt/livechat/issues/149)).

### Mutation-checked

Each mutation fails only what it guards:

| mutation | result |
|---|---|
| zod override reverted to 4.3.6 | `OLDER-THAN-REQUIRED`, naming `@afixt/usecase-runner@2.0.1 needs zod@^4.4.3 -> resolved 4.3.6` |
| an accepted entry removed | the major-jump case only |
| a stale entry added | the stale-entry case only |

## Also

`semver` becomes an explicit devDependency of `shared` rather than being borrowed
transitively — the same class of problem this test detects.

## Verification

`check` clean, `test:ci` green on Node 22.23.2 **and** 26.7.0 (38 shared / 400
api / 52 ui / 48 widget), `check:all` green on the way in.