### PR TITLE
test(api): retire the remaining fixed sleeps in chat-flow and staff-availability

### DIFF
--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -3,9 +3,16 @@ import { io as ioClient, type Socket } from 'socket.io-client';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
+import { GLOBAL_STAFF_ROOM } from '../../src/io/rooms.js';
 import { Chat, Tenant, User } from '../../src/models/index.js';
 
-import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
+import {
+  integrationDbUp,
+  probeLiveHarness,
+  waitForRoomSize,
+  waitUntil,
+  type LiveTestHarness,
+} from './setup.js';
 
 async function seedTenantAndStaff(
   tenantSlug: string,
@@ -171,8 +178,8 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
   test('tenant isolation: tenant A staff never receives tenant B messages', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('alpha', 'a-staff@alpha.example');
+    const { baseUrl, io } = harness;
+    const { tenantId: alphaTenantId } = await seedTenantAndStaff('alpha', 'a-staff@alpha.example');
     await seedTenantAndStaff('beta', 'b-staff@beta.example');
 
     const staffAToken = await loginAs(baseUrl, 'a-staff@alpha.example', 'Staff!Password1');
@@ -199,15 +206,23 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
       forceNew: true,
     });
     await Promise.all([waitFor(staffA, 'connect'), waitFor(visitorB, 'connect')]);
+    // A fair negative needs staff A fully in its rooms first — otherwise the
+    // "no leak" assertion would pass trivially against a half-connected socket.
+    await waitForRoomSize(io.of('/staff'), `tenant:${alphaTenantId}`, 1);
     visitorB.emit('chat:join', { chatId: betaChatId });
+    await waitForRoomSize(io.of('/visitor'), `chat:${betaChatId}`, 1);
 
     let leakedToA = false;
     staffA.on('chat:message', () => {
       leakedToA = true;
     });
 
+    // Anchor the negative to the same broadcast: the room echo back to the
+    // sender is written by the very server emit that would have leaked, so
+    // once it arrives the fan-out for this message has been fully decided.
+    const echo = waitFor(visitorB, 'chat:message');
     visitorB.emit('chat:message', { chatId: betaChatId, body: 'beta message' });
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await echo;
     expect(leakedToA).toBe(false);
 
     staffA.disconnect();
@@ -216,8 +231,8 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
   test('availability drives no_support; current chat + support-initiated wiring', async () => {
     if (harness === null) return;
-    const { baseUrl, redis } = harness;
-    await seedTenantAndStaff('gamma', 'g-staff@gamma.example');
+    const { baseUrl, redis, io, services } = harness;
+    const { tenantId: gammaTenantId } = await seedTenantAndStaff('gamma', 'g-staff@gamma.example');
     const accessToken = await loginAs(baseUrl, 'g-staff@gamma.example', 'Staff!Password1');
     const { cookie: visitorCookie, sessionId, csrfToken } = await initVisitor(baseUrl, 'gamma');
 
@@ -249,8 +264,14 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
       forceNew: true,
     });
     await waitFor(staffSocket, 'connect');
+    await waitForRoomSize(io.of('/staff'), `tenant:${gammaTenantId}`, 1);
     staffSocket.emit('availability:set', { status: 'available' });
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // The POST below consults the presence record, so wait for that exact
+    // state rather than guessing how long the handler needs to write it.
+    await waitUntil(
+      async () => services.presence.anyStaffAvailable(gammaTenantId),
+      'gamma staff never became available',
+    );
     const onlineRes = await request(baseUrl)
       .post('/api/v1/visitor/chats')
       .set('cookie', `livechat_visitor=${visitorCookie}`)
@@ -277,11 +298,11 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
   test('untenanted staff watch all tenants; scoped staff stay isolated', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io } = harness;
     // A visitor in tenant "delta", an untenanted AFixt staff (tenant_id null),
     // and a staff scoped to an unrelated tenant "omega".
     await seedTenantAndStaff('delta', 'd-staff@delta.example');
-    await seedTenantAndStaff('omega', 'o-staff@omega.example');
+    const { tenantId: omegaTenantId } = await seedTenantAndStaff('omega', 'o-staff@omega.example');
     await User.create({
       email: 'global@afixt.example',
       passwordHash: 'Staff!Password1',
@@ -320,8 +341,11 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
       forceNew: true,
     });
     await Promise.all([waitFor(globalSocket, 'connect'), waitFor(omegaSocket, 'connect')]);
-    // Let the connection handlers finish joining their rooms.
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    // Wait on the rooms themselves rather than guessing how long the
+    // connection handlers need: the untenanted agent lands in the global
+    // room, the omega agent in its tenant room.
+    await waitForRoomSize(io.of('/staff'), GLOBAL_STAFF_ROOM, 1);
+    await waitForRoomSize(io.of('/staff'), `tenant:${omegaTenantId}`, 1);
 
     let leakedToOmega = false;
     omegaSocket.on('visitor:joined', () => {
@@ -341,7 +365,9 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
     const joined = await globalSeesVisitor;
     expect(joined.visitorSessionId).toBeTruthy();
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // The would-be leak is written by the same server emit that just reached
+    // the global socket, so the fan-out for it has already been decided —
+    // there is nothing further to wait for.
     expect(leakedToOmega).toBe(false);
 
     globalSocket.disconnect();
@@ -389,7 +415,9 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
     staffA.emit('chat:message', { chatId: betaChatId, body: 'hijack attempt' });
     expect((await messageErr).event).toBe('chat:message');
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Both chat:error round-trips arrived on staffA's own connection, which
+    // is FIFO: any wrongful chat:assigned from those handlers would already
+    // have been delivered before the errors. No wait needed.
     expect(assigned).toBe(false);
     const chatAfter = await Chat.findByPk(betaChatId);
     expect(chatAfter?.assignedTo).toBeNull();

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -225,13 +225,56 @@ export async function waitForRoomSize(
   size: number,
   timeoutMs = 5000,
 ): Promise<void> {
+  await waitUntil(
+    () => (nsp.adapter.rooms.get(room)?.size ?? 0) >= size,
+    `room ${room} did not reach ${String(size)} member(s)`,
+    timeoutMs,
+  );
+}
+
+/**
+ * Poll a namespace's adapter until `room` holds at most `size` members. The
+ * shrink counterpart of {@link waitForRoomSize}: a client `disconnect()`
+ * resolves before the server has processed the departure, so a test that
+ * asserts on post-disconnect state waits for the membership to actually drop.
+ * @param nsp - The namespace whose adapter to watch.
+ * @param room - The room name.
+ * @param size - Maximum member count to wait for.
+ * @param timeoutMs - Give-up threshold.
+ */
+export async function waitForRoomSizeAtMost(
+  nsp: { adapter: { rooms: Map<string, Set<string>> } },
+  room: string,
+  size: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  await waitUntil(
+    () => (nsp.adapter.rooms.get(room)?.size ?? 0) <= size,
+    `room ${room} did not drop to ${String(size)} member(s)`,
+    timeoutMs,
+  );
+}
+
+/**
+ * Poll an arbitrary condition until it holds. The general form behind the
+ * room waits, for states the adapter cannot see — e.g. a presence record the
+ * next HTTP request will consult. Prefer the specific helpers where they fit;
+ * a condition passed here should still be *structural* (the state an
+ * assertion depends on), never a disguised sleep.
+ * @param condition - Returns true (or a promise of true) once the state holds.
+ * @param label - Failure description, phrased as what never happened.
+ * @param timeoutMs - Give-up threshold.
+ */
+export async function waitUntil(
+  condition: () => Promise<boolean> | boolean,
+  label: string,
+  timeoutMs = 5000,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    if ((nsp.adapter.rooms.get(room)?.size ?? 0) >= size) return;
+    if (await condition()) return;
     if (Date.now() > deadline) {
-      throw new Error(
-        `room ${room} did not reach ${String(size)} member(s) within ${String(timeoutMs)}ms`,
-      );
+      throw new Error(`${label} within ${String(timeoutMs)}ms`);
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }

--- a/api/tests/integration/staff-availability.test.ts
+++ b/api/tests/integration/staff-availability.test.ts
@@ -4,7 +4,14 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
+import {
+  integrationDbUp,
+  probeLiveHarness,
+  waitForRoomSize,
+  waitForRoomSizeAtMost,
+  waitUntil,
+  type LiveTestHarness,
+} from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -155,8 +162,6 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
   });
 }
 
-const settle = (ms = 150): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
 describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
@@ -190,13 +195,18 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('availability is per-user, not per-socket: a second tab closing does not drop it', async () => {
     if (harness === null) return;
-    const { baseUrl, services } = harness;
+    const { baseUrl, io, services } = harness;
     const { tenantId } = await seedTenantAndStaff('avail-multitab', 'multitab@avail.example');
     const token = await loginAs(baseUrl, 'multitab@avail.example');
 
+    // Consume each tab's connect-time availability:self restore ('away') —
+    // it is the last thing the connection handler emits, so receiving it
+    // proves setup finished AND keeps the toggle listener below from
+    // catching a restore instead of the toggle.
     const tabA = await connectStaff(baseUrl, token);
+    await waitFor(tabA, 'availability:self');
     const tabB = await connectStaff(baseUrl, token);
-    await settle();
+    await waitFor(tabB, 'availability:self');
 
     // Setting available in one tab is echoed to the other (same user room).
     const bSeesSelf = waitFor<{ status: string }>(tabB, 'availability:self');
@@ -206,7 +216,7 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
     // Closing one tab must not flip the agent away while the other is open.
     tabB.disconnect();
-    await settle();
+    await waitForRoomSizeAtMost(io.of('/staff'), `tenant:${tenantId}`, 1);
     expect(await services.presence.anyStaffAvailable(tenantId)).toBe(true);
 
     tabA.disconnect();
@@ -214,7 +224,7 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('explicit away status persists across a reconnect (survives reload)', async () => {
     if (harness === null) return;
-    const { baseUrl, services } = harness;
+    const { baseUrl, io, services } = harness;
     const { tenantId } = await seedTenantAndStaff('avail-persist', 'persist@avail.example');
     const token = await loginAs(baseUrl, 'persist@avail.example');
 
@@ -223,7 +233,7 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
     await waitFor(first, 'availability:self');
     expect(await services.presence.anyStaffAvailable(tenantId)).toBe(true);
     first.disconnect();
-    await settle();
+    await waitForRoomSizeAtMost(io.of('/staff'), `tenant:${tenantId}`, 0);
 
     // Reconnect restores the persisted 'available' status, not a default.
     const second = await connectStaff(baseUrl, token);
@@ -259,8 +269,8 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('availability change bridges to the visitor room via support:availability_changed', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('avail-bridge', 'bridge@avail.example');
+    const { baseUrl, io } = harness;
+    const { tenantId } = await seedTenantAndStaff('avail-bridge', 'bridge@avail.example');
     const token = await loginAs(baseUrl, 'bridge@avail.example');
 
     // A visitor session joins the tenant's visitor room on connect.
@@ -280,9 +290,15 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
       forceNew: true,
     });
     await waitFor(visitorSocket, 'connect');
-    await settle();
+    // support:availability_changed targets the visitor-namespace tenant room,
+    // so membership there is the state to wait for.
+    await waitForRoomSize(io.of('/visitor'), `tenant:${tenantId}`, 1);
 
     const staffSocket = await connectStaff(baseUrl, token);
+    // Wait out the connect-time restore: it broadcasts
+    // support:availability_changed unconditionally and would race the toggle
+    // broadcast below. availability:self is emitted after that completes.
+    await waitFor(staffSocket, 'availability:self');
     const visitorSeesAvailable = waitFor<{ available: boolean }>(
       visitorSocket,
       'support:availability_changed',
@@ -318,19 +334,29 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('an untenanted global agent toggling availability live-pushes to a served tenant visitor', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io, services } = harness;
     // A tenant with a connected visitor but NO tenant-scoped agent of its own —
     // only the untenanted global agent (issue #19) can serve it.
-    await seedTenantAndStaff('avail-global', 'ignored@avail.example');
+    const { tenantId } = await seedTenantAndStaff('avail-global', 'ignored@avail.example');
     await seedGlobalStaff('global@avail.example');
     const token = await loginAs(baseUrl, 'global@avail.example');
 
     const visitorSocket = await connectVisitor(baseUrl, 'avail-global');
-    await settle();
+    await waitForRoomSize(io.of('/visitor'), `tenant:${tenantId}`, 1);
+    // The visitor's presence record is written by a detached task on connect,
+    // and the global broadcast's tenant fan-out reads exactly that record —
+    // room membership alone does not prove it landed.
+    await waitUntil(
+      async () => (await services.presence.tenantsWithVisitors()).includes(tenantId),
+      'visitor presence never registered',
+    );
 
     // The global agent connects; nothing should flip yet (they default away).
+    // Its connect-time restore runs broadcastGlobalStaffAvailability, whose
+    // after-snapshot would see the toggle below and emit a duplicate — the
+    // availability:self that follows it is the completion signal to wait for.
     const staffSocket = await connectStaff(baseUrl, token);
-    await settle();
+    await waitFor(staffSocket, 'availability:self');
 
     // Going available must live-push the §5.1.2 transition to the already-
     // connected visitor even though the agent belongs to no tenant.


### PR DESCRIPTION
Follow-up to #172, completing the sweep it scoped out. All ten remaining fixed sleeps are gone — five in `chat-flow.test.ts`, five via `staff-availability.test.ts`'s `settle()` helper (deleted). `audit-logging`'s 40 ms is untouched: it is a poll interval inside a bounded retry loop, not a blind sleep.

## Helpers

`setup.ts` grows a `waitUntil(condition, label)` core; `waitForRoomSize` is rebuilt on it, and `waitForRoomSizeAtMost` covers disconnect processing (a client `disconnect()` resolves before the server notices the departure).

## What each sleep became

| was | now keyed to |
|---|---|
| join settling (250/150 ms) | room membership via the adapter |
| availability gate before a visitor POST (200 ms) | `presence.anyStaffAvailable` — the record the POST consults |
| global-agent fan-out setup (150 ms) | `presence.tenantsWithVisitors` — written by a **detached** task on visitor connect, which room membership cannot vouch for |
| "no leak" negative windows (300/200 ms) | causality: the room echo written by the same server emit that would have leaked, or same-connection FIFO where an awaited `chat:error` round-trip proves any wrongful event would already have arrived |

## The hazard the sleeps were hiding

A staff socket's connect-time restore broadcasts availability **concurrently** with any toggle a test fires right after connect — `broadcastTenantAvailability` emits unconditionally, and `broadcastGlobalStaffAvailability`'s before/after snapshot can observe the toggle's state and emit a duplicate `support:availability_changed` that a once-listener misattributes. Naive room waits made the multitab and global-agent tests fail 3/3; the bridge test carried the same race latently. The anchor is the connect-time `availability:self`, emitted only after the restore completes — those three tests now consume it before toggling.

## Verified

- `chat-flow` + `staff-availability`: 5/5 consecutive green runs against the real stack
- Full API suite 402/402; lint + typecheck clean; pre-push `check:all` green on push