### PR TITLE
test(api): key visitor-socket waits to room membership, not wall-clock

### DIFF
--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -206,6 +206,38 @@ export async function probeHarness(): Promise<TestHarness | null> {
 }
 
 /**
+ * Poll a namespace's adapter until `room` holds at least `size` members.
+ *
+ * Socket tests used to sleep a fixed 150ms after emitting a join-inducing
+ * event and hope the server handler had finished — a wall-clock race that
+ * loses on a loaded runner (`chat:accept` awaits a MySQL update before its
+ * `socket.join`, observed >4s on CI). Room membership is the exact state
+ * every room broadcast depends on, so waiting for it directly keys the test
+ * to structure instead of timing (#171 review follow-up).
+ * @param nsp - The namespace whose adapter to watch, e.g. `io.of('/staff')`.
+ * @param room - The room name, e.g. `chat:{id}` or `tenant:{id}`.
+ * @param size - Minimum member count to wait for.
+ * @param timeoutMs - Give-up threshold.
+ */
+export async function waitForRoomSize(
+  nsp: { adapter: { rooms: Map<string, Set<string>> } },
+  room: string,
+  size: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if ((nsp.adapter.rooms.get(room)?.size ?? 0) >= size) return;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `room ${room} did not reach ${String(size)} member(s) within ${String(timeoutMs)}ms`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/**
  * Probe + bind a real HTTP server on an ephemeral port, with Socket.IO
  * attached. Used by socket integration tests.
  * @returns A live harness or `null` if the stack isn't up.

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -4,7 +4,12 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
+import {
+  integrationDbUp,
+  probeLiveHarness,
+  waitForRoomSize,
+  type LiveTestHarness,
+} from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -166,7 +171,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('chat:typing fans out to the chat room and the staff namespace', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io } = harness;
     await seedTenantAndStaff('typing', 'staff@typing.example');
     const accessToken = await loginAs(baseUrl, 'staff@typing.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, csrfToken } = await initVisitor(baseUrl, 'typing');
@@ -197,7 +202,11 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
     // chat:message) is not also mirrored to the tenant room, so without this
     // the staff socket never sees it.
     staffSocket.emit('chat:accept', { chatId });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // The accept handler awaits a MySQL assignment before its socket.join, so
+    // wait on the membership itself — the state the fan-out depends on —
+    // rather than on wall-clock time.
+    await waitForRoomSize(io.of('/staff'), `chat:${chatId}`, 1);
+    await waitForRoomSize(io.of('/visitor'), `chat:${chatId}`, 1);
 
     const otherVisitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
       path: '/api/socket.io',
@@ -207,7 +216,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
     });
     await waitFor(otherVisitorSocket, 'connect');
     otherVisitorSocket.emit('chat:join', { chatId });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitForRoomSize(io.of('/visitor'), `chat:${chatId}`, 2);
 
     const staffSeesTyping = waitFor<{ chatId: string; actor: string; isTyping: boolean }>(
       staffSocket,
@@ -231,7 +240,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('visitor chat:end ends the chat as customer and notifies staff', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io } = harness;
     await seedTenantAndStaff('vend', 'staff@vend.example');
     const accessToken = await loginAs(baseUrl, 'staff@vend.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, csrfToken } = await initVisitor(baseUrl, 'vend');
@@ -259,7 +268,10 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
     await Promise.all([waitFor(staffSocket, 'connect'), waitFor(visitorSocket, 'connect')]);
     visitorSocket.emit('chat:join', { chatId });
     staffSocket.emit('chat:accept', { chatId });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // chat:ended is emitted to the staff-namespace `chat:{id}` room, so the
+    // membership itself is the precondition to wait for.
+    await waitForRoomSize(io.of('/staff'), `chat:${chatId}`, 1);
+    await waitForRoomSize(io.of('/visitor'), `chat:${chatId}`, 1);
 
     const staffSeesEnd = waitFor<{ chatId: string; endedBy: string }>(staffSocket, 'chat:ended');
     visitorSocket.emit('chat:end', { chatId });
@@ -273,8 +285,8 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('visitor:page_changed fans out to the tenant staff room', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('pagechange', 'staff@pagechange.example');
+    const { baseUrl, io } = harness;
+    const { tenantId } = await seedTenantAndStaff('pagechange', 'staff@pagechange.example');
     const accessToken = await loginAs(baseUrl, 'staff@pagechange.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'pagechange');
 
@@ -285,7 +297,9 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
       forceNew: true,
     });
     await waitFor(staffSocket, 'connect');
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // The fan-out targets the staff-namespace tenant room, which the staff
+    // connection handler joins asynchronously after the handshake completes.
+    await waitForRoomSize(io.of('/staff'), `tenant:${tenantId}`, 1);
 
     const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
       path: '/api/socket.io',
@@ -310,8 +324,8 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('visitor disconnect removes presence and notifies staff visitor:left', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('leaving', 'staff@leaving.example');
+    const { baseUrl, io } = harness;
+    const { tenantId } = await seedTenantAndStaff('leaving', 'staff@leaving.example');
     const accessToken = await loginAs(baseUrl, 'staff@leaving.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'leaving');
 
@@ -322,8 +336,14 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
       forceNew: true,
     });
     await waitFor(staffSocket, 'connect');
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Staff must be in the tenant room before the visitor connects, or the
+    // visitor:joined / visitor:left broadcasts have no one to reach.
+    await waitForRoomSize(io.of('/staff'), `tenant:${tenantId}`, 1);
 
+    // Register the visitor:joined listener before the visitor connects — the
+    // broadcast fires during the visitor's connection handler, and receiving
+    // it proves the handler ran and tenant-room delivery works end to end.
+    const staffSeesJoined = waitFor(staffSocket, 'visitor:joined');
     const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
       path: '/api/socket.io',
       auth: { cookie: visitorCookie },
@@ -331,7 +351,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
       forceNew: true,
     });
     await waitFor(visitorSocket, 'connect');
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await staffSeesJoined;
 
     const staffSeesLeft = waitFor<{ tenantId: string; visitorSessionId: string }>(
       staffSocket,


### PR DESCRIPTION
Fixes the flake observed on #171's first CI run: `timeout waiting for chat:typing` (401/402 otherwise green; passed on rerun and locally).

## Root cause

The `chat:accept` handler awaits a MySQL assignment before its `socket.join`. The test slept a fixed 150 ms after emitting the accept and then emitted `chat:typing` — on a loaded runner the join hadn't landed, the event was broadcast into a room the staff socket wasn't in, and the 3 s `waitFor` timed out. Five more sleeps in the same file carried the same race.

## Fix

- New `waitForRoomSize` helper in `tests/integration/setup.ts`: polls the namespace adapter until the room a broadcast targets actually holds the expected members — the precise state each fan-out depends on. Throws after 5 s, so a wrong room name fails loudly instead of passing vacuously.
- All six fixed sleeps in `visitor-socket.test.ts` replaced: `chat:{id}` membership after accept/join (typing and chat:end tests), `tenant:{tenantId}` membership after staff connect (presence tests).
- The `visitor:left` test also waits for staff to receive `visitor:joined` before disconnecting the visitor, proving the visitor connection handler ran and tenant-room delivery works end to end.

## Scope

Deliberately limited to the file that flaked. `chat-flow.test.ts` (5 sleeps), `staff-availability.test.ts` (`settle()` helper), and `audit-logging.test.ts` (1) carry the same pattern and can adopt the helper in a follow-up.

## Verified

- `visitor-socket.test.ts`: 5/5 consecutive green runs against the real stack
- Full API suite 402/402; lint + typecheck clean; pre-push `check:all` green on push