### PR TITLE
fix(api): fail loudly, or skip visibly, when the integration stack is down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,9 @@ jobs:
         with:
           args: --no-progress '**/*.md'
 
-      # The integration tests return early on a null harness, so without a
-      # database they pass while asserting nothing — a green check that means
-      # nothing. Bring the real stack up and set REQUIRE_DB=1 below so an
-      # unreachable stack fails loudly instead of silently skipping.
+      # An unreachable integration stack fails the suite by default (#170) —
+      # REQUIRE_DB is gone; failing loudly no longer needs opting into. Bring
+      # the real stack up so the integration tests actually run.
       - name: Start integration infrastructure
         run: |
           set -euo pipefail
@@ -70,8 +69,6 @@ jobs:
           docker exec livechat-redis redis-cli ping
 
       - run: npm run check:all
-        env:
-          REQUIRE_DB: "1"
 
   usecases-diff-gate:
     runs-on: ubuntu-latest

--- a/api/tests/availability-gate.test.ts
+++ b/api/tests/availability-gate.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guard for the guard: proves an unreachable integration stack can never read
+ * as a pass (#170).
+ *
+ * Before this existed, every integration test opened with
+ * `if (harness === null) return;` — with MySQL/Redis down the whole suite
+ * reported ✓ passed in 0–1 ms, indistinguishable from a real run. The fix
+ * (`tests/integration/setup.ts`) probes the stack once at module load: down
+ * means the file fails loudly, unless `INTEGRATION_DB_OPTIONAL=1` explicitly
+ * requested running without it, in which case `describe.skipIf` reports the
+ * tests as *skipped*.
+ *
+ * A gate like that is only trustworthy if it is exercised in the state it
+ * exists to catch (cf. `shared/tests/generated-specs-gate.test.ts`), so this
+ * runs a real integration file in a child vitest pointed at ports where
+ * nothing listens, and asserts both arms: failure by default, visible skips
+ * under the opt-out — and never a pass.
+ */
+/* eslint-disable n/no-sync */
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const API_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The child target: the smallest integration file, so each spawn pays for one
+ * app import, not the suite.
+ */
+const TARGET = 'tests/integration/cors.test.ts';
+
+/**
+ * Run TARGET in a child vitest against ports where nothing listens.
+ * @param extraEnv - Env overrides for the child (the opt-out flag).
+ * @returns The completed child process result.
+ */
+function runAgainstDeadStack(extraEnv: Record<string, string>): SpawnSyncReturns<string> {
+  return spawnSync('npx', ['vitest', 'run', TARGET], {
+    cwd: API_ROOT,
+    encoding: 'utf8',
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      // TCP port 1 on localhost: connection refused immediately, nothing to
+      // wait out. Chosen over a fake host so DNS cannot slow the probe down.
+      DB_HOST: '127.0.0.1',
+      DB_PORT: '1',
+      REDIS_HOST: '127.0.0.1',
+      REDIS_PORT: '1',
+      ...extraEnv,
+    },
+  });
+}
+
+describe('integration availability gate (#170)', () => {
+  it('fails loudly by default when the stack is unreachable', () => {
+    const result = runAgainstDeadStack({ INTEGRATION_DB_OPTIONAL: '' });
+    const output = result.stdout + result.stderr;
+
+    expect(result.status, `child vitest passed against a dead stack:\n${output}`).not.toBe(0);
+    // The failure must carry operator guidance, not a bare connection error.
+    expect(output).toContain('Integration stack unreachable');
+    expect(output).toContain('docker compose up -d mysql redis');
+    // And it must be a failure, never a green run that asserted nothing.
+    expect(output).not.toMatch(/\d+ passed/);
+  }, 120_000);
+
+  it('reports tests as skipped — never passed — under INTEGRATION_DB_OPTIONAL=1', () => {
+    const result = runAgainstDeadStack({ INTEGRATION_DB_OPTIONAL: '1' });
+    const output = result.stdout + result.stderr;
+
+    expect(result.status, `opt-out run did not exit cleanly:\n${output}`).toBe(0);
+    expect(output).toMatch(/skipped/);
+    expect(output).not.toMatch(/\d+ passed/);
+  }, 120_000);
+});

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Role } from '@livechat/shared';
 
@@ -80,7 +80,7 @@ async function login(email: string, password: string): Promise<string> {
   return res.body.data.accessToken as string;
 }
 
-describe('admin routes (integration)', () => {
+describe.skipIf(!integrationDbUp)('admin routes (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) {

--- a/api/tests/integration/audit-logging.test.ts
+++ b/api/tests/integration/audit-logging.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, Tenant, User } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Role } from '@livechat/shared';
 
@@ -98,7 +98,7 @@ function auditPath(row: AuditLog): string {
   return typeof meta.path === 'string' ? meta.path : '';
 }
 
-describe('audit logging (integration)', () => {
+describe.skipIf(!integrationDbUp)('audit logging (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) {

--- a/api/tests/integration/auth-flow.test.ts
+++ b/api/tests/integration/auth-flow.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Invitation, Tenant, User } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -47,7 +47,7 @@ async function seedTenantAndAdmin(): Promise<{
   return { tenantId: tenant.id, adminEmail, adminPassword };
 }
 
-describe('auth flow (integration)', () => {
+describe.skipIf(!integrationDbUp)('auth flow (integration)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/auth-lifecycle.test.ts
+++ b/api/tests/integration/auth-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, Invitation, Tenant, User, UserSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Role, UserStatus } from '@livechat/shared';
 import type { Express } from 'express';
@@ -74,7 +74,7 @@ async function loginAsSuperAdmin(app: Express, email: string): Promise<string> {
   return res.body.data.accessToken as string;
 }
 
-describe('auth lifecycle (integration)', () => {
+describe.skipIf(!integrationDbUp)('auth lifecycle (integration)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Chat, Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 async function seedTenantAndStaff(
   tenantSlug: string,
@@ -86,7 +86,7 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
   });
 }
 
-describe('chat flow (integration)', () => {
+describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Chat, ChatMessage, Tenant, User, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { ChatStatus } from '@livechat/shared';
 import type { Express } from 'express';
@@ -200,7 +200,7 @@ async function seedMessage(chatId: string, body: string, deliveredAt: Date): Pro
   });
 }
 
-describe('chat routes (integration)', () => {
+describe.skipIf(!integrationDbUp)('chat routes (integration)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/cluster-availability.test.ts
+++ b/api/tests/integration/cluster-availability.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { createPresenceService } from '../../src/services/presence-service.js';
 
-import { probeHarness, testEnv } from './setup.js';
+import { integrationDbUp, probeHarness, testEnv } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -16,87 +16,90 @@ const TENANT_B = '22222222-2222-4222-8222-222222222222';
  * processes. That is exactly the condition #125 is about: each node sees only
  * its own Socket.IO room membership, but they share Redis.
  */
-describe('availability fan-out is cluster-wide, not per-node (#125)', () => {
-  let harness: Harness;
-  // Undefined when the harness bails (no infrastructure), which afterAll
-  // must tolerate rather than throwing over the real skip reason.
-  let redisA: Redis | undefined;
-  let redisB: Redis | undefined;
+describe.skipIf(!integrationDbUp)(
+  'availability fan-out is cluster-wide, not per-node (#125)',
+  () => {
+    let harness: Harness;
+    // Undefined when the harness bails (no infrastructure), which afterAll
+    // must tolerate rather than throwing over the real skip reason.
+    let redisA: Redis | undefined;
+    let redisB: Redis | undefined;
 
-  beforeAll(async () => {
-    harness = await probeHarness();
-    if (harness === null) {
-      console.warn('[integration] MySQL or Redis not reachable — skipping');
-      return;
-    }
-    const env = testEnv();
-    redisA = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
-    redisB = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
-    await redisA.del('presence:visitor-tenants');
-  }, 60_000);
+    beforeAll(async () => {
+      harness = await probeHarness();
+      if (harness === null) {
+        console.warn('[integration] MySQL or Redis not reachable — skipping');
+        return;
+      }
+      const env = testEnv();
+      redisA = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
+      redisB = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
+      await redisA.del('presence:visitor-tenants');
+    }, 60_000);
 
-  afterAll(async () => {
-    await redisA?.quit().catch(() => undefined);
-    await redisB?.quit().catch(() => undefined);
-    if (harness !== null) await harness.cleanup();
-  });
+    afterAll(async () => {
+      await redisA?.quit().catch(() => undefined);
+      await redisB?.quit().catch(() => undefined);
+      if (harness !== null) await harness.cleanup();
+    });
 
-  test('a visitor on another node is still enumerated', async () => {
-    if (harness === null) return;
-    if (redisA === undefined || redisB === undefined) return;
-    const nodeA = createPresenceService({ redis: redisA });
-    const nodeB = createPresenceService({ redis: redisB });
+    test('a visitor on another node is still enumerated', async () => {
+      if (harness === null) return;
+      if (redisA === undefined || redisB === undefined) return;
+      const nodeA = createPresenceService({ redis: redisA });
+      const nodeB = createPresenceService({ redis: redisB });
 
-    await nodeA.markVisitorPresent(TENANT_A, 'visitor-on-a', { url: 'https://a.example' });
-    await nodeB.markVisitorPresent(TENANT_B, 'visitor-on-b', { url: 'https://b.example' });
+      await nodeA.markVisitorPresent(TENANT_A, 'visitor-on-a', { url: 'https://a.example' });
+      await nodeB.markVisitorPresent(TENANT_B, 'visitor-on-b', { url: 'https://b.example' });
 
-    // Either node must see both tenants — this is what makes the global-staff
-    // live push reach a visitor connected to a different process.
-    expect((await nodeA.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
-    expect((await nodeB.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
-  });
+      // Either node must see both tenants — this is what makes the global-staff
+      // live push reach a visitor connected to a different process.
+      expect((await nodeA.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
+      expect((await nodeB.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
+    });
 
-  test('Socket.IO room membership — the old source — cannot see the other node', async () => {
-    if (harness === null) return;
-    // Demonstrates the defect rather than only asserting the fix. Two Socket.IO
-    // servers, each with its own adapter: a room joined on one is invisible to
-    // the other, which is why `adapter.rooms` was the wrong source.
-    // Constructed without an http server: these never listen, so there is
-    // nothing to close afterwards — only their adapters are under test.
-    const nodeA = new Server();
-    const nodeB = new Server();
-    await nodeB.of('/visitor').adapter.addAll('socket-on-b', new Set([`tenant:${TENANT_B}`]));
+    test('Socket.IO room membership — the old source — cannot see the other node', async () => {
+      if (harness === null) return;
+      // Demonstrates the defect rather than only asserting the fix. Two Socket.IO
+      // servers, each with its own adapter: a room joined on one is invisible to
+      // the other, which is why `adapter.rooms` was the wrong source.
+      // Constructed without an http server: these never listen, so there is
+      // nothing to close afterwards — only their adapters are under test.
+      const nodeA = new Server();
+      const nodeB = new Server();
+      await nodeB.of('/visitor').adapter.addAll('socket-on-b', new Set([`tenant:${TENANT_B}`]));
 
-    const roomsSeenByA = [...nodeA.of('/visitor').adapter.rooms.keys()];
-    expect(roomsSeenByA).not.toContain(`tenant:${TENANT_B}`);
-    expect([...nodeB.of('/visitor').adapter.rooms.keys()]).toContain(`tenant:${TENANT_B}`);
-  });
+      const roomsSeenByA = [...nodeA.of('/visitor').adapter.rooms.keys()];
+      expect(roomsSeenByA).not.toContain(`tenant:${TENANT_B}`);
+      expect([...nodeB.of('/visitor').adapter.rooms.keys()]).toContain(`tenant:${TENANT_B}`);
+    });
 
-  test('a tenant whose visitors have all gone is pruned from the index', async () => {
-    if (harness === null) return;
-    if (redisA === undefined) return;
-    const nodeA = createPresenceService({ redis: redisA });
-    // Its own tenant, so the visitors left behind by the test above cannot keep
-    // this one's presence hash alive.
-    const tenantC = '33333333-3333-4333-8333-333333333333';
+    test('a tenant whose visitors have all gone is pruned from the index', async () => {
+      if (harness === null) return;
+      if (redisA === undefined) return;
+      const nodeA = createPresenceService({ redis: redisA });
+      // Its own tenant, so the visitors left behind by the test above cannot keep
+      // this one's presence hash alive.
+      const tenantC = '33333333-3333-4333-8333-333333333333';
 
-    await nodeA.markVisitorPresent(tenantC, 'only-visitor', { url: 'https://c.example' });
-    expect(await nodeA.tenantsWithVisitors()).toContain(tenantC);
+      await nodeA.markVisitorPresent(tenantC, 'only-visitor', { url: 'https://c.example' });
+      expect(await nodeA.tenantsWithVisitors()).toContain(tenantC);
 
-    // Removing the last visitor empties the hash, and Redis drops an empty
-    // hash — so the tenant must fall out of the index rather than widening the
-    // fan-out it exists to bound.
-    await nodeA.removeVisitor(tenantC, 'only-visitor');
-    expect(await nodeA.tenantsWithVisitors()).not.toContain(tenantC);
-    // Pruned from the set itself, not merely filtered on the way out.
-    expect(await redisA.smembers('presence:visitor-tenants')).not.toContain(tenantC);
-  });
+      // Removing the last visitor empties the hash, and Redis drops an empty
+      // hash — so the tenant must fall out of the index rather than widening the
+      // fan-out it exists to bound.
+      await nodeA.removeVisitor(tenantC, 'only-visitor');
+      expect(await nodeA.tenantsWithVisitors()).not.toContain(tenantC);
+      // Pruned from the set itself, not merely filtered on the way out.
+      expect(await redisA.smembers('presence:visitor-tenants')).not.toContain(tenantC);
+    });
 
-  test('returns nothing when no visitor is present anywhere', async () => {
-    if (harness === null) return;
-    if (redisA === undefined) return;
-    const nodeA = createPresenceService({ redis: redisA });
-    await redisA.del('presence:visitor-tenants');
-    expect(await nodeA.tenantsWithVisitors()).toEqual([]);
-  });
-});
+    test('returns nothing when no visitor is present anywhere', async () => {
+      if (harness === null) return;
+      if (redisA === undefined) return;
+      const nodeA = createPresenceService({ redis: redisA });
+      await redisA.del('presence:visitor-tenants');
+      expect(await nodeA.tenantsWithVisitors()).toEqual([]);
+    });
+  },
+);

--- a/api/tests/integration/cors.test.ts
+++ b/api/tests/integration/cors.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { clearOriginCache } from '../../src/middlewares/cors.js';
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -30,7 +30,7 @@ async function seedTenant(slug: string, allowedOrigins: string[] | null): Promis
   return tenant.id;
 }
 
-describe('per-tenant CORS (#74)', () => {
+describe.skipIf(!integrationDbUp)('per-tenant CORS (#74)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/csrf.test.ts
+++ b/api/tests/integration/csrf.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -32,7 +32,7 @@ async function bootstrapVisitor(
   return { cookie, csrfToken: res.body.data.csrfToken as string };
 }
 
-describe('CSRF protection on visitor write routes (#77)', () => {
+describe.skipIf(!integrationDbUp)('CSRF protection on visitor write routes (#77)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/data-retention.test.ts
+++ b/api/tests/integration/data-retention.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { Chat, ChatMessage, Tenant, VisitorSession } from '../../src/models/index.js';
 import { createDataRetentionService } from '../../src/services/data-retention-service.js';
 
-import { probeHarness, type TestHarness } from './setup.js';
+import { integrationDbUp, probeHarness, type TestHarness } from './setup.js';
 
 const logger = pino({ level: 'silent' });
 
@@ -74,7 +74,7 @@ async function seedSession(
   return session.id;
 }
 
-describe('data retention service', () => {
+describe.skipIf(!integrationDbUp)('data retention service', () => {
   let harness: TestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/data-subject-request.test.ts
+++ b/api/tests/integration/data-subject-request.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/models/index.js';
 import { createServices } from '../../src/services/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Env } from '../../src/config/env.js';
 import type { Express } from 'express';
@@ -24,7 +24,7 @@ interface Subject {
   chatId: string;
 }
 
-describe('data-subject access and erasure (#121)', () => {
+describe.skipIf(!integrationDbUp)('data-subject access and erasure (#121)', () => {
   let harness: Harness;
   let app: Express;
   /** An app configured to hard-delete rather than anonymize. */

--- a/api/tests/integration/embed-hardening.test.ts
+++ b/api/tests/integration/embed-hardening.test.ts
@@ -4,9 +4,9 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness, type TestHarness } from './setup.js';
+import { integrationDbUp, probeHarness, type TestHarness } from './setup.js';
 
-describe('embed hardening (integration)', () => {
+describe.skipIf(!integrationDbUp)('embed hardening (integration)', () => {
   let harness: TestHarness | null = null;
   let tenantId = '';
 

--- a/api/tests/integration/privacy-api.test.ts
+++ b/api/tests/integration/privacy-api.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, ConsentRecord, Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -36,7 +36,7 @@ function cookiesOf(res: request.Response): string[] {
   return raw ?? [];
 }
 
-describe('privacy API (integration)', () => {
+describe.skipIf(!integrationDbUp)('privacy API (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) console.warn('[integration] MySQL or Redis not reachable — skipping');

--- a/api/tests/integration/reconnect.test.ts
+++ b/api/tests/integration/reconnect.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { ChatMessage, Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 /**
  * Sort a copy of a body list. `delivered_at` is whole-second precision, so
@@ -143,7 +143,7 @@ async function visitorTranscriptBodies(baseUrl: string, cookie: string): Promise
   return (res.body.data.messages as { body: string }[]).map((m) => m.body);
 }
 
-describe('socket reconnect (integration, #69)', () => {
+describe.skipIf(!integrationDbUp)('socket reconnect (integration, #69)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/schema-parity.test.ts
+++ b/api/tests/integration/schema-parity.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { resetSchemaFromMigrations } from '../../src/db/migrator.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Sequelize } from 'sequelize';
 
@@ -74,7 +74,7 @@ async function introspect(sequelize: Sequelize): Promise<Record<string, TableSha
   return out;
 }
 
-describe('schema parity: migrations vs models (integration)', () => {
+describe.skipIf(!integrationDbUp)('schema parity: migrations vs models (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) {

--- a/api/tests/integration/security-regression.test.ts
+++ b/api/tests/integration/security-regression.test.ts
@@ -5,7 +5,7 @@ import { createApp } from '../../src/app.js';
 import { computeCsrfToken } from '../../src/middlewares/csrf.js';
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness, type TestHarness } from './setup.js';
+import { integrationDbUp, probeHarness, type TestHarness } from './setup.js';
 
 import type { Express } from 'express';
 
@@ -39,216 +39,219 @@ function expectNoLeak(body: unknown): void {
   expect(serialized.toLowerCase()).not.toContain('econnrefused');
 }
 
-describe('security regression: input validation + storage (integration)', () => {
-  let harness: TestHarness | null = null;
-  let prodApp: Express | null = null;
+describe.skipIf(!integrationDbUp)(
+  'security regression: input validation + storage (integration)',
+  () => {
+    let harness: TestHarness | null = null;
+    let prodApp: Express | null = null;
 
-  beforeAll(async () => {
-    harness = await probeHarness();
-    if (harness === null) {
-      console.warn('[integration] MySQL or Redis not reachable — skipping');
-      return;
-    }
-    await Tenant.create({
-      name: 'Sec Regression Tenant',
-      slug: TENANT_SLUG,
-      status: 'active',
-      domain: null,
-      expiresAt: null,
-      settings: null,
-    });
-    // A second app whose env reports production, so we can assert the visitor
-    // cookie gains the `Secure` flag there. It shares the live DB/Redis/services.
-    prodApp = createApp({
-      env: { ...harness.env, NODE_ENV: 'production', isProduction: true, isTest: false },
-      logger: harness.logger,
-      redis: harness.redis,
-      services: harness.services,
-      skipRateLimit: true,
-    });
-  }, 60_000);
+    beforeAll(async () => {
+      harness = await probeHarness();
+      if (harness === null) {
+        console.warn('[integration] MySQL or Redis not reachable — skipping');
+        return;
+      }
+      await Tenant.create({
+        name: 'Sec Regression Tenant',
+        slug: TENANT_SLUG,
+        status: 'active',
+        domain: null,
+        expiresAt: null,
+        settings: null,
+      });
+      // A second app whose env reports production, so we can assert the visitor
+      // cookie gains the `Secure` flag there. It shares the live DB/Redis/services.
+      prodApp = createApp({
+        env: { ...harness.env, NODE_ENV: 'production', isProduction: true, isTest: false },
+        logger: harness.logger,
+        redis: harness.redis,
+        services: harness.services,
+        skipRateLimit: true,
+      });
+    }, 60_000);
 
-  afterAll(async () => {
-    if (harness !== null) await harness.cleanup();
-  });
-
-  describe('zod validation rejects bad input with 400, never 500', () => {
-    test('auth/register with wrong field types is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/register')
-        .send({ email: 123, password: [], firstName: null, lastName: 7, token: {} });
-      expect(res.status).toBe(400);
-      expect(res.body.message).toBe('Validation failed');
-      expectNoLeak(res.body);
+    afterAll(async () => {
+      if (harness !== null) await harness.cleanup();
     });
 
-    test('auth/login with a missing password is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .send({ email: 'someone@example.com' });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
+    describe('zod validation rejects bad input with 400, never 500', () => {
+      test('auth/register with wrong field types is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/register')
+          .send({ email: 123, password: [], firstName: null, lastName: 7, token: {} });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toBe('Validation failed');
+        expectNoLeak(res.body);
+      });
+
+      test('auth/login with a missing password is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .send({ email: 'someone@example.com' });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('auth/login with an SQL-injection-ish email is rejected by validation (400)', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .send({ email: "' OR 1=1 --", password: "'; DROP TABLE users; --" });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('visitor/session with a missing tenantKey is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app).post('/api/v1/visitor/session').send({});
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('visitor/session with a wrong-typed tenantKey is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: 12345 });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('visitor/chats with an invalid body is a 400 (before the cookie check)', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/chats')
+          .send({ customerName: '', body: '' });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('an injection string in tenantKey is treated as a literal slug — clean 400, no SQL error', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: "'; DROP TABLE tenants; --" });
+        // Parameterized lookup finds no such slug: a clean 4xx, never a 500.
+        expect(res.status).toBe(400);
+        expect(res.status).not.toBe(500);
+        expectNoLeak(res.body);
+      });
     });
 
-    test('auth/login with an SQL-injection-ish email is rejected by validation (400)', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .send({ email: "' OR 1=1 --", password: "'; DROP TABLE users; --" });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
+    describe('malformed / oversized request bodies', () => {
+      test('malformed JSON on auth/login is a 400, not a 500', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .set('Content-Type', 'application/json')
+          .send('{"email": "a@b.co", ');
+        expect(res.status).toBe(400);
+        expect(res.body).toEqual({ success: false, message: 'Malformed request body' });
+      });
+
+      test('a body beyond the 1mb json limit is a 413, not a 500', async () => {
+        if (harness === null) return;
+        const oversized = JSON.stringify({ tenantKey: 'x'.repeat(1_200_000) });
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .set('Content-Type', 'application/json')
+          .send(oversized);
+        expect(res.status).toBe(413);
+        expect(res.body).toEqual({ success: false, message: 'Request payload too large' });
+      });
     });
 
-    test('visitor/session with a missing tenantKey is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app).post('/api/v1/visitor/session').send({});
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
+    describe('visitor session cookie flags + forgery', () => {
+      test('in dev the visitor cookie is HttpOnly + SameSite=Lax (no Secure)', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: TENANT_SLUG });
+        expect(res.status).toBe(201);
+        const cookie = visitorSetCookie(res);
+        expect(cookie).toBeDefined();
+        expect(cookie).toMatch(/HttpOnly/i);
+        // Local dev is same-origin over plain HTTP: SameSite=None would require
+        // Secure, and a Secure cookie is dropped on localhost HTTP (#75).
+        expect(cookie).toMatch(/SameSite=Lax/i);
+        expect(cookie).not.toMatch(/Secure/i);
+      });
+
+      test('in production the visitor cookie is SameSite=None; Secure; Partitioned', async () => {
+        if (harness === null || prodApp === null) return;
+        const res = await request(prodApp)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: TENANT_SLUG });
+        expect(res.status).toBe(201);
+        const cookie = visitorSetCookie(res);
+        expect(cookie).toBeDefined();
+        expect(cookie).toMatch(/HttpOnly/i);
+        // The widget is embedded cross-site, so the cookie is only ever sent
+        // with SameSite=None — which browsers reject without Secure (#75).
+        expect(cookie).toMatch(/SameSite=None/i);
+        expect(cookie).toMatch(/Secure/i);
+        expect(cookie).toMatch(/Partitioned/i);
+        expect(cookie).not.toMatch(/SameSite=Lax/i);
+      });
+
+      test('auth/login does not set any session cookie (JWTs are returned in the body)', async () => {
+        if (harness === null) return;
+        // Wrong credentials still exercise the response path; we only assert the
+        // absence of a Set-Cookie so a future accidental cookie is caught.
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .send({ email: 'nobody@example.com', password: 'whatever-123' });
+        expect(res.headers['set-cookie']).toBeUndefined();
+      });
+
+      test('a valid visitor cookie is accepted, a forged one is rejected 401', async () => {
+        if (harness === null) return;
+        const created = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          // x-geo-country: US (trusted edge header) → opt-out jurisdiction → the consent gate permits presence
+          // and a tracked `visitor_sessions` row is created (#53). The heartbeat
+          // positive control below resolves the cookie to that row, so without a
+          // geo hint the jurisdiction resolves to UNKNOWN, no row exists, and the
+          // control 401s for a reason that has nothing to do with cookie forgery.
+          .set('x-geo-country', 'US')
+          .send({ tenantKey: TENANT_SLUG });
+        expect(created.status).toBe(201);
+        const rawCookie = visitorSetCookie(created)?.split(';')[0] ?? '';
+        const value = rawCookie.replace('livechat_visitor=', '');
+        expect(value).toContain('.');
+
+        // Positive control: the genuine cookie authenticates the heartbeat.
+        // The heartbeat is a CSRF-protected write (#77), so the token issued
+        // alongside the cookie has to be echoed — this asserts cookie validity,
+        // not CSRF behavior, which `csrf.test.ts` covers.
+        const ok = await request(harness.app)
+          .post('/api/v1/visitor/heartbeat')
+          .set('Cookie', rawCookie)
+          .set('X-XSRF-TOKEN', created.body.data.csrfToken as string)
+          .send({});
+        expect(ok.status).toBe(200);
+
+        // Forge it: keep the session id, corrupt the HMAC signature.
+        const [sessionId, sig] = value.split('.');
+        const forgedSig = (sig ?? '').replace(/./g, '0');
+        const forged = `livechat_visitor=${sessionId ?? ''}.${forgedSig}`;
+        // Give the forged cookie its own matching CSRF token so the CSRF layer
+        // passes and the cookie-signature check is what actually answers. Without
+        // this the request is rejected at the CSRF layer (403) and the test would
+        // no longer be exercising signature verification at all.
+        const bad = await request(harness.app)
+          .post('/api/v1/visitor/heartbeat')
+          .set('Cookie', forged)
+          .set(
+            'X-XSRF-TOKEN',
+            computeCsrfToken(forged.replace('livechat_visitor=', ''), harness.env.COOKIE_SECRET),
+          )
+          .send({});
+        expect(bad.status).toBe(401);
+        expectNoLeak(bad.body);
+      });
     });
-
-    test('visitor/session with a wrong-typed tenantKey is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: 12345 });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
-    });
-
-    test('visitor/chats with an invalid body is a 400 (before the cookie check)', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/chats')
-        .send({ customerName: '', body: '' });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
-    });
-
-    test('an injection string in tenantKey is treated as a literal slug — clean 400, no SQL error', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: "'; DROP TABLE tenants; --" });
-      // Parameterized lookup finds no such slug: a clean 4xx, never a 500.
-      expect(res.status).toBe(400);
-      expect(res.status).not.toBe(500);
-      expectNoLeak(res.body);
-    });
-  });
-
-  describe('malformed / oversized request bodies', () => {
-    test('malformed JSON on auth/login is a 400, not a 500', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .set('Content-Type', 'application/json')
-        .send('{"email": "a@b.co", ');
-      expect(res.status).toBe(400);
-      expect(res.body).toEqual({ success: false, message: 'Malformed request body' });
-    });
-
-    test('a body beyond the 1mb json limit is a 413, not a 500', async () => {
-      if (harness === null) return;
-      const oversized = JSON.stringify({ tenantKey: 'x'.repeat(1_200_000) });
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .set('Content-Type', 'application/json')
-        .send(oversized);
-      expect(res.status).toBe(413);
-      expect(res.body).toEqual({ success: false, message: 'Request payload too large' });
-    });
-  });
-
-  describe('visitor session cookie flags + forgery', () => {
-    test('in dev the visitor cookie is HttpOnly + SameSite=Lax (no Secure)', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: TENANT_SLUG });
-      expect(res.status).toBe(201);
-      const cookie = visitorSetCookie(res);
-      expect(cookie).toBeDefined();
-      expect(cookie).toMatch(/HttpOnly/i);
-      // Local dev is same-origin over plain HTTP: SameSite=None would require
-      // Secure, and a Secure cookie is dropped on localhost HTTP (#75).
-      expect(cookie).toMatch(/SameSite=Lax/i);
-      expect(cookie).not.toMatch(/Secure/i);
-    });
-
-    test('in production the visitor cookie is SameSite=None; Secure; Partitioned', async () => {
-      if (harness === null || prodApp === null) return;
-      const res = await request(prodApp)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: TENANT_SLUG });
-      expect(res.status).toBe(201);
-      const cookie = visitorSetCookie(res);
-      expect(cookie).toBeDefined();
-      expect(cookie).toMatch(/HttpOnly/i);
-      // The widget is embedded cross-site, so the cookie is only ever sent
-      // with SameSite=None — which browsers reject without Secure (#75).
-      expect(cookie).toMatch(/SameSite=None/i);
-      expect(cookie).toMatch(/Secure/i);
-      expect(cookie).toMatch(/Partitioned/i);
-      expect(cookie).not.toMatch(/SameSite=Lax/i);
-    });
-
-    test('auth/login does not set any session cookie (JWTs are returned in the body)', async () => {
-      if (harness === null) return;
-      // Wrong credentials still exercise the response path; we only assert the
-      // absence of a Set-Cookie so a future accidental cookie is caught.
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .send({ email: 'nobody@example.com', password: 'whatever-123' });
-      expect(res.headers['set-cookie']).toBeUndefined();
-    });
-
-    test('a valid visitor cookie is accepted, a forged one is rejected 401', async () => {
-      if (harness === null) return;
-      const created = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        // x-geo-country: US (trusted edge header) → opt-out jurisdiction → the consent gate permits presence
-        // and a tracked `visitor_sessions` row is created (#53). The heartbeat
-        // positive control below resolves the cookie to that row, so without a
-        // geo hint the jurisdiction resolves to UNKNOWN, no row exists, and the
-        // control 401s for a reason that has nothing to do with cookie forgery.
-        .set('x-geo-country', 'US')
-        .send({ tenantKey: TENANT_SLUG });
-      expect(created.status).toBe(201);
-      const rawCookie = visitorSetCookie(created)?.split(';')[0] ?? '';
-      const value = rawCookie.replace('livechat_visitor=', '');
-      expect(value).toContain('.');
-
-      // Positive control: the genuine cookie authenticates the heartbeat.
-      // The heartbeat is a CSRF-protected write (#77), so the token issued
-      // alongside the cookie has to be echoed — this asserts cookie validity,
-      // not CSRF behavior, which `csrf.test.ts` covers.
-      const ok = await request(harness.app)
-        .post('/api/v1/visitor/heartbeat')
-        .set('Cookie', rawCookie)
-        .set('X-XSRF-TOKEN', created.body.data.csrfToken as string)
-        .send({});
-      expect(ok.status).toBe(200);
-
-      // Forge it: keep the session id, corrupt the HMAC signature.
-      const [sessionId, sig] = value.split('.');
-      const forgedSig = (sig ?? '').replace(/./g, '0');
-      const forged = `livechat_visitor=${sessionId ?? ''}.${forgedSig}`;
-      // Give the forged cookie its own matching CSRF token so the CSRF layer
-      // passes and the cookie-signature check is what actually answers. Without
-      // this the request is rejected at the CSRF layer (403) and the test would
-      // no longer be exercising signature verification at all.
-      const bad = await request(harness.app)
-        .post('/api/v1/visitor/heartbeat')
-        .set('Cookie', forged)
-        .set(
-          'X-XSRF-TOKEN',
-          computeCsrfToken(forged.replace('livechat_visitor=', ''), harness.env.COOKIE_SECRET),
-        )
-        .send({});
-      expect(bad.status).toBe(401);
-      expectNoLeak(bad.body);
-    });
-  });
-});
+  },
+);

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -81,9 +81,85 @@ export interface LiveTestHarness extends TestHarness {
 }
 
 /**
- * Probe for a live MySQL + Redis matching {@link testEnv}. Returns `null` if
- * either is unreachable — integration tests use this to auto-skip.
- * @returns A harness if the stack is up, else `null`.
+ * True when running without the stack was explicitly requested. This is the
+ * only condition under which an unreachable MySQL/Redis is tolerated — and
+ * then the tests are reported as skipped, never passed.
+ * @returns Whether `INTEGRATION_DB_OPTIONAL=1` is set.
+ */
+function stackIsOptional(): boolean {
+  return process.env['INTEGRATION_DB_OPTIONAL'] === '1';
+}
+
+/**
+ * The operator-facing explanation for an unreachable stack.
+ * @param env - The env whose endpoints were probed.
+ * @param cause - The underlying connection error.
+ * @returns A message naming the endpoints, the fix, and the opt-out.
+ */
+function unreachableMessage(env: Env, cause: unknown): string {
+  return (
+    'Integration stack unreachable — ' +
+    `MySQL ${env.DB_HOST}:${String(env.DB_PORT)}/${env.DB_NAME}, ` +
+    `Redis ${env.REDIS_HOST}:${String(env.REDIS_PORT)}. ` +
+    'Start it with `docker compose up -d mysql redis`, or set ' +
+    'INTEGRATION_DB_OPTIONAL=1 to run without it (integration tests are then ' +
+    'reported as skipped — never as passed). ' +
+    `Cause: ${cause instanceof Error ? cause.message : String(cause)}`
+  );
+}
+
+/**
+ * Connect to MySQL + Redis exactly as {@link probeHarness} would, then
+ * disconnect. Used once at module load so the result is known at collection
+ * time, where `describe.skipIf` can consult it.
+ * @returns Whether both are reachable.
+ * @throws When unreachable and running without the stack was not requested —
+ * absent infrastructure must read as a failure, not a pass (#170).
+ */
+async function probeStack(): Promise<boolean> {
+  const env = testEnv();
+  const logger = pino({ level: 'silent' });
+  const sequelize = createSequelize(env, logger);
+  const redis = new Redis({
+    host: env.REDIS_HOST,
+    port: env.REDIS_PORT,
+    lazyConnect: true,
+    maxRetriesPerRequest: 0,
+    connectTimeout: 1000,
+  });
+  try {
+    await sequelize.authenticate();
+    await redis.connect();
+    return true;
+  } catch (error) {
+    if (!stackIsOptional()) throw new Error(unreachableMessage(env, error));
+    return false;
+  } finally {
+    await sequelize.close().catch(() => undefined);
+    await redis.quit().catch(() => undefined);
+  }
+}
+
+/**
+ * Whether the integration stack was reachable at module load. Every
+ * integration test file gates its top-level `describe` on this via
+ * `describe.skipIf(!integrationDbUp)`, so a missing stack shows up in the run
+ * summary as skipped tests. Before this existed, per-test `harness === null`
+ * early returns reported the same condition as *passed* — a green run that
+ * asserted nothing (#170). Resolved with top-level await so the value is
+ * final before collection; when the stack is down and
+ * `INTEGRATION_DB_OPTIONAL=1` was not set, module evaluation throws instead
+ * and the whole file fails loudly.
+ */
+export const integrationDbUp: boolean = await probeStack();
+
+/**
+ * Probe for a live MySQL + Redis matching {@link testEnv} and build an app
+ * harness against it.
+ * @returns A harness if the stack is up; `null` only when
+ * `INTEGRATION_DB_OPTIONAL=1` and the stack went away after module load.
+ * @throws When the stack is unreachable and running without it was not
+ * requested.
  */
 export async function probeHarness(): Promise<TestHarness | null> {
   const env = testEnv();
@@ -102,20 +178,10 @@ export async function probeHarness(): Promise<TestHarness | null> {
   } catch (error) {
     await sequelize.close().catch(() => undefined);
     await redis.quit().catch(() => undefined);
-    if (process.env['REQUIRE_DB'] === '1') {
-      // Every integration test returns early on a null harness, so absent
-      // infrastructure otherwise reads as a pass — a green run that asserted
-      // nothing. CI sets REQUIRE_DB=1 so that can never be mistaken for
-      // coverage; locally the null path still skips so `npm test` works
-      // without docker.
-      throw new Error(
-        'REQUIRE_DB=1 but the integration stack is unreachable — ' +
-          `MySQL ${env.DB_HOST}:${String(env.DB_PORT)}/${env.DB_NAME}, ` +
-          `Redis ${env.REDIS_HOST}:${String(env.REDIS_PORT)}. ` +
-          'Start it with `docker compose up -d mysql redis`. ' +
-          `Cause: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
+    // The module-load gate above already decided reachability; landing here
+    // means the stack died between collection and this file's beforeAll. Same
+    // rule applies: only an explicit opt-out may swallow it.
+    if (!stackIsOptional()) throw new Error(unreachableMessage(env, error));
     return null;
   }
 

--- a/api/tests/integration/socket-adapter.test.ts
+++ b/api/tests/integration/socket-adapter.test.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { createSocketRedisAdapter } from '../../src/io/adapter.js';
 
-import { testEnv } from './setup.js';
+import { integrationDbUp, testEnv } from './setup.js';
 
 const NS = '/adapter-test';
 
@@ -114,7 +114,7 @@ async function connectAndJoin(url: string, room: string): Promise<Socket> {
   return socket;
 }
 
-describe('socket.io redis adapter (integration)', () => {
+describe.skipIf(!integrationDbUp)('socket.io redis adapter (integration)', () => {
   let a: Instance | null = null;
   let b: Instance | null = null;
 

--- a/api/tests/integration/socket-authz-abuse.test.ts
+++ b/api/tests/integration/socket-authz-abuse.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 /**
  * Resolve with the first `connect_error` for a handshake that must be refused,
@@ -30,7 +30,7 @@ function expectRefused(socket: Socket, timeoutMs = 4000): Promise<Error> {
   });
 }
 
-describe('socket.io authorization abuse (integration)', () => {
+describe.skipIf(!integrationDbUp)('socket.io authorization abuse (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/staff-availability.test.ts
+++ b/api/tests/integration/staff-availability.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -157,7 +157,7 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
 
 const settle = (ms = 150): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe('staff availability (integration)', () => {
+describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/transcript.test.ts
+++ b/api/tests/integration/transcript.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Express } from 'express';
 
@@ -43,7 +43,7 @@ interface VisitorCreds {
   csrfToken: string;
 }
 
-describe('email transcript (#80)', () => {
+describe.skipIf(!integrationDbUp)('email transcript (#80)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-consent-gate.test.ts
+++ b/api/tests/integration/visitor-consent-gate.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { ConsentRecord, Tenant, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -34,7 +34,7 @@ async function sessionCount(tenantId: string): Promise<number> {
   return VisitorSession.count({ where: { tenantId } });
 }
 
-describe('visitor consent gate (integration)', () => {
+describe.skipIf(!integrationDbUp)('visitor consent gate (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) console.warn('[integration] MySQL or Redis not reachable — skipping');

--- a/api/tests/integration/visitor-gpc.test.ts
+++ b/api/tests/integration/visitor-gpc.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, ConsentRecord, Tenant, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -48,7 +48,7 @@ async function expectHonoredGpc(tenantId: string): Promise<void> {
   expect(applied).not.toBeNull();
 }
 
-describe('GPC universal opt-out (integration)', () => {
+describe.skipIf(!integrationDbUp)('GPC universal opt-out (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) console.warn('[integration] MySQL or Redis not reachable — skipping');

--- a/api/tests/integration/visitor-session-expiry.test.ts
+++ b/api/tests/integration/visitor-session-expiry.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, VisitorSession } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -58,7 +58,7 @@ async function socketRefused(baseUrl: string, cookie: string): Promise<boolean> 
   });
 }
 
-describe('visitor session expiry + revocation (#79)', () => {
+describe.skipIf(!integrationDbUp)('visitor session expiry + revocation (#79)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-session-fallback.test.ts
+++ b/api/tests/integration/visitor-session-fallback.test.ts
@@ -3,13 +3,13 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
 const TENANT_SLUG = 'fallback-t';
 
-describe('visitor session header fallback (#75)', () => {
+describe.skipIf(!integrationDbUp)('visitor session header fallback (#75)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-session-revoke.test.ts
+++ b/api/tests/integration/visitor-session-revoke.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Chat, Tenant, User, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Express } from 'express';
 
@@ -107,7 +107,7 @@ async function bootVisitor(
   return { cookie, id: created!.visitorSessionId };
 }
 
-describe('staff revocation of a visitor session (#123)', () => {
+describe.skipIf(!integrationDbUp)('staff revocation of a visitor session (#123)', () => {
   let harness: Harness;
   let app: Express;
 

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -108,7 +108,7 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
   });
 }
 
-describe('visitor namespace + visitor routes (integration)', () => {
+describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {


### PR DESCRIPTION
Closes #170.

## The defect

With MySQL/Redis down, every integration test hit its `if (harness === null) return;` guard and reported **✓ passed in 0–1 ms** — 400/400 green with zero integration coverage, indistinguishable from a real run. `test.runIf(() => harness !== null)` never helped: it evaluates at collection time, before `beforeAll` assigns the harness. Locally nothing set `REQUIRE_DB`, so the pre-push gate — this repo's primary gate — only caught the condition by accident, via the coverage threshold collapsing two steps later with an error that never mentions databases. Observed for real during the v0.4.0 release.

## The fix

- **`tests/integration/setup.ts`** probes the stack once at module load (top-level await, the same `authenticate()`/`connect()` the harness uses). Down ⇒ the file **fails** with operator guidance: the endpoints, `docker compose up -d mysql redis`, and the opt-out. `REQUIRE_DB` is deleted — failing loudly is the default now, so `ci.yml` drops the env.
- **`INTEGRATION_DB_OPTIONAL=1`** is the only way to run without the stack, and it produces **visible skips**: setup exports `integrationDbUp`, and every file's top-level `describe` is gated with `describe.skipIf(!integrationDbUp)`. The summary then reads `4 skipped` — never `4 passed`.
- **`probeHarness`** applies the same throw-unless-opted-out rule as a backstop for a stack dying between collection and `beforeAll`.
- The now-dead interior `harness === null` guards are left in place deliberately — they can no longer fire in a way that masks anything, and sweeping ~200 of them across 26 files would bury the real change in churn.

## The gate for the gate

`api/tests/availability-gate.test.ts` runs a real integration file in a child vitest pointed at dead ports and pins both arms (cf. `shared/tests/generated-specs-gate.test.ts`):

| arm | requirement |
|---|---|
| default | exit ≠ 0, output carries the operator guidance, no pass reported |
| `INTEGRATION_DB_OPTIONAL=1` | exit 0, tests reported *skipped*, no pass reported |

## Verified

- Default + dead ports: exit 1, `Integration stack unreachable — MySQL … docker compose up -d mysql redis …` ✅
- Opt-out + dead ports: exit 0, `Test Files 1 skipped / Tests 4 skipped` ✅
- Stack up: full API suite **402/402 passed (56 files)** including both new gate cases; repo-wide lint + typecheck clean; full pre-push `check:all` green on push ✅

The 26 test-file diffs are two lines each (import + `describe.skipIf`); the rest of their churn is prettier rewrapping the longer describe lines via the pre-commit hook.