### PR TITLE
Release v0.4.0

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,28 @@
+# Bring node_modules in line after a merge or checkout that moved the lockfile.
+#
+# `npm ci` rather than `npm install`, because install RE-RESOLVES and rewrites
+# package-lock.json — and this repo's zod overrides give npm two defensible
+# resolutions for chromium-bidi's zod, so it alternates between them (#161).
+# The result was a tree that went dirty on every branch switch, for a file
+# nobody edited, with `git commit -am` standing ready to sweep it into an
+# unrelated commit. `npm ci` installs exactly what is committed and never
+# writes to the lockfile.
+#
+# The fallback is not decoration. `npm ci` DELETES node_modules before it
+# installs, so a failure part-way — an expired registry token, a network blip —
+# leaves no working install at all. That is how this hook's own environment got
+# destroyed while #161 was being investigated. `npm install` can repair from a
+# partial state, so it is what we reach for when ci fails: the lockfile may get
+# rewritten, but a rewritten lockfile beats an unusable checkout.
 changed=$(git diff HEAD@{1} HEAD --name-only)
 if echo "$changed" | grep -q "package-lock.json"; then
   echo "Lockfile changed; installing and auditing..."
-  npm install
-  npm audit --production --audit-level=high || true
+  if ! npm ci; then
+    echo "post-merge: 'npm ci' failed — falling back to 'npm install' to leave you a working tree." >&2
+    echo "post-merge: if package-lock.json comes back modified, that is the fallback, not your change (#161)." >&2
+    npm install
+  fi
+  # --omit=dev, not the legacy --production alias, which npm warns about on
+  # every run: identical output here (both: found 0 vulnerabilities).
+  npm audit --omit=dev --audit-level=high || true
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
+## [0.4.0] - 2026-08-29
+
+### Changed
+
+- **`@afixt/usecase-runner` upgraded to 2.0.1**, dropping the scoped
+  `zod: 3.25.76` override that 1.3.2 forced on its subtree. That override was
+  the cause of npm holding two defensible resolutions for `chromium-bidi`'s
+  zod and alternating between them on every install — the lockfile is now
+  byte-identical across repeated installs. All 39 use cases validate under
+  2.x's stricter parser, and the generated Playwright specs were regenerated.
+  ([#163], [#164]; also closes the cause of [#161])
+
+### Fixed
+
+- **`usecase-runner` no longer runs below its declared zod minimum.** The root
+  override pinned `zod@4.3.6` while `@afixt/usecase-runner@2.0.1` declares
+  `^4.4.3` — and `npm ls | grep invalid` structurally cannot see this, because
+  npm reports an overridden edge as satisfied-by-fiat, never `invalid`. zod is
+  now 4.4.3 in the root override and the `shared`/`api`/`ui` pins, and
+  `shared/tests/dependency-ranges.test.ts` guards the whole class: it walks the
+  installed tree with real semver comparisons, fails anything resolved below
+  its declared minimum, and requires a written entry for any major-boundary
+  override. The two `chromium-bidi` copies forced from zod 3 to 4 are accepted
+  there in writing — scoping the override for them was measured and made
+  things worse. ([#165], [#166])
+
+- **The post-merge hook installs with `npm ci`**, which installs exactly what
+  the lockfile says and never rewrites it. `npm install` re-resolved on every
+  lockfile-moving merge or checkout, dirtying the working tree with a change
+  nobody made — it fired twice during the v0.3.1 release, including on the
+  checkout of `main` immediately before tagging. ([#161], [#162])
+
 ## [0.3.1] - 2026-08-26
 
 ### Fixed
@@ -1030,7 +1062,8 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
   ships with Node 22, and effective on toolchain upgrade.
 - `body-parser` bumped to 2.3.0, clearing OSV `GHSA-v422-hmwv-36x6`.
 
-[Unreleased]: https://github.com/AFixt/livechat/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/AFixt/livechat/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/AFixt/livechat/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/AFixt/livechat/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/AFixt/livechat/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/AFixt/livechat/compare/v0.1.2...v0.2.0
@@ -1062,3 +1095,9 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
 [#150]: https://github.com/AFixt/livechat/issues/150
 [#148]: https://github.com/AFixt/livechat/pull/148
 [#155]: https://github.com/AFixt/livechat/issues/155
+[#161]: https://github.com/AFixt/livechat/issues/161
+[#162]: https://github.com/AFixt/livechat/pull/162
+[#163]: https://github.com/AFixt/livechat/issues/163
+[#164]: https://github.com/AFixt/livechat/pull/164
+[#165]: https://github.com/AFixt/livechat/issues/165
+[#166]: https://github.com/AFixt/livechat/pull/166

--- a/api/package.json
+++ b/api/package.json
@@ -51,7 +51,7 @@
     "swagger-ui-express": "5.0.1",
     "tsx": "4.21.0",
     "uuid": "14.0.0",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/compression": "1.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "UNLICENSED",
       "workspaces": [
         "shared",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@double-great/stylelint-a11y": "3.4.10",
         "@eslint/js": "9.39.4",
         "@total-typescript/ts-reset": "0.6.1",
+        "@types/semver": "7.8.0",
         "@typescript-eslint/parser": "8.59.0",
         "eslint": "9.39.4",
         "eslint-config-prettier": "9.1.0",
@@ -88,7 +89,7 @@
         "swagger-ui-express": "5.0.1",
         "tsx": "4.21.0",
         "uuid": "14.0.0",
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@types/compression": "1.8.1",
@@ -4061,6 +4062,13 @@
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
       "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -15060,6 +15068,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -18158,9 +18167,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18197,9 +18207,10 @@
       "name": "@livechat/shared",
       "version": "0.0.0",
       "dependencies": {
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "devDependencies": {
+        "semver": "7.7.4",
         "typescript": "5.7.2",
         "vite": "7.3.6",
         "vitest": "4.1.5"
@@ -18226,7 +18237,7 @@
         "react-i18next": "17.0.4",
         "react-router-dom": "7.18.2",
         "socket.io-client": "4.8.3",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
         "zustand": "5.0.12"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "e2e"
       ],
       "devDependencies": {
-        "@afixt/usecase-runner": "1.3.2",
+        "@afixt/usecase-runner": "2.0.1",
         "@commitlint/cli": "19.6.1",
         "@commitlint/config-conventional": "19.6.0",
         "@double-great/stylelint-a11y": "3.4.10",
@@ -446,44 +446,84 @@
       }
     },
     "node_modules/@afixt/test-utils": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/@afixt/test-utils/-/test-utils-2.9.7.tgz",
-      "integrity": "sha512-dct+VB9cCEbsW9GwueIIwWstcuH9XCTNiCVg3STf0psoECXJbcyOF5kvIIsbIc/UfEuXFHLCo79dN+98fsdJkA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@afixt/test-utils/-/test-utils-2.23.0.tgz",
+      "integrity": "sha512-rTKe44s52mn5oOdOTy12tgN3Vqk7q1mYEhA/5ORk+ZyQGdhmumWjxFrfEcvHw6zmtfxfDV46fWV3kQ4V2xT7Jw==",
       "dev": true,
+      "license": "UNLICENSED",
       "dependencies": {
         "franc": "^6.2.0",
-        "tesseract.js": "^6.0.0"
+        "tesseract.js": "^7.0.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
       }
     },
-    "node_modules/@afixt/usecase-runner": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-1.3.2.tgz",
-      "integrity": "sha512-pAYOn4BDYM3WC9bsvlBi0iikI2K5Qm3x349//k5MBWBsl0k5MijaHtj8FRe0A8RTNv23RV91PieFE/EAQD4B2Q==",
+    "node_modules/@afixt/test-utils/node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
       "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/@afixt/test-utils/node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@afixt/usecase-runner": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-2.0.1.tgz",
+      "integrity": "sha512-lw6RsofU7FxvubqSENXPLP/xst8rqCN/oOPAu40sphWh0tTfJrRcGY4k2PSrSN0OXTOmQ3MDvWYI6YL+Sc2FJA==",
+      "dev": true,
+      "license": "UNLICENSED",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
-        "glob": "^11.0.0",
+        "glob": "^13.0.6",
         "handlebars": "^4.7.8",
-        "yaml": "^2.6.1",
-        "zod": "^3.24.1"
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "usecase-runner": "bin/usecase-runner.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@afixt/afixt-engine": ">=1.0.0",
+        "@afixt/afixt-engine": ">=1.9.0",
+        "@afixt/test-utils": ">=2.10.0",
+        "@guidepup/guidepup": ">=0.21.0",
+        "@guidepup/virtual-screen-reader": ">=0.27.0",
         "@playwright/test": ">=1.40.0",
         "playwright": ">=1.40.0"
       },
       "peerDependenciesMeta": {
         "@afixt/afixt-engine": {
+          "optional": true
+        },
+        "@afixt/test-utils": {
+          "optional": true
+        },
+        "@guidepup/guidepup": {
+          "optional": true
+        },
+        "@guidepup/virtual-screen-reader": {
           "optional": true
         },
         "@playwright/test": {
@@ -492,15 +532,6 @@
         "playwright": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@afixt/usecase-runner/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2444,15 +2475,6 @@
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4146,6 +4168,7 @@
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5831,16 +5854,6 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
-      }
-    },
-    "node_modules/chromium-bidi/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/ci-info": {
@@ -9149,24 +9162,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10474,21 +10481,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jiti": {
@@ -13394,6 +13386,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   "overrides": {
     "zod": "4.3.6",
     "vite": "7.3.6",
-    "@afixt/usecase-runner": {
-      "zod": "3.25.76"
-    },
     "@afixt/a11y-assert": "2.1.3",
     "@babel/core": "^7.29.6",
     "basic-ftp": "^5.3.1",
@@ -122,7 +119,7 @@
     "test:e2e:journeys": "npm --workspace @livechat/e2e run test"
   },
   "devDependencies": {
-    "@afixt/usecase-runner": "1.3.2",
+    "@afixt/usecase-runner": "2.0.1",
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",
     "@double-great/stylelint-a11y": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "e2e"
   ],
   "overrides": {
-    "zod": "4.3.6",
+    "zod": "4.4.3",
     "vite": "7.3.6",
     "@afixt/a11y-assert": "2.1.3",
     "@babel/core": "^7.29.6",
@@ -125,6 +125,7 @@
     "@double-great/stylelint-a11y": "3.4.10",
     "@eslint/js": "9.39.4",
     "@total-typescript/ts-reset": "0.6.1",
+    "@types/semver": "7.8.0",
     "@typescript-eslint/parser": "8.59.0",
     "eslint": "9.39.4",
     "eslint-config-prettier": "9.1.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -11,9 +11,10 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
+    "semver": "7.7.4",
     "typescript": "5.7.2",
     "vite": "7.3.6",
     "vitest": "4.1.5"

--- a/shared/tests/dependency-ranges.test.ts
+++ b/shared/tests/dependency-ranges.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Guard for override-induced dependency-range violations (#165).
+ *
+ * The root `overrides` block forces versions on transitive dependencies —
+ * mostly to pull in patched releases ahead of what a parent declares. That is
+ * what overrides are for. The hazard is that npm reports an overridden edge as
+ * satisfied-by-fiat: `npm ls` marks it `overridden`, never `invalid`, so
+ * `npm ls | grep invalid` returns zero however far an override drags a package
+ * off its declared range. That check was in this repo's own acceptance criteria
+ * for #163 and could not have failed.
+ *
+ * Discovered the hard way: `@afixt/usecase-runner@2.0.1` declares `zod@^4.4.3`
+ * and was silently running on `4.3.6` — a package older than its stated
+ * minimum, which is the one direction that can break at runtime on any code
+ * path we do not happen to exercise.
+ *
+ * So this walks the installed tree, compares every declared `dependencies` and
+ * non-optional `peerDependencies` range against the version actually resolvable
+ * from that package, and classifies what it finds:
+ *
+ *   OLDER-THAN-REQUIRED  the resolved version is below the range's minimum.
+ *                        Always a failure. A package cannot call an API that
+ *                        does not exist yet.
+ *   MAJOR-JUMP           resolved across a major boundary. Allowed only with an
+ *                        entry in ACCEPTED_MAJOR_JUMPS explaining why.
+ *   ahead-in-line        newer, same major. This is the intended effect of a
+ *                        security override; not reported.
+ *
+ * It reads what is on disk rather than the lockfile, because the lockfile is
+ * what we intend and node_modules is what actually gets imported.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import semver from 'semver';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Walk up from `start` to the directory holding the root package.json.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, 'package-lock.json'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`could not locate the repository root from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+
+/**
+ * Major-version overrides we have looked at and decided to keep. Each entry is
+ * a promise that someone checked the consequence, so leave the reason attached.
+ */
+const ACCEPTED_MAJOR_JUMPS: Record<string, string> = {
+  // puppeteer's BiDi layer, four levels down under @afixt/usecase-runner. The
+  // root override moves the whole tree to zod 4; pinning chromium-bidi back to
+  // zod 3 was measured and made things worse (invalid=2, overridden=5, three
+  // zod copies). We never call chromium-bidi directly — puppeteer drives it.
+  'chromium-bidi:zod': 'forced 3.x -> 4.x by the root zod override; not called directly (#165)',
+  // sequelize 6 declares uuid ^8; the override lifts it to 11 to clear
+  // advisories against the 8.x line. Sequelize uses uuid only to generate v4
+  // ids, an API stable across all three majors.
+  'sequelize:uuid': 'forced 8.x -> 11.x for advisories; only uuid.v4() is used (#165)',
+};
+
+interface PackageManifest {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  /** An optional peer that is absent is not a violation — npm treats it as satisfied. */
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+interface Violation {
+  kind: 'OLDER-THAN-REQUIRED' | 'MAJOR-JUMP';
+  parent: string;
+  dep: string;
+  range: string;
+  resolved: string;
+  key: string;
+}
+
+/**
+ * Read a package.json, or null when absent or unparseable.
+ * @param dir - Directory holding the manifest.
+ * @returns The parsed manifest, or null.
+ */
+function readPkg(dir: string): PackageManifest | null {
+  try {
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as PackageManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve `name` the way Node would from `fromDir`: nearest `node_modules`
+ * walking upward. Reading the tree, not the lockfile, is the point.
+ * @param fromDir - Directory of the package doing the requiring.
+ * @param name - Package being required.
+ * @returns The resolved manifest, or null when nothing is installed.
+ */
+function resolveFrom(fromDir: string, name: string): { version?: string } | null {
+  let dir = fromDir;
+  for (;;) {
+    const candidate = join(dir, 'node_modules', name);
+    if (existsSync(join(candidate, 'package.json'))) return readPkg(candidate);
+    const parent = dirname(dir);
+    if (parent === dir || !dir.startsWith(REPO_ROOT)) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * How deep a nested node_modules chain this walk will follow. The tree bottoms
+ * out at 2 today, measured; the cap is a runaway guard, not a budget. It is
+ * reported rather than silently applied — a detector that quietly stops looking
+ * is the failure this whole test exists to prevent.
+ */
+const MAX_NESTING = 12;
+
+/** Deepest nesting actually reached, so the cap can be asserted against it. */
+let deepestSeen = 0;
+
+/**
+ * Yield every installed package under a node_modules directory.
+ * @param nmDir - A node_modules directory.
+ * @param depth - Current nesting depth.
+ * @yields Directory and manifest for each package found.
+ */
+function* walkInstalled(
+  nmDir: string,
+  depth = 0,
+): Generator<[string, NonNullable<ReturnType<typeof readPkg>>]> {
+  if (depth > MAX_NESTING || !existsSync(nmDir)) return;
+  if (depth > deepestSeen) deepestSeen = depth;
+  for (const entry of readdirSync(nmDir)) {
+    if (entry === '.bin' || entry.startsWith('.')) continue;
+    const full = join(nmDir, entry);
+    if (entry.startsWith('@')) {
+      yield* walkInstalled(full, depth);
+      continue;
+    }
+    const pkg = readPkg(full);
+    if (pkg) yield [full, pkg];
+    yield* walkInstalled(join(full, 'node_modules'), depth + 1);
+  }
+}
+
+/**
+ * Collect every declared range the installed tree does not satisfy.
+ * @returns Violations, deduplicated by parent/dep/resolved.
+ */
+function findViolations(): Violation[] {
+  const found = new Map<string, Violation>();
+
+  for (const [dir, pkg] of walkInstalled(join(REPO_ROOT, 'node_modules'))) {
+    const declared = [
+      ...Object.entries(pkg.dependencies ?? {}),
+      // Peers break at runtime just as hard, and cost nothing to include: there
+      // are none violated today, so this is coverage against tomorrow.
+      ...Object.entries(pkg.peerDependencies ?? {}).filter(
+        ([dep]) => pkg.peerDependenciesMeta?.[dep]?.optional !== true,
+      ),
+    ];
+
+    for (const [dep, range] of declared) {
+      if (!semver.validRange(range)) continue;
+
+      const resolved = resolveFrom(dir, dep)?.version;
+      if (resolved === undefined || semver.satisfies(resolved, range)) continue;
+
+      const min = semver.minVersion(range);
+      if (min === null) continue;
+
+      const kind = semver.lt(resolved, min)
+        ? 'OLDER-THAN-REQUIRED'
+        : semver.major(resolved) === semver.major(min)
+          ? null // ahead within the same major: the intended effect of an override
+          : 'MAJOR-JUMP';
+      if (kind === null) continue;
+
+      const key = `${pkg.name ?? dir}:${dep}`;
+      found.set(`${key}@${resolved}`, {
+        kind,
+        parent: `${pkg.name ?? dir}@${pkg.version ?? '?'}`,
+        dep,
+        range,
+        resolved,
+        key,
+      });
+    }
+  }
+
+  return [...found.values()];
+}
+
+/**
+ * Render violations for an assertion message.
+ * @param violations - The violations to describe.
+ * @returns One line per violation.
+ */
+function describeAll(violations: Violation[]): string {
+  return violations
+    .map((v) => `  [${v.kind}] ${v.parent} needs ${v.dep}@${v.range} -> resolved ${v.resolved}`)
+    .join('\n');
+}
+
+describe('dependency ranges under the root overrides (#165)', () => {
+  const violations = findViolations();
+
+  it('resolves nothing OLDER than the version its parent requires', () => {
+    // The dangerous direction, and the one npm will never call invalid while an
+    // override is responsible. `usecase-runner` spent this repo's whole 2.x
+    // upgrade running on a zod below its declared minimum.
+    const older = violations.filter((v) => v.kind === 'OLDER-THAN-REQUIRED');
+
+    expect(
+      older,
+      `packages resolved below their required minimum:\n${describeAll(older)}`,
+    ).toStrictEqual([]);
+  });
+
+  it('crosses a major boundary only where that has been accepted in writing', () => {
+    const unexplained = violations.filter(
+      (v) => v.kind === 'MAJOR-JUMP' && !(v.key in ACCEPTED_MAJOR_JUMPS),
+    );
+
+    expect(
+      unexplained,
+      `major-version overrides with no entry in ACCEPTED_MAJOR_JUMPS:\n${describeAll(unexplained)}\n` +
+        'Add one with the reason it is safe, or change the override.',
+    ).toStrictEqual([]);
+  });
+
+  it('walked the whole tree rather than stopping at the nesting cap', () => {
+    // Without this the cap could truncate the scan and every other case here
+    // would still pass, reporting a clean tree it never finished reading.
+    expect(
+      deepestSeen,
+      `the walk reached the ${String(MAX_NESTING)} level cap, so packages below it went unchecked — raise MAX_NESTING`,
+    ).toBeLessThan(MAX_NESTING);
+  });
+
+  it('has no stale entries in the accepted list', () => {
+    // Control: without this the allowlist only ever grows, and an entry that
+    // stopped applying would keep vouching for a condition that no longer
+    // exists — the same shape of dead reassurance as a gate that cannot fail.
+    const live = new Set(violations.filter((v) => v.kind === 'MAJOR-JUMP').map((v) => v.key));
+    const stale = Object.keys(ACCEPTED_MAJOR_JUMPS).filter((key) => !live.has(key));
+
+    expect(
+      stale,
+      `ACCEPTED_MAJOR_JUMPS entries no longer matching anything: ${stale.join(', ')}`,
+    ).toStrictEqual([]);
+  });
+});

--- a/shared/tests/post-merge-hook.test.ts
+++ b/shared/tests/post-merge-hook.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression guard for the post-merge install hook.
+ *
+ * `.husky/post-merge` reinstalls when a merge or checkout moved the lockfile.
+ * It used to run `npm install`, which RE-RESOLVES dependencies and rewrites
+ * `package-lock.json`. This repo's zod overrides leave npm two defensible
+ * resolutions for `chromium-bidi`'s zod, so it alternates between them (#161) —
+ * and the tree went dirty on every branch switch, for a file nobody edited,
+ * with `git commit -am` standing ready to sweep it into an unrelated commit.
+ *
+ * `npm ci` installs exactly what is committed and never writes the lockfile.
+ * But it DELETES `node_modules` first, so a failure part-way leaves no working
+ * install at all — which is how the environment was destroyed while #161 was
+ * being investigated. Hence the fallback to `npm install`.
+ *
+ * Both halves are load-bearing and both are asserted here, in the manner of
+ * `pre-push-hook.test.ts`: that the hook reaches for `ci` and not `install` on
+ * the happy path, AND that a failing `ci` still ends with a working install.
+ * Without the second half the test would pass just as happily against a hook
+ * that left the developer with nothing.
+ *
+ * The real hook file is executed, with `npm` stubbed on PATH — so what is under
+ * test is the shipped file's branching, not a re-implementation of it.
+ */
+/* eslint-disable n/no-sync, security/detect-non-literal-fs-filename */
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOOK = '.husky/post-merge';
+
+/**
+ * Walk up from `start` until the directory holding the hook.
+ * @param start - Directory to start from.
+ * @returns The repository root.
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, HOOK))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`could not locate ${HOOK} from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(HERE);
+
+/**
+ * Git hooks export GIT_DIR and friends; a child git would otherwise operate on
+ * THIS repository instead of the fixture. Same guard as
+ * `generated-specs-gate.test.ts`, learned the same way.
+ */
+const GIT_ENV: NodeJS.ProcessEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+);
+
+const scratchDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Run git in `cwd`, throwing on failure.
+ * @param cwd - Repository directory.
+ * @param args - git arguments.
+ */
+function git(cwd: string, ...args: string[]): void {
+  const run = spawnSync('git', args, { cwd, encoding: 'utf8', env: GIT_ENV });
+  if (run.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${run.stderr}`);
+}
+
+/**
+ * Build a throwaway repo carrying the real hook, a stubbed `npm`, and a commit
+ * history whose tip either did or did not touch the lockfile.
+ * @param options - Fixture options.
+ * @param options.touchLockfile - Whether the last commit modifies package-lock.json.
+ * @param options.ciExit - Exit status the stubbed `npm ci` returns.
+ * @returns The fixture directory.
+ */
+function fixture(options: { touchLockfile: boolean; ciExit?: number; realGit?: boolean }): string {
+  const { touchLockfile, ciExit = 0, realGit = false } = options;
+
+  const root = mkdtempSync(join(tmpdir(), 'post-merge-'));
+  scratchDirs.push(root);
+
+  mkdirSync(join(root, '.husky'), { recursive: true });
+  copyFileSync(join(REPO_ROOT, HOOK), join(root, HOOK));
+  writeFileSync(join(root, 'package-lock.json'), '{"lockfileVersion":3}\n');
+  writeFileSync(join(root, 'README.md'), 'seed\n');
+
+  const stubDir = join(root, 'stub');
+  mkdirSync(stubDir, { recursive: true });
+
+  // Stub npm: record every invocation, and let `ci` fail on demand.
+  writeFileSync(
+    join(stubDir, 'npm'),
+    [
+      '#!/usr/bin/env sh',
+      `echo "npm $*" >> "${join(root, 'npm-calls.log')}"`,
+      `if [ "$1" = "ci" ]; then exit ${String(ciExit)}; fi`,
+      'exit 0',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+
+  if (realGit) {
+    // One case exercises real git, proving `git diff HEAD@{1} HEAD --name-only`
+    // actually reports what the branching assumes. It costs five subprocesses,
+    // so it is deliberately the only one that pays for them — see the note on
+    // its timeout.
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'test');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-q', '-m', 'seed');
+    writeFileSync(join(root, touchLockfile ? 'package-lock.json' : 'README.md'), 'changed\n');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-q', '-m', 'second');
+    return root;
+  }
+
+  // Everything else stubs git too. What is under test is how the hook BRANCHES
+  // on the changed-file list, not git's ability to produce one — and building a
+  // throwaway repo per case cost five subprocesses each, enough to push this
+  // file and its neighbours past vitest's 5s default and make the gate flaky.
+  writeFileSync(
+    join(stubDir, 'git'),
+    ['#!/usr/bin/env sh', `echo "${touchLockfile ? 'package-lock.json' : 'README.md'}"`, ''].join(
+      '\n',
+    ),
+    { mode: 0o755 },
+  );
+
+  return root;
+}
+
+/**
+ * Run the real hook inside a fixture.
+ * @param root - Fixture directory.
+ * @returns The npm invocations it made, plus combined output.
+ */
+function runHook(root: string): { calls: string[]; output: string } {
+  // `sh`, not `bash`: husky's `.husky/_/h` opens with `#!/usr/bin/env sh` and
+  // the hook files carry no shebang, so `sh` is what production uses. Running
+  // it under bash here would let a bashism pass this suite and break the hook
+  // for everyone (`pre-push-hook.test.ts` runs its hook under `sh` for the
+  // same reason).
+  const run = spawnSync('sh', [HOOK], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...GIT_ENV, PATH: `${join(root, 'stub')}:${process.env['PATH'] ?? ''}` },
+  });
+  const log = join(root, 'npm-calls.log');
+  const calls = existsSync(log)
+    ? readFileSync(log, 'utf8')
+        .split('\n')
+        .filter((line) => line !== '')
+    : [];
+  return { calls, output: [run.stdout, run.stderr].join('') };
+}
+
+describe('post-merge install hook (#161)', () => {
+  it('installs with `npm ci`, which never rewrites the lockfile', () => {
+    const { calls } = runHook(fixture({ touchLockfile: true }));
+
+    expect(calls).toContain('npm ci');
+    // The whole point: `npm install` re-resolves and rewrites package-lock.json.
+    expect(calls).not.toContain('npm install');
+  });
+
+  it('falls back to `npm install` when ci fails, rather than leaving no install', () => {
+    // `npm ci` deletes node_modules before installing, so a failure part-way
+    // leaves nothing. A rewritten lockfile beats an unusable checkout.
+    const { calls, output } = runHook(fixture({ touchLockfile: true, ciExit: 1 }));
+
+    // Order matters: `install` AFTER a failed `ci` is a fallback; the other way
+    // round, or unconditionally, is just a slow double install.
+    expect(calls[0]).toBe('npm ci');
+    expect(calls).toContain('npm install');
+    expect(calls.indexOf('npm install')).toBeGreaterThan(calls.indexOf('npm ci'));
+    expect(output).toContain('falling back');
+  });
+
+  it('does nothing at all when the merge did not touch the lockfile', () => {
+    // Control: without this, a hook that reinstalled unconditionally would
+    // satisfy both cases above while making every merge slow.
+    const { calls } = runHook(fixture({ touchLockfile: false }));
+
+    expect(calls).toStrictEqual([]);
+  });
+
+  it('still runs the audit after a successful install', () => {
+    const { calls } = runHook(fixture({ touchLockfile: true }));
+
+    expect(calls.some((call) => call.startsWith('npm audit'))).toBe(true);
+  });
+
+  it('reads the changed-file list from real git, not just a stub', () => {
+    // The other cases stub git so the suite stays fast; this one proves the
+    // command the hook actually runs — `git diff HEAD@{1} HEAD --name-only` —
+    // reports the lockfile after a commit that touched it. Five git
+    // subprocesses, so it gets a timeout that reflects that rather than
+    // riding on vitest's 5s default and flaking under load.
+    const { calls } = runHook(fixture({ touchLockfile: true, realGit: true }));
+
+    expect(calls).toContain('npm ci');
+  }, 20_000);
+
+  it('still runs the audit when the fallback fired', () => {
+    // The audit sits outside the install branch on purpose. A restructure that
+    // pulled it inside would silently stop auditing exactly the runs that had
+    // trouble installing.
+    const { calls } = runHook(fixture({ touchLockfile: true, ciExit: 1 }));
+
+    expect(calls.some((call) => call.startsWith('npm audit'))).toBe(true);
+  });
+});

--- a/ui/e2e/generated/support-initiate-chat.spec.ts
+++ b/ui/e2e/generated/support-initiate-chat.spec.ts
@@ -17,16 +17,11 @@ test.describe('Operator starts a chat with a visitor from the presence list', ()
     // Step 2: Locate heading "Visitors on site" (initiate-chat.uc.yaml:1)
     await expect(page.getByRole('heading', { name: 'Visitors on site' })).toBeVisible();
 
-    // Step 3: Note Each visitor row is a button whose accessible name is
-"Start a chat with visitor <id>"; activating it emits chat:initiate for
-that visitor. The per-visitor name and the socket round trip are covered
-by the cross-ends journey suite.
- (initiate-chat.uc.yaml:2)
+    // Step 3: Note Each visitor row is a button whose accessible name is "Start a chat with visitor <id>"; activating it emits chat:initiate for that visitor. The per-visitor name and the socket round trip are covered by the cross-ends journey suite. (initiate-chat.uc.yaml:2)
     // Note: Each visitor row is a button whose accessible name is
-"Start a chat with visitor <id>"; activating it emits chat:initiate for
-that visitor. The per-visitor name and the socket round trip are covered
-by the cross-ends journey suite.
-
+    // "Start a chat with visitor <id>"; activating it emits chat:initiate for
+    // that visitor. The per-visitor name and the socket round trip are covered
+    // by the cross-ends journey suite.
 
   });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
     "react-i18next": "17.0.4",
     "react-router-dom": "7.18.2",
     "socket.io-client": "4.8.3",
-    "zod": "4.3.6",
+    "zod": "4.4.3",
     "zustand": "5.0.12"
   },
   "devDependencies": {

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*", "vite.config.ts", "vitest.config.ts", "playwright.config.ts", "e2e/**/*"],
-  "exclude": ["node_modules", "dist", "coverage", "e2e/generated"]
+  "exclude": ["node_modules", "dist", "coverage"]
 }


### PR DESCRIPTION
Promotes develop to main for **v0.4.0** — a minor release: one tooling feature and two dependency/tooling fixes since v0.3.1.

## What's shipping

- #164 — **`@afixt/usecase-runner` 2.0.1**, dropping the scoped zod override that left npm two defensible resolutions for `chromium-bidi`'s zod and made the lockfile non-idempotent (closes #163; cause of #161). All 39 use cases validate under 2.x's stricter parser; generated Playwright specs regenerated.
- #166 — **zod 4.4.3 everywhere** so usecase-runner no longer runs below its declared minimum, plus `shared/tests/dependency-ranges.test.ts`, a semver-based detector for override-induced range violations that `npm ls` structurally cannot report (closes #165). The two `chromium-bidi` major jumps are accepted in writing in its allowlist.
- #162 — **post-merge hook installs with `npm ci`**, so it stops rewriting the lockfile on every lockfile-moving merge (refs #161).
- #167 — version bump + CHANGELOG entry.

No user-facing behavior changes; no breaking changes; no schema or API changes.

Compare: https://github.com/AFixt/livechat/compare/v0.3.1...develop