### PR TITLE
Release v0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,9 @@ jobs:
         with:
           args: --no-progress '**/*.md'
 
-      # The integration tests return early on a null harness, so without a
-      # database they pass while asserting nothing — a green check that means
-      # nothing. Bring the real stack up and set REQUIRE_DB=1 below so an
-      # unreachable stack fails loudly instead of silently skipping.
+      # An unreachable integration stack fails the suite by default (#170) —
+      # REQUIRE_DB is gone; failing loudly no longer needs opting into. Bring
+      # the real stack up so the integration tests actually run.
       - name: Start integration infrastructure
         run: |
           set -euo pipefail
@@ -70,8 +69,6 @@ jobs:
           docker exec livechat-redis redis-cli ping
 
       - run: npm run check:all
-        env:
-          REQUIRE_DB: "1"
 
   usecases-diff-gate:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Architecture decisions referenced below live in [`docs/adr/`](docs/adr/).
 
+## [0.4.1] - 2026-08-29
+
+### Fixed
+
+- **An unreachable integration stack now fails the API test suite instead of
+  passing it.** With MySQL/Redis down, every integration test hit its
+  `if (harness === null) return;` guard and reported ✓ passed in 0–1 ms —
+  400/400 green with zero integration coverage. `tests/integration/setup.ts`
+  now probes the stack once at module load and fails the file with operator
+  guidance when it is down; running without the stack takes an explicit
+  `INTEGRATION_DB_OPTIONAL=1`, under which every suite reports as *skipped*,
+  never passed. `REQUIRE_DB` is gone — failing loudly is no longer opt-in.
+  `api/tests/availability-gate.test.ts` pins both arms against a child vitest
+  run pointed at dead ports. ([#170], [#171])
+
+- **The socket integration tests no longer race wall-clock sleeps.** Seventeen
+  fixed 150–300 ms sleeps across `visitor-socket`, `chat-flow` and
+  `staff-availability` are replaced with waits keyed to the state each
+  assertion actually consults: room membership via the adapter
+  (`waitForRoomSize` / `waitForRoomSizeAtMost`), presence records
+  (`waitUntil`), and causal anchors for the "no leak" negatives. The
+  `chat:typing` fan-out flake observed on CI — the accept handler awaits a
+  MySQL assignment before its `socket.join`, so 150 ms was not always
+  enough — is fixed, and the conversion surfaced a real hazard the sleeps had
+  papered over: a staff socket's connect-time availability restore broadcasts
+  concurrently with any toggle fired right after connect, which can emit a
+  duplicate `support:availability_changed`. Affected tests now anchor on the
+  connect-time `availability:self` that follows the restore. ([#172], [#173])
+
 ## [0.4.0] - 2026-08-29
 
 ### Changed
@@ -1062,7 +1091,8 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
   ships with Node 22, and effective on toolchain upgrade.
 - `body-parser` bumped to 2.3.0, clearing OSV `GHSA-v422-hmwv-36x6`.
 
-[Unreleased]: https://github.com/AFixt/livechat/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/AFixt/livechat/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/AFixt/livechat/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/AFixt/livechat/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/AFixt/livechat/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/AFixt/livechat/compare/v0.2.0...v0.3.0
@@ -1101,3 +1131,7 @@ had never carried any of it. The product is pre-1.0 and not yet deployed.
 [#164]: https://github.com/AFixt/livechat/pull/164
 [#165]: https://github.com/AFixt/livechat/issues/165
 [#166]: https://github.com/AFixt/livechat/pull/166
+[#170]: https://github.com/AFixt/livechat/issues/170
+[#171]: https://github.com/AFixt/livechat/pull/171
+[#172]: https://github.com/AFixt/livechat/pull/172
+[#173]: https://github.com/AFixt/livechat/pull/173

--- a/api/tests/availability-gate.test.ts
+++ b/api/tests/availability-gate.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guard for the guard: proves an unreachable integration stack can never read
+ * as a pass (#170).
+ *
+ * Before this existed, every integration test opened with
+ * `if (harness === null) return;` — with MySQL/Redis down the whole suite
+ * reported ✓ passed in 0–1 ms, indistinguishable from a real run. The fix
+ * (`tests/integration/setup.ts`) probes the stack once at module load: down
+ * means the file fails loudly, unless `INTEGRATION_DB_OPTIONAL=1` explicitly
+ * requested running without it, in which case `describe.skipIf` reports the
+ * tests as *skipped*.
+ *
+ * A gate like that is only trustworthy if it is exercised in the state it
+ * exists to catch (cf. `shared/tests/generated-specs-gate.test.ts`), so this
+ * runs a real integration file in a child vitest pointed at ports where
+ * nothing listens, and asserts both arms: failure by default, visible skips
+ * under the opt-out — and never a pass.
+ */
+/* eslint-disable n/no-sync */
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const API_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The child target: the smallest integration file, so each spawn pays for one
+ * app import, not the suite.
+ */
+const TARGET = 'tests/integration/cors.test.ts';
+
+/**
+ * Run TARGET in a child vitest against ports where nothing listens.
+ * @param extraEnv - Env overrides for the child (the opt-out flag).
+ * @returns The completed child process result.
+ */
+function runAgainstDeadStack(extraEnv: Record<string, string>): SpawnSyncReturns<string> {
+  return spawnSync('npx', ['vitest', 'run', TARGET], {
+    cwd: API_ROOT,
+    encoding: 'utf8',
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      // TCP port 1 on localhost: connection refused immediately, nothing to
+      // wait out. Chosen over a fake host so DNS cannot slow the probe down.
+      DB_HOST: '127.0.0.1',
+      DB_PORT: '1',
+      REDIS_HOST: '127.0.0.1',
+      REDIS_PORT: '1',
+      ...extraEnv,
+    },
+  });
+}
+
+describe('integration availability gate (#170)', () => {
+  it('fails loudly by default when the stack is unreachable', () => {
+    const result = runAgainstDeadStack({ INTEGRATION_DB_OPTIONAL: '' });
+    const output = result.stdout + result.stderr;
+
+    expect(result.status, `child vitest passed against a dead stack:\n${output}`).not.toBe(0);
+    // The failure must carry operator guidance, not a bare connection error.
+    expect(output).toContain('Integration stack unreachable');
+    expect(output).toContain('docker compose up -d mysql redis');
+    // And it must be a failure, never a green run that asserted nothing.
+    expect(output).not.toMatch(/\d+ passed/);
+  }, 120_000);
+
+  it('reports tests as skipped — never passed — under INTEGRATION_DB_OPTIONAL=1', () => {
+    const result = runAgainstDeadStack({ INTEGRATION_DB_OPTIONAL: '1' });
+    const output = result.stdout + result.stderr;
+
+    expect(result.status, `opt-out run did not exit cleanly:\n${output}`).toBe(0);
+    expect(output).toMatch(/skipped/);
+    expect(output).not.toMatch(/\d+ passed/);
+  }, 120_000);
+});

--- a/api/tests/integration/admin-routes.test.ts
+++ b/api/tests/integration/admin-routes.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Role } from '@livechat/shared';
 
@@ -80,7 +80,7 @@ async function login(email: string, password: string): Promise<string> {
   return res.body.data.accessToken as string;
 }
 
-describe('admin routes (integration)', () => {
+describe.skipIf(!integrationDbUp)('admin routes (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) {

--- a/api/tests/integration/audit-logging.test.ts
+++ b/api/tests/integration/audit-logging.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, Tenant, User } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Role } from '@livechat/shared';
 
@@ -98,7 +98,7 @@ function auditPath(row: AuditLog): string {
   return typeof meta.path === 'string' ? meta.path : '';
 }
 
-describe('audit logging (integration)', () => {
+describe.skipIf(!integrationDbUp)('audit logging (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) {

--- a/api/tests/integration/auth-flow.test.ts
+++ b/api/tests/integration/auth-flow.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Invitation, Tenant, User } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -47,7 +47,7 @@ async function seedTenantAndAdmin(): Promise<{
   return { tenantId: tenant.id, adminEmail, adminPassword };
 }
 
-describe('auth flow (integration)', () => {
+describe.skipIf(!integrationDbUp)('auth flow (integration)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/auth-lifecycle.test.ts
+++ b/api/tests/integration/auth-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, Invitation, Tenant, User, UserSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Role, UserStatus } from '@livechat/shared';
 import type { Express } from 'express';
@@ -74,7 +74,7 @@ async function loginAsSuperAdmin(app: Express, email: string): Promise<string> {
   return res.body.data.accessToken as string;
 }
 
-describe('auth lifecycle (integration)', () => {
+describe.skipIf(!integrationDbUp)('auth lifecycle (integration)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -3,9 +3,16 @@ import { io as ioClient, type Socket } from 'socket.io-client';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
+import { GLOBAL_STAFF_ROOM } from '../../src/io/rooms.js';
 import { Chat, Tenant, User } from '../../src/models/index.js';
 
-import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
+import {
+  integrationDbUp,
+  probeLiveHarness,
+  waitForRoomSize,
+  waitUntil,
+  type LiveTestHarness,
+} from './setup.js';
 
 async function seedTenantAndStaff(
   tenantSlug: string,
@@ -171,8 +178,8 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
   test('tenant isolation: tenant A staff never receives tenant B messages', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('alpha', 'a-staff@alpha.example');
+    const { baseUrl, io } = harness;
+    const { tenantId: alphaTenantId } = await seedTenantAndStaff('alpha', 'a-staff@alpha.example');
     await seedTenantAndStaff('beta', 'b-staff@beta.example');
 
     const staffAToken = await loginAs(baseUrl, 'a-staff@alpha.example', 'Staff!Password1');
@@ -199,15 +206,23 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
       forceNew: true,
     });
     await Promise.all([waitFor(staffA, 'connect'), waitFor(visitorB, 'connect')]);
+    // A fair negative needs staff A fully in its rooms first — otherwise the
+    // "no leak" assertion would pass trivially against a half-connected socket.
+    await waitForRoomSize(io.of('/staff'), `tenant:${alphaTenantId}`, 1);
     visitorB.emit('chat:join', { chatId: betaChatId });
+    await waitForRoomSize(io.of('/visitor'), `chat:${betaChatId}`, 1);
 
     let leakedToA = false;
     staffA.on('chat:message', () => {
       leakedToA = true;
     });
 
+    // Anchor the negative to the same broadcast: the room echo back to the
+    // sender is written by the very server emit that would have leaked, so
+    // once it arrives the fan-out for this message has been fully decided.
+    const echo = waitFor(visitorB, 'chat:message');
     visitorB.emit('chat:message', { chatId: betaChatId, body: 'beta message' });
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await echo;
     expect(leakedToA).toBe(false);
 
     staffA.disconnect();
@@ -216,8 +231,8 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
   test('availability drives no_support; current chat + support-initiated wiring', async () => {
     if (harness === null) return;
-    const { baseUrl, redis } = harness;
-    await seedTenantAndStaff('gamma', 'g-staff@gamma.example');
+    const { baseUrl, redis, io, services } = harness;
+    const { tenantId: gammaTenantId } = await seedTenantAndStaff('gamma', 'g-staff@gamma.example');
     const accessToken = await loginAs(baseUrl, 'g-staff@gamma.example', 'Staff!Password1');
     const { cookie: visitorCookie, sessionId, csrfToken } = await initVisitor(baseUrl, 'gamma');
 
@@ -249,8 +264,14 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
       forceNew: true,
     });
     await waitFor(staffSocket, 'connect');
+    await waitForRoomSize(io.of('/staff'), `tenant:${gammaTenantId}`, 1);
     staffSocket.emit('availability:set', { status: 'available' });
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // The POST below consults the presence record, so wait for that exact
+    // state rather than guessing how long the handler needs to write it.
+    await waitUntil(
+      async () => services.presence.anyStaffAvailable(gammaTenantId),
+      'gamma staff never became available',
+    );
     const onlineRes = await request(baseUrl)
       .post('/api/v1/visitor/chats')
       .set('cookie', `livechat_visitor=${visitorCookie}`)
@@ -277,11 +298,11 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
   test('untenanted staff watch all tenants; scoped staff stay isolated', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io } = harness;
     // A visitor in tenant "delta", an untenanted AFixt staff (tenant_id null),
     // and a staff scoped to an unrelated tenant "omega".
     await seedTenantAndStaff('delta', 'd-staff@delta.example');
-    await seedTenantAndStaff('omega', 'o-staff@omega.example');
+    const { tenantId: omegaTenantId } = await seedTenantAndStaff('omega', 'o-staff@omega.example');
     await User.create({
       email: 'global@afixt.example',
       passwordHash: 'Staff!Password1',
@@ -320,8 +341,11 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
       forceNew: true,
     });
     await Promise.all([waitFor(globalSocket, 'connect'), waitFor(omegaSocket, 'connect')]);
-    // Let the connection handlers finish joining their rooms.
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    // Wait on the rooms themselves rather than guessing how long the
+    // connection handlers need: the untenanted agent lands in the global
+    // room, the omega agent in its tenant room.
+    await waitForRoomSize(io.of('/staff'), GLOBAL_STAFF_ROOM, 1);
+    await waitForRoomSize(io.of('/staff'), `tenant:${omegaTenantId}`, 1);
 
     let leakedToOmega = false;
     omegaSocket.on('visitor:joined', () => {
@@ -341,7 +365,9 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
 
     const joined = await globalSeesVisitor;
     expect(joined.visitorSessionId).toBeTruthy();
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // The would-be leak is written by the same server emit that just reached
+    // the global socket, so the fan-out for it has already been decided —
+    // there is nothing further to wait for.
     expect(leakedToOmega).toBe(false);
 
     globalSocket.disconnect();
@@ -389,7 +415,9 @@ describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
     staffA.emit('chat:message', { chatId: betaChatId, body: 'hijack attempt' });
     expect((await messageErr).event).toBe('chat:message');
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Both chat:error round-trips arrived on staffA's own connection, which
+    // is FIFO: any wrongful chat:assigned from those handlers would already
+    // have been delivered before the errors. No wait needed.
     expect(assigned).toBe(false);
     const chatAfter = await Chat.findByPk(betaChatId);
     expect(chatAfter?.assignedTo).toBeNull();

--- a/api/tests/integration/chat-flow.test.ts
+++ b/api/tests/integration/chat-flow.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Chat, Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 async function seedTenantAndStaff(
   tenantSlug: string,
@@ -86,7 +86,7 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
   });
 }
 
-describe('chat flow (integration)', () => {
+describe.skipIf(!integrationDbUp)('chat flow (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/chat-routes.test.ts
+++ b/api/tests/integration/chat-routes.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Chat, ChatMessage, Tenant, User, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { ChatStatus } from '@livechat/shared';
 import type { Express } from 'express';
@@ -200,7 +200,7 @@ async function seedMessage(chatId: string, body: string, deliveredAt: Date): Pro
   });
 }
 
-describe('chat routes (integration)', () => {
+describe.skipIf(!integrationDbUp)('chat routes (integration)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/cluster-availability.test.ts
+++ b/api/tests/integration/cluster-availability.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { createPresenceService } from '../../src/services/presence-service.js';
 
-import { probeHarness, testEnv } from './setup.js';
+import { integrationDbUp, probeHarness, testEnv } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -16,87 +16,90 @@ const TENANT_B = '22222222-2222-4222-8222-222222222222';
  * processes. That is exactly the condition #125 is about: each node sees only
  * its own Socket.IO room membership, but they share Redis.
  */
-describe('availability fan-out is cluster-wide, not per-node (#125)', () => {
-  let harness: Harness;
-  // Undefined when the harness bails (no infrastructure), which afterAll
-  // must tolerate rather than throwing over the real skip reason.
-  let redisA: Redis | undefined;
-  let redisB: Redis | undefined;
+describe.skipIf(!integrationDbUp)(
+  'availability fan-out is cluster-wide, not per-node (#125)',
+  () => {
+    let harness: Harness;
+    // Undefined when the harness bails (no infrastructure), which afterAll
+    // must tolerate rather than throwing over the real skip reason.
+    let redisA: Redis | undefined;
+    let redisB: Redis | undefined;
 
-  beforeAll(async () => {
-    harness = await probeHarness();
-    if (harness === null) {
-      console.warn('[integration] MySQL or Redis not reachable — skipping');
-      return;
-    }
-    const env = testEnv();
-    redisA = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
-    redisB = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
-    await redisA.del('presence:visitor-tenants');
-  }, 60_000);
+    beforeAll(async () => {
+      harness = await probeHarness();
+      if (harness === null) {
+        console.warn('[integration] MySQL or Redis not reachable — skipping');
+        return;
+      }
+      const env = testEnv();
+      redisA = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
+      redisB = new Redis({ host: env.REDIS_HOST, port: env.REDIS_PORT });
+      await redisA.del('presence:visitor-tenants');
+    }, 60_000);
 
-  afterAll(async () => {
-    await redisA?.quit().catch(() => undefined);
-    await redisB?.quit().catch(() => undefined);
-    if (harness !== null) await harness.cleanup();
-  });
+    afterAll(async () => {
+      await redisA?.quit().catch(() => undefined);
+      await redisB?.quit().catch(() => undefined);
+      if (harness !== null) await harness.cleanup();
+    });
 
-  test('a visitor on another node is still enumerated', async () => {
-    if (harness === null) return;
-    if (redisA === undefined || redisB === undefined) return;
-    const nodeA = createPresenceService({ redis: redisA });
-    const nodeB = createPresenceService({ redis: redisB });
+    test('a visitor on another node is still enumerated', async () => {
+      if (harness === null) return;
+      if (redisA === undefined || redisB === undefined) return;
+      const nodeA = createPresenceService({ redis: redisA });
+      const nodeB = createPresenceService({ redis: redisB });
 
-    await nodeA.markVisitorPresent(TENANT_A, 'visitor-on-a', { url: 'https://a.example' });
-    await nodeB.markVisitorPresent(TENANT_B, 'visitor-on-b', { url: 'https://b.example' });
+      await nodeA.markVisitorPresent(TENANT_A, 'visitor-on-a', { url: 'https://a.example' });
+      await nodeB.markVisitorPresent(TENANT_B, 'visitor-on-b', { url: 'https://b.example' });
 
-    // Either node must see both tenants — this is what makes the global-staff
-    // live push reach a visitor connected to a different process.
-    expect((await nodeA.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
-    expect((await nodeB.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
-  });
+      // Either node must see both tenants — this is what makes the global-staff
+      // live push reach a visitor connected to a different process.
+      expect((await nodeA.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
+      expect((await nodeB.tenantsWithVisitors()).sort()).toEqual([TENANT_A, TENANT_B].sort());
+    });
 
-  test('Socket.IO room membership — the old source — cannot see the other node', async () => {
-    if (harness === null) return;
-    // Demonstrates the defect rather than only asserting the fix. Two Socket.IO
-    // servers, each with its own adapter: a room joined on one is invisible to
-    // the other, which is why `adapter.rooms` was the wrong source.
-    // Constructed without an http server: these never listen, so there is
-    // nothing to close afterwards — only their adapters are under test.
-    const nodeA = new Server();
-    const nodeB = new Server();
-    await nodeB.of('/visitor').adapter.addAll('socket-on-b', new Set([`tenant:${TENANT_B}`]));
+    test('Socket.IO room membership — the old source — cannot see the other node', async () => {
+      if (harness === null) return;
+      // Demonstrates the defect rather than only asserting the fix. Two Socket.IO
+      // servers, each with its own adapter: a room joined on one is invisible to
+      // the other, which is why `adapter.rooms` was the wrong source.
+      // Constructed without an http server: these never listen, so there is
+      // nothing to close afterwards — only their adapters are under test.
+      const nodeA = new Server();
+      const nodeB = new Server();
+      await nodeB.of('/visitor').adapter.addAll('socket-on-b', new Set([`tenant:${TENANT_B}`]));
 
-    const roomsSeenByA = [...nodeA.of('/visitor').adapter.rooms.keys()];
-    expect(roomsSeenByA).not.toContain(`tenant:${TENANT_B}`);
-    expect([...nodeB.of('/visitor').adapter.rooms.keys()]).toContain(`tenant:${TENANT_B}`);
-  });
+      const roomsSeenByA = [...nodeA.of('/visitor').adapter.rooms.keys()];
+      expect(roomsSeenByA).not.toContain(`tenant:${TENANT_B}`);
+      expect([...nodeB.of('/visitor').adapter.rooms.keys()]).toContain(`tenant:${TENANT_B}`);
+    });
 
-  test('a tenant whose visitors have all gone is pruned from the index', async () => {
-    if (harness === null) return;
-    if (redisA === undefined) return;
-    const nodeA = createPresenceService({ redis: redisA });
-    // Its own tenant, so the visitors left behind by the test above cannot keep
-    // this one's presence hash alive.
-    const tenantC = '33333333-3333-4333-8333-333333333333';
+    test('a tenant whose visitors have all gone is pruned from the index', async () => {
+      if (harness === null) return;
+      if (redisA === undefined) return;
+      const nodeA = createPresenceService({ redis: redisA });
+      // Its own tenant, so the visitors left behind by the test above cannot keep
+      // this one's presence hash alive.
+      const tenantC = '33333333-3333-4333-8333-333333333333';
 
-    await nodeA.markVisitorPresent(tenantC, 'only-visitor', { url: 'https://c.example' });
-    expect(await nodeA.tenantsWithVisitors()).toContain(tenantC);
+      await nodeA.markVisitorPresent(tenantC, 'only-visitor', { url: 'https://c.example' });
+      expect(await nodeA.tenantsWithVisitors()).toContain(tenantC);
 
-    // Removing the last visitor empties the hash, and Redis drops an empty
-    // hash — so the tenant must fall out of the index rather than widening the
-    // fan-out it exists to bound.
-    await nodeA.removeVisitor(tenantC, 'only-visitor');
-    expect(await nodeA.tenantsWithVisitors()).not.toContain(tenantC);
-    // Pruned from the set itself, not merely filtered on the way out.
-    expect(await redisA.smembers('presence:visitor-tenants')).not.toContain(tenantC);
-  });
+      // Removing the last visitor empties the hash, and Redis drops an empty
+      // hash — so the tenant must fall out of the index rather than widening the
+      // fan-out it exists to bound.
+      await nodeA.removeVisitor(tenantC, 'only-visitor');
+      expect(await nodeA.tenantsWithVisitors()).not.toContain(tenantC);
+      // Pruned from the set itself, not merely filtered on the way out.
+      expect(await redisA.smembers('presence:visitor-tenants')).not.toContain(tenantC);
+    });
 
-  test('returns nothing when no visitor is present anywhere', async () => {
-    if (harness === null) return;
-    if (redisA === undefined) return;
-    const nodeA = createPresenceService({ redis: redisA });
-    await redisA.del('presence:visitor-tenants');
-    expect(await nodeA.tenantsWithVisitors()).toEqual([]);
-  });
-});
+    test('returns nothing when no visitor is present anywhere', async () => {
+      if (harness === null) return;
+      if (redisA === undefined) return;
+      const nodeA = createPresenceService({ redis: redisA });
+      await redisA.del('presence:visitor-tenants');
+      expect(await nodeA.tenantsWithVisitors()).toEqual([]);
+    });
+  },
+);

--- a/api/tests/integration/cors.test.ts
+++ b/api/tests/integration/cors.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { clearOriginCache } from '../../src/middlewares/cors.js';
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -30,7 +30,7 @@ async function seedTenant(slug: string, allowedOrigins: string[] | null): Promis
   return tenant.id;
 }
 
-describe('per-tenant CORS (#74)', () => {
+describe.skipIf(!integrationDbUp)('per-tenant CORS (#74)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/csrf.test.ts
+++ b/api/tests/integration/csrf.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -32,7 +32,7 @@ async function bootstrapVisitor(
   return { cookie, csrfToken: res.body.data.csrfToken as string };
 }
 
-describe('CSRF protection on visitor write routes (#77)', () => {
+describe.skipIf(!integrationDbUp)('CSRF protection on visitor write routes (#77)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/data-retention.test.ts
+++ b/api/tests/integration/data-retention.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { Chat, ChatMessage, Tenant, VisitorSession } from '../../src/models/index.js';
 import { createDataRetentionService } from '../../src/services/data-retention-service.js';
 
-import { probeHarness, type TestHarness } from './setup.js';
+import { integrationDbUp, probeHarness, type TestHarness } from './setup.js';
 
 const logger = pino({ level: 'silent' });
 
@@ -74,7 +74,7 @@ async function seedSession(
   return session.id;
 }
 
-describe('data retention service', () => {
+describe.skipIf(!integrationDbUp)('data retention service', () => {
   let harness: TestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/data-subject-request.test.ts
+++ b/api/tests/integration/data-subject-request.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/models/index.js';
 import { createServices } from '../../src/services/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Env } from '../../src/config/env.js';
 import type { Express } from 'express';
@@ -24,7 +24,7 @@ interface Subject {
   chatId: string;
 }
 
-describe('data-subject access and erasure (#121)', () => {
+describe.skipIf(!integrationDbUp)('data-subject access and erasure (#121)', () => {
   let harness: Harness;
   let app: Express;
   /** An app configured to hard-delete rather than anonymize. */

--- a/api/tests/integration/embed-hardening.test.ts
+++ b/api/tests/integration/embed-hardening.test.ts
@@ -4,9 +4,9 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness, type TestHarness } from './setup.js';
+import { integrationDbUp, probeHarness, type TestHarness } from './setup.js';
 
-describe('embed hardening (integration)', () => {
+describe.skipIf(!integrationDbUp)('embed hardening (integration)', () => {
   let harness: TestHarness | null = null;
   let tenantId = '';
 

--- a/api/tests/integration/privacy-api.test.ts
+++ b/api/tests/integration/privacy-api.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, ConsentRecord, Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -36,7 +36,7 @@ function cookiesOf(res: request.Response): string[] {
   return raw ?? [];
 }
 
-describe('privacy API (integration)', () => {
+describe.skipIf(!integrationDbUp)('privacy API (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) console.warn('[integration] MySQL or Redis not reachable — skipping');

--- a/api/tests/integration/reconnect.test.ts
+++ b/api/tests/integration/reconnect.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { ChatMessage, Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 /**
  * Sort a copy of a body list. `delivered_at` is whole-second precision, so
@@ -143,7 +143,7 @@ async function visitorTranscriptBodies(baseUrl: string, cookie: string): Promise
   return (res.body.data.messages as { body: string }[]).map((m) => m.body);
 }
 
-describe('socket reconnect (integration, #69)', () => {
+describe.skipIf(!integrationDbUp)('socket reconnect (integration, #69)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/schema-parity.test.ts
+++ b/api/tests/integration/schema-parity.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { resetSchemaFromMigrations } from '../../src/db/migrator.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Sequelize } from 'sequelize';
 
@@ -74,7 +74,7 @@ async function introspect(sequelize: Sequelize): Promise<Record<string, TableSha
   return out;
 }
 
-describe('schema parity: migrations vs models (integration)', () => {
+describe.skipIf(!integrationDbUp)('schema parity: migrations vs models (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) {

--- a/api/tests/integration/security-regression.test.ts
+++ b/api/tests/integration/security-regression.test.ts
@@ -5,7 +5,7 @@ import { createApp } from '../../src/app.js';
 import { computeCsrfToken } from '../../src/middlewares/csrf.js';
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness, type TestHarness } from './setup.js';
+import { integrationDbUp, probeHarness, type TestHarness } from './setup.js';
 
 import type { Express } from 'express';
 
@@ -39,216 +39,219 @@ function expectNoLeak(body: unknown): void {
   expect(serialized.toLowerCase()).not.toContain('econnrefused');
 }
 
-describe('security regression: input validation + storage (integration)', () => {
-  let harness: TestHarness | null = null;
-  let prodApp: Express | null = null;
+describe.skipIf(!integrationDbUp)(
+  'security regression: input validation + storage (integration)',
+  () => {
+    let harness: TestHarness | null = null;
+    let prodApp: Express | null = null;
 
-  beforeAll(async () => {
-    harness = await probeHarness();
-    if (harness === null) {
-      console.warn('[integration] MySQL or Redis not reachable — skipping');
-      return;
-    }
-    await Tenant.create({
-      name: 'Sec Regression Tenant',
-      slug: TENANT_SLUG,
-      status: 'active',
-      domain: null,
-      expiresAt: null,
-      settings: null,
-    });
-    // A second app whose env reports production, so we can assert the visitor
-    // cookie gains the `Secure` flag there. It shares the live DB/Redis/services.
-    prodApp = createApp({
-      env: { ...harness.env, NODE_ENV: 'production', isProduction: true, isTest: false },
-      logger: harness.logger,
-      redis: harness.redis,
-      services: harness.services,
-      skipRateLimit: true,
-    });
-  }, 60_000);
+    beforeAll(async () => {
+      harness = await probeHarness();
+      if (harness === null) {
+        console.warn('[integration] MySQL or Redis not reachable — skipping');
+        return;
+      }
+      await Tenant.create({
+        name: 'Sec Regression Tenant',
+        slug: TENANT_SLUG,
+        status: 'active',
+        domain: null,
+        expiresAt: null,
+        settings: null,
+      });
+      // A second app whose env reports production, so we can assert the visitor
+      // cookie gains the `Secure` flag there. It shares the live DB/Redis/services.
+      prodApp = createApp({
+        env: { ...harness.env, NODE_ENV: 'production', isProduction: true, isTest: false },
+        logger: harness.logger,
+        redis: harness.redis,
+        services: harness.services,
+        skipRateLimit: true,
+      });
+    }, 60_000);
 
-  afterAll(async () => {
-    if (harness !== null) await harness.cleanup();
-  });
-
-  describe('zod validation rejects bad input with 400, never 500', () => {
-    test('auth/register with wrong field types is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/register')
-        .send({ email: 123, password: [], firstName: null, lastName: 7, token: {} });
-      expect(res.status).toBe(400);
-      expect(res.body.message).toBe('Validation failed');
-      expectNoLeak(res.body);
+    afterAll(async () => {
+      if (harness !== null) await harness.cleanup();
     });
 
-    test('auth/login with a missing password is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .send({ email: 'someone@example.com' });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
+    describe('zod validation rejects bad input with 400, never 500', () => {
+      test('auth/register with wrong field types is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/register')
+          .send({ email: 123, password: [], firstName: null, lastName: 7, token: {} });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toBe('Validation failed');
+        expectNoLeak(res.body);
+      });
+
+      test('auth/login with a missing password is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .send({ email: 'someone@example.com' });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('auth/login with an SQL-injection-ish email is rejected by validation (400)', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .send({ email: "' OR 1=1 --", password: "'; DROP TABLE users; --" });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('visitor/session with a missing tenantKey is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app).post('/api/v1/visitor/session').send({});
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('visitor/session with a wrong-typed tenantKey is a 400', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: 12345 });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('visitor/chats with an invalid body is a 400 (before the cookie check)', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/chats')
+          .send({ customerName: '', body: '' });
+        expect(res.status).toBe(400);
+        expectNoLeak(res.body);
+      });
+
+      test('an injection string in tenantKey is treated as a literal slug — clean 400, no SQL error', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: "'; DROP TABLE tenants; --" });
+        // Parameterized lookup finds no such slug: a clean 4xx, never a 500.
+        expect(res.status).toBe(400);
+        expect(res.status).not.toBe(500);
+        expectNoLeak(res.body);
+      });
     });
 
-    test('auth/login with an SQL-injection-ish email is rejected by validation (400)', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .send({ email: "' OR 1=1 --", password: "'; DROP TABLE users; --" });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
+    describe('malformed / oversized request bodies', () => {
+      test('malformed JSON on auth/login is a 400, not a 500', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .set('Content-Type', 'application/json')
+          .send('{"email": "a@b.co", ');
+        expect(res.status).toBe(400);
+        expect(res.body).toEqual({ success: false, message: 'Malformed request body' });
+      });
+
+      test('a body beyond the 1mb json limit is a 413, not a 500', async () => {
+        if (harness === null) return;
+        const oversized = JSON.stringify({ tenantKey: 'x'.repeat(1_200_000) });
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .set('Content-Type', 'application/json')
+          .send(oversized);
+        expect(res.status).toBe(413);
+        expect(res.body).toEqual({ success: false, message: 'Request payload too large' });
+      });
     });
 
-    test('visitor/session with a missing tenantKey is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app).post('/api/v1/visitor/session').send({});
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
+    describe('visitor session cookie flags + forgery', () => {
+      test('in dev the visitor cookie is HttpOnly + SameSite=Lax (no Secure)', async () => {
+        if (harness === null) return;
+        const res = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: TENANT_SLUG });
+        expect(res.status).toBe(201);
+        const cookie = visitorSetCookie(res);
+        expect(cookie).toBeDefined();
+        expect(cookie).toMatch(/HttpOnly/i);
+        // Local dev is same-origin over plain HTTP: SameSite=None would require
+        // Secure, and a Secure cookie is dropped on localhost HTTP (#75).
+        expect(cookie).toMatch(/SameSite=Lax/i);
+        expect(cookie).not.toMatch(/Secure/i);
+      });
+
+      test('in production the visitor cookie is SameSite=None; Secure; Partitioned', async () => {
+        if (harness === null || prodApp === null) return;
+        const res = await request(prodApp)
+          .post('/api/v1/visitor/session')
+          .send({ tenantKey: TENANT_SLUG });
+        expect(res.status).toBe(201);
+        const cookie = visitorSetCookie(res);
+        expect(cookie).toBeDefined();
+        expect(cookie).toMatch(/HttpOnly/i);
+        // The widget is embedded cross-site, so the cookie is only ever sent
+        // with SameSite=None — which browsers reject without Secure (#75).
+        expect(cookie).toMatch(/SameSite=None/i);
+        expect(cookie).toMatch(/Secure/i);
+        expect(cookie).toMatch(/Partitioned/i);
+        expect(cookie).not.toMatch(/SameSite=Lax/i);
+      });
+
+      test('auth/login does not set any session cookie (JWTs are returned in the body)', async () => {
+        if (harness === null) return;
+        // Wrong credentials still exercise the response path; we only assert the
+        // absence of a Set-Cookie so a future accidental cookie is caught.
+        const res = await request(harness.app)
+          .post('/api/v1/auth/login')
+          .send({ email: 'nobody@example.com', password: 'whatever-123' });
+        expect(res.headers['set-cookie']).toBeUndefined();
+      });
+
+      test('a valid visitor cookie is accepted, a forged one is rejected 401', async () => {
+        if (harness === null) return;
+        const created = await request(harness.app)
+          .post('/api/v1/visitor/session')
+          // x-geo-country: US (trusted edge header) → opt-out jurisdiction → the consent gate permits presence
+          // and a tracked `visitor_sessions` row is created (#53). The heartbeat
+          // positive control below resolves the cookie to that row, so without a
+          // geo hint the jurisdiction resolves to UNKNOWN, no row exists, and the
+          // control 401s for a reason that has nothing to do with cookie forgery.
+          .set('x-geo-country', 'US')
+          .send({ tenantKey: TENANT_SLUG });
+        expect(created.status).toBe(201);
+        const rawCookie = visitorSetCookie(created)?.split(';')[0] ?? '';
+        const value = rawCookie.replace('livechat_visitor=', '');
+        expect(value).toContain('.');
+
+        // Positive control: the genuine cookie authenticates the heartbeat.
+        // The heartbeat is a CSRF-protected write (#77), so the token issued
+        // alongside the cookie has to be echoed — this asserts cookie validity,
+        // not CSRF behavior, which `csrf.test.ts` covers.
+        const ok = await request(harness.app)
+          .post('/api/v1/visitor/heartbeat')
+          .set('Cookie', rawCookie)
+          .set('X-XSRF-TOKEN', created.body.data.csrfToken as string)
+          .send({});
+        expect(ok.status).toBe(200);
+
+        // Forge it: keep the session id, corrupt the HMAC signature.
+        const [sessionId, sig] = value.split('.');
+        const forgedSig = (sig ?? '').replace(/./g, '0');
+        const forged = `livechat_visitor=${sessionId ?? ''}.${forgedSig}`;
+        // Give the forged cookie its own matching CSRF token so the CSRF layer
+        // passes and the cookie-signature check is what actually answers. Without
+        // this the request is rejected at the CSRF layer (403) and the test would
+        // no longer be exercising signature verification at all.
+        const bad = await request(harness.app)
+          .post('/api/v1/visitor/heartbeat')
+          .set('Cookie', forged)
+          .set(
+            'X-XSRF-TOKEN',
+            computeCsrfToken(forged.replace('livechat_visitor=', ''), harness.env.COOKIE_SECRET),
+          )
+          .send({});
+        expect(bad.status).toBe(401);
+        expectNoLeak(bad.body);
+      });
     });
-
-    test('visitor/session with a wrong-typed tenantKey is a 400', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: 12345 });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
-    });
-
-    test('visitor/chats with an invalid body is a 400 (before the cookie check)', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/chats')
-        .send({ customerName: '', body: '' });
-      expect(res.status).toBe(400);
-      expectNoLeak(res.body);
-    });
-
-    test('an injection string in tenantKey is treated as a literal slug — clean 400, no SQL error', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: "'; DROP TABLE tenants; --" });
-      // Parameterized lookup finds no such slug: a clean 4xx, never a 500.
-      expect(res.status).toBe(400);
-      expect(res.status).not.toBe(500);
-      expectNoLeak(res.body);
-    });
-  });
-
-  describe('malformed / oversized request bodies', () => {
-    test('malformed JSON on auth/login is a 400, not a 500', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .set('Content-Type', 'application/json')
-        .send('{"email": "a@b.co", ');
-      expect(res.status).toBe(400);
-      expect(res.body).toEqual({ success: false, message: 'Malformed request body' });
-    });
-
-    test('a body beyond the 1mb json limit is a 413, not a 500', async () => {
-      if (harness === null) return;
-      const oversized = JSON.stringify({ tenantKey: 'x'.repeat(1_200_000) });
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .set('Content-Type', 'application/json')
-        .send(oversized);
-      expect(res.status).toBe(413);
-      expect(res.body).toEqual({ success: false, message: 'Request payload too large' });
-    });
-  });
-
-  describe('visitor session cookie flags + forgery', () => {
-    test('in dev the visitor cookie is HttpOnly + SameSite=Lax (no Secure)', async () => {
-      if (harness === null) return;
-      const res = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: TENANT_SLUG });
-      expect(res.status).toBe(201);
-      const cookie = visitorSetCookie(res);
-      expect(cookie).toBeDefined();
-      expect(cookie).toMatch(/HttpOnly/i);
-      // Local dev is same-origin over plain HTTP: SameSite=None would require
-      // Secure, and a Secure cookie is dropped on localhost HTTP (#75).
-      expect(cookie).toMatch(/SameSite=Lax/i);
-      expect(cookie).not.toMatch(/Secure/i);
-    });
-
-    test('in production the visitor cookie is SameSite=None; Secure; Partitioned', async () => {
-      if (harness === null || prodApp === null) return;
-      const res = await request(prodApp)
-        .post('/api/v1/visitor/session')
-        .send({ tenantKey: TENANT_SLUG });
-      expect(res.status).toBe(201);
-      const cookie = visitorSetCookie(res);
-      expect(cookie).toBeDefined();
-      expect(cookie).toMatch(/HttpOnly/i);
-      // The widget is embedded cross-site, so the cookie is only ever sent
-      // with SameSite=None — which browsers reject without Secure (#75).
-      expect(cookie).toMatch(/SameSite=None/i);
-      expect(cookie).toMatch(/Secure/i);
-      expect(cookie).toMatch(/Partitioned/i);
-      expect(cookie).not.toMatch(/SameSite=Lax/i);
-    });
-
-    test('auth/login does not set any session cookie (JWTs are returned in the body)', async () => {
-      if (harness === null) return;
-      // Wrong credentials still exercise the response path; we only assert the
-      // absence of a Set-Cookie so a future accidental cookie is caught.
-      const res = await request(harness.app)
-        .post('/api/v1/auth/login')
-        .send({ email: 'nobody@example.com', password: 'whatever-123' });
-      expect(res.headers['set-cookie']).toBeUndefined();
-    });
-
-    test('a valid visitor cookie is accepted, a forged one is rejected 401', async () => {
-      if (harness === null) return;
-      const created = await request(harness.app)
-        .post('/api/v1/visitor/session')
-        // x-geo-country: US (trusted edge header) → opt-out jurisdiction → the consent gate permits presence
-        // and a tracked `visitor_sessions` row is created (#53). The heartbeat
-        // positive control below resolves the cookie to that row, so without a
-        // geo hint the jurisdiction resolves to UNKNOWN, no row exists, and the
-        // control 401s for a reason that has nothing to do with cookie forgery.
-        .set('x-geo-country', 'US')
-        .send({ tenantKey: TENANT_SLUG });
-      expect(created.status).toBe(201);
-      const rawCookie = visitorSetCookie(created)?.split(';')[0] ?? '';
-      const value = rawCookie.replace('livechat_visitor=', '');
-      expect(value).toContain('.');
-
-      // Positive control: the genuine cookie authenticates the heartbeat.
-      // The heartbeat is a CSRF-protected write (#77), so the token issued
-      // alongside the cookie has to be echoed — this asserts cookie validity,
-      // not CSRF behavior, which `csrf.test.ts` covers.
-      const ok = await request(harness.app)
-        .post('/api/v1/visitor/heartbeat')
-        .set('Cookie', rawCookie)
-        .set('X-XSRF-TOKEN', created.body.data.csrfToken as string)
-        .send({});
-      expect(ok.status).toBe(200);
-
-      // Forge it: keep the session id, corrupt the HMAC signature.
-      const [sessionId, sig] = value.split('.');
-      const forgedSig = (sig ?? '').replace(/./g, '0');
-      const forged = `livechat_visitor=${sessionId ?? ''}.${forgedSig}`;
-      // Give the forged cookie its own matching CSRF token so the CSRF layer
-      // passes and the cookie-signature check is what actually answers. Without
-      // this the request is rejected at the CSRF layer (403) and the test would
-      // no longer be exercising signature verification at all.
-      const bad = await request(harness.app)
-        .post('/api/v1/visitor/heartbeat')
-        .set('Cookie', forged)
-        .set(
-          'X-XSRF-TOKEN',
-          computeCsrfToken(forged.replace('livechat_visitor=', ''), harness.env.COOKIE_SECRET),
-        )
-        .send({});
-      expect(bad.status).toBe(401);
-      expectNoLeak(bad.body);
-    });
-  });
-});
+  },
+);

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -81,9 +81,85 @@ export interface LiveTestHarness extends TestHarness {
 }
 
 /**
- * Probe for a live MySQL + Redis matching {@link testEnv}. Returns `null` if
- * either is unreachable — integration tests use this to auto-skip.
- * @returns A harness if the stack is up, else `null`.
+ * True when running without the stack was explicitly requested. This is the
+ * only condition under which an unreachable MySQL/Redis is tolerated — and
+ * then the tests are reported as skipped, never passed.
+ * @returns Whether `INTEGRATION_DB_OPTIONAL=1` is set.
+ */
+function stackIsOptional(): boolean {
+  return process.env['INTEGRATION_DB_OPTIONAL'] === '1';
+}
+
+/**
+ * The operator-facing explanation for an unreachable stack.
+ * @param env - The env whose endpoints were probed.
+ * @param cause - The underlying connection error.
+ * @returns A message naming the endpoints, the fix, and the opt-out.
+ */
+function unreachableMessage(env: Env, cause: unknown): string {
+  return (
+    'Integration stack unreachable — ' +
+    `MySQL ${env.DB_HOST}:${String(env.DB_PORT)}/${env.DB_NAME}, ` +
+    `Redis ${env.REDIS_HOST}:${String(env.REDIS_PORT)}. ` +
+    'Start it with `docker compose up -d mysql redis`, or set ' +
+    'INTEGRATION_DB_OPTIONAL=1 to run without it (integration tests are then ' +
+    'reported as skipped — never as passed). ' +
+    `Cause: ${cause instanceof Error ? cause.message : String(cause)}`
+  );
+}
+
+/**
+ * Connect to MySQL + Redis exactly as {@link probeHarness} would, then
+ * disconnect. Used once at module load so the result is known at collection
+ * time, where `describe.skipIf` can consult it.
+ * @returns Whether both are reachable.
+ * @throws When unreachable and running without the stack was not requested —
+ * absent infrastructure must read as a failure, not a pass (#170).
+ */
+async function probeStack(): Promise<boolean> {
+  const env = testEnv();
+  const logger = pino({ level: 'silent' });
+  const sequelize = createSequelize(env, logger);
+  const redis = new Redis({
+    host: env.REDIS_HOST,
+    port: env.REDIS_PORT,
+    lazyConnect: true,
+    maxRetriesPerRequest: 0,
+    connectTimeout: 1000,
+  });
+  try {
+    await sequelize.authenticate();
+    await redis.connect();
+    return true;
+  } catch (error) {
+    if (!stackIsOptional()) throw new Error(unreachableMessage(env, error));
+    return false;
+  } finally {
+    await sequelize.close().catch(() => undefined);
+    await redis.quit().catch(() => undefined);
+  }
+}
+
+/**
+ * Whether the integration stack was reachable at module load. Every
+ * integration test file gates its top-level `describe` on this via
+ * `describe.skipIf(!integrationDbUp)`, so a missing stack shows up in the run
+ * summary as skipped tests. Before this existed, per-test `harness === null`
+ * early returns reported the same condition as *passed* — a green run that
+ * asserted nothing (#170). Resolved with top-level await so the value is
+ * final before collection; when the stack is down and
+ * `INTEGRATION_DB_OPTIONAL=1` was not set, module evaluation throws instead
+ * and the whole file fails loudly.
+ */
+export const integrationDbUp: boolean = await probeStack();
+
+/**
+ * Probe for a live MySQL + Redis matching {@link testEnv} and build an app
+ * harness against it.
+ * @returns A harness if the stack is up; `null` only when
+ * `INTEGRATION_DB_OPTIONAL=1` and the stack went away after module load.
+ * @throws When the stack is unreachable and running without it was not
+ * requested.
  */
 export async function probeHarness(): Promise<TestHarness | null> {
   const env = testEnv();
@@ -102,20 +178,10 @@ export async function probeHarness(): Promise<TestHarness | null> {
   } catch (error) {
     await sequelize.close().catch(() => undefined);
     await redis.quit().catch(() => undefined);
-    if (process.env['REQUIRE_DB'] === '1') {
-      // Every integration test returns early on a null harness, so absent
-      // infrastructure otherwise reads as a pass — a green run that asserted
-      // nothing. CI sets REQUIRE_DB=1 so that can never be mistaken for
-      // coverage; locally the null path still skips so `npm test` works
-      // without docker.
-      throw new Error(
-        'REQUIRE_DB=1 but the integration stack is unreachable — ' +
-          `MySQL ${env.DB_HOST}:${String(env.DB_PORT)}/${env.DB_NAME}, ` +
-          `Redis ${env.REDIS_HOST}:${String(env.REDIS_PORT)}. ` +
-          'Start it with `docker compose up -d mysql redis`. ' +
-          `Cause: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
+    // The module-load gate above already decided reachability; landing here
+    // means the stack died between collection and this file's beforeAll. Same
+    // rule applies: only an explicit opt-out may swallow it.
+    if (!stackIsOptional()) throw new Error(unreachableMessage(env, error));
     return null;
   }
 

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -206,6 +206,38 @@ export async function probeHarness(): Promise<TestHarness | null> {
 }
 
 /**
+ * Poll a namespace's adapter until `room` holds at least `size` members.
+ *
+ * Socket tests used to sleep a fixed 150ms after emitting a join-inducing
+ * event and hope the server handler had finished — a wall-clock race that
+ * loses on a loaded runner (`chat:accept` awaits a MySQL update before its
+ * `socket.join`, observed >4s on CI). Room membership is the exact state
+ * every room broadcast depends on, so waiting for it directly keys the test
+ * to structure instead of timing (#171 review follow-up).
+ * @param nsp - The namespace whose adapter to watch, e.g. `io.of('/staff')`.
+ * @param room - The room name, e.g. `chat:{id}` or `tenant:{id}`.
+ * @param size - Minimum member count to wait for.
+ * @param timeoutMs - Give-up threshold.
+ */
+export async function waitForRoomSize(
+  nsp: { adapter: { rooms: Map<string, Set<string>> } },
+  room: string,
+  size: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if ((nsp.adapter.rooms.get(room)?.size ?? 0) >= size) return;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `room ${room} did not reach ${String(size)} member(s) within ${String(timeoutMs)}ms`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/**
  * Probe + bind a real HTTP server on an ephemeral port, with Socket.IO
  * attached. Used by socket integration tests.
  * @returns A live harness or `null` if the stack isn't up.

--- a/api/tests/integration/setup.ts
+++ b/api/tests/integration/setup.ts
@@ -225,13 +225,56 @@ export async function waitForRoomSize(
   size: number,
   timeoutMs = 5000,
 ): Promise<void> {
+  await waitUntil(
+    () => (nsp.adapter.rooms.get(room)?.size ?? 0) >= size,
+    `room ${room} did not reach ${String(size)} member(s)`,
+    timeoutMs,
+  );
+}
+
+/**
+ * Poll a namespace's adapter until `room` holds at most `size` members. The
+ * shrink counterpart of {@link waitForRoomSize}: a client `disconnect()`
+ * resolves before the server has processed the departure, so a test that
+ * asserts on post-disconnect state waits for the membership to actually drop.
+ * @param nsp - The namespace whose adapter to watch.
+ * @param room - The room name.
+ * @param size - Maximum member count to wait for.
+ * @param timeoutMs - Give-up threshold.
+ */
+export async function waitForRoomSizeAtMost(
+  nsp: { adapter: { rooms: Map<string, Set<string>> } },
+  room: string,
+  size: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  await waitUntil(
+    () => (nsp.adapter.rooms.get(room)?.size ?? 0) <= size,
+    `room ${room} did not drop to ${String(size)} member(s)`,
+    timeoutMs,
+  );
+}
+
+/**
+ * Poll an arbitrary condition until it holds. The general form behind the
+ * room waits, for states the adapter cannot see — e.g. a presence record the
+ * next HTTP request will consult. Prefer the specific helpers where they fit;
+ * a condition passed here should still be *structural* (the state an
+ * assertion depends on), never a disguised sleep.
+ * @param condition - Returns true (or a promise of true) once the state holds.
+ * @param label - Failure description, phrased as what never happened.
+ * @param timeoutMs - Give-up threshold.
+ */
+export async function waitUntil(
+  condition: () => Promise<boolean> | boolean,
+  label: string,
+  timeoutMs = 5000,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    if ((nsp.adapter.rooms.get(room)?.size ?? 0) >= size) return;
+    if (await condition()) return;
     if (Date.now() > deadline) {
-      throw new Error(
-        `room ${room} did not reach ${String(size)} member(s) within ${String(timeoutMs)}ms`,
-      );
+      throw new Error(`${label} within ${String(timeoutMs)}ms`);
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }

--- a/api/tests/integration/socket-adapter.test.ts
+++ b/api/tests/integration/socket-adapter.test.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { createSocketRedisAdapter } from '../../src/io/adapter.js';
 
-import { testEnv } from './setup.js';
+import { integrationDbUp, testEnv } from './setup.js';
 
 const NS = '/adapter-test';
 
@@ -114,7 +114,7 @@ async function connectAndJoin(url: string, room: string): Promise<Socket> {
   return socket;
 }
 
-describe('socket.io redis adapter (integration)', () => {
+describe.skipIf(!integrationDbUp)('socket.io redis adapter (integration)', () => {
   let a: Instance | null = null;
   let b: Instance | null = null;
 

--- a/api/tests/integration/socket-authz-abuse.test.ts
+++ b/api/tests/integration/socket-authz-abuse.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 /**
  * Resolve with the first `connect_error` for a handshake that must be refused,
@@ -30,7 +30,7 @@ function expectRefused(socket: Socket, timeoutMs = 4000): Promise<Error> {
   });
 }
 
-describe('socket.io authorization abuse (integration)', () => {
+describe.skipIf(!integrationDbUp)('socket.io authorization abuse (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/staff-availability.test.ts
+++ b/api/tests/integration/staff-availability.test.ts
@@ -4,7 +4,14 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
+import {
+  integrationDbUp,
+  probeLiveHarness,
+  waitForRoomSize,
+  waitForRoomSizeAtMost,
+  waitUntil,
+  type LiveTestHarness,
+} from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -155,8 +162,6 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
   });
 }
 
-const settle = (ms = 150): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
 describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
@@ -190,13 +195,18 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('availability is per-user, not per-socket: a second tab closing does not drop it', async () => {
     if (harness === null) return;
-    const { baseUrl, services } = harness;
+    const { baseUrl, io, services } = harness;
     const { tenantId } = await seedTenantAndStaff('avail-multitab', 'multitab@avail.example');
     const token = await loginAs(baseUrl, 'multitab@avail.example');
 
+    // Consume each tab's connect-time availability:self restore ('away') —
+    // it is the last thing the connection handler emits, so receiving it
+    // proves setup finished AND keeps the toggle listener below from
+    // catching a restore instead of the toggle.
     const tabA = await connectStaff(baseUrl, token);
+    await waitFor(tabA, 'availability:self');
     const tabB = await connectStaff(baseUrl, token);
-    await settle();
+    await waitFor(tabB, 'availability:self');
 
     // Setting available in one tab is echoed to the other (same user room).
     const bSeesSelf = waitFor<{ status: string }>(tabB, 'availability:self');
@@ -206,7 +216,7 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
     // Closing one tab must not flip the agent away while the other is open.
     tabB.disconnect();
-    await settle();
+    await waitForRoomSizeAtMost(io.of('/staff'), `tenant:${tenantId}`, 1);
     expect(await services.presence.anyStaffAvailable(tenantId)).toBe(true);
 
     tabA.disconnect();
@@ -214,7 +224,7 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('explicit away status persists across a reconnect (survives reload)', async () => {
     if (harness === null) return;
-    const { baseUrl, services } = harness;
+    const { baseUrl, io, services } = harness;
     const { tenantId } = await seedTenantAndStaff('avail-persist', 'persist@avail.example');
     const token = await loginAs(baseUrl, 'persist@avail.example');
 
@@ -223,7 +233,7 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
     await waitFor(first, 'availability:self');
     expect(await services.presence.anyStaffAvailable(tenantId)).toBe(true);
     first.disconnect();
-    await settle();
+    await waitForRoomSizeAtMost(io.of('/staff'), `tenant:${tenantId}`, 0);
 
     // Reconnect restores the persisted 'available' status, not a default.
     const second = await connectStaff(baseUrl, token);
@@ -259,8 +269,8 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('availability change bridges to the visitor room via support:availability_changed', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('avail-bridge', 'bridge@avail.example');
+    const { baseUrl, io } = harness;
+    const { tenantId } = await seedTenantAndStaff('avail-bridge', 'bridge@avail.example');
     const token = await loginAs(baseUrl, 'bridge@avail.example');
 
     // A visitor session joins the tenant's visitor room on connect.
@@ -280,9 +290,15 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
       forceNew: true,
     });
     await waitFor(visitorSocket, 'connect');
-    await settle();
+    // support:availability_changed targets the visitor-namespace tenant room,
+    // so membership there is the state to wait for.
+    await waitForRoomSize(io.of('/visitor'), `tenant:${tenantId}`, 1);
 
     const staffSocket = await connectStaff(baseUrl, token);
+    // Wait out the connect-time restore: it broadcasts
+    // support:availability_changed unconditionally and would race the toggle
+    // broadcast below. availability:self is emitted after that completes.
+    await waitFor(staffSocket, 'availability:self');
     const visitorSeesAvailable = waitFor<{ available: boolean }>(
       visitorSocket,
       'support:availability_changed',
@@ -318,19 +334,29 @@ describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
 
   test('an untenanted global agent toggling availability live-pushes to a served tenant visitor', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io, services } = harness;
     // A tenant with a connected visitor but NO tenant-scoped agent of its own —
     // only the untenanted global agent (issue #19) can serve it.
-    await seedTenantAndStaff('avail-global', 'ignored@avail.example');
+    const { tenantId } = await seedTenantAndStaff('avail-global', 'ignored@avail.example');
     await seedGlobalStaff('global@avail.example');
     const token = await loginAs(baseUrl, 'global@avail.example');
 
     const visitorSocket = await connectVisitor(baseUrl, 'avail-global');
-    await settle();
+    await waitForRoomSize(io.of('/visitor'), `tenant:${tenantId}`, 1);
+    // The visitor's presence record is written by a detached task on connect,
+    // and the global broadcast's tenant fan-out reads exactly that record —
+    // room membership alone does not prove it landed.
+    await waitUntil(
+      async () => (await services.presence.tenantsWithVisitors()).includes(tenantId),
+      'visitor presence never registered',
+    );
 
     // The global agent connects; nothing should flip yet (they default away).
+    // Its connect-time restore runs broadcastGlobalStaffAvailability, whose
+    // after-snapshot would see the toggle below and emit a duplicate — the
+    // availability:self that follows it is the completion signal to wait for.
     const staffSocket = await connectStaff(baseUrl, token);
-    await settle();
+    await waitFor(staffSocket, 'availability:self');
 
     // Going available must live-push the §5.1.2 transition to the already-
     // connected visitor even though the agent belongs to no tenant.

--- a/api/tests/integration/staff-availability.test.ts
+++ b/api/tests/integration/staff-availability.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -157,7 +157,7 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
 
 const settle = (ms = 150): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe('staff availability (integration)', () => {
+describe.skipIf(!integrationDbUp)('staff availability (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/transcript.test.ts
+++ b/api/tests/integration/transcript.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Express } from 'express';
 
@@ -43,7 +43,7 @@ interface VisitorCreds {
   csrfToken: string;
 }
 
-describe('email transcript (#80)', () => {
+describe.skipIf(!integrationDbUp)('email transcript (#80)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-consent-gate.test.ts
+++ b/api/tests/integration/visitor-consent-gate.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { ConsentRecord, Tenant, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -34,7 +34,7 @@ async function sessionCount(tenantId: string): Promise<number> {
   return VisitorSession.count({ where: { tenantId } });
 }
 
-describe('visitor consent gate (integration)', () => {
+describe.skipIf(!integrationDbUp)('visitor consent gate (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) console.warn('[integration] MySQL or Redis not reachable — skipping');

--- a/api/tests/integration/visitor-gpc.test.ts
+++ b/api/tests/integration/visitor-gpc.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { AuditLog, ConsentRecord, Tenant, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
@@ -48,7 +48,7 @@ async function expectHonoredGpc(tenantId: string): Promise<void> {
   expect(applied).not.toBeNull();
 }
 
-describe('GPC universal opt-out (integration)', () => {
+describe.skipIf(!integrationDbUp)('GPC universal opt-out (integration)', () => {
   beforeAll(async () => {
     harness = await probeHarness();
     if (harness === null) console.warn('[integration] MySQL or Redis not reachable — skipping');

--- a/api/tests/integration/visitor-session-expiry.test.ts
+++ b/api/tests/integration/visitor-session-expiry.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, VisitorSession } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -58,7 +58,7 @@ async function socketRefused(baseUrl: string, cookie: string): Promise<boolean> 
   });
 }
 
-describe('visitor session expiry + revocation (#79)', () => {
+describe.skipIf(!integrationDbUp)('visitor session expiry + revocation (#79)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-session-fallback.test.ts
+++ b/api/tests/integration/visitor-session-fallback.test.ts
@@ -3,13 +3,13 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 type Harness = Awaited<ReturnType<typeof probeHarness>>;
 
 const TENANT_SLUG = 'fallback-t';
 
-describe('visitor session header fallback (#75)', () => {
+describe.skipIf(!integrationDbUp)('visitor session header fallback (#75)', () => {
   let harness: Harness;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-session-revoke.test.ts
+++ b/api/tests/integration/visitor-session-revoke.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Chat, Tenant, User, VisitorSession } from '../../src/models/index.js';
 
-import { probeHarness } from './setup.js';
+import { integrationDbUp, probeHarness } from './setup.js';
 
 import type { Express } from 'express';
 
@@ -107,7 +107,7 @@ async function bootVisitor(
   return { cookie, id: created!.visitorSessionId };
 }
 
-describe('staff revocation of a visitor session (#123)', () => {
+describe.skipIf(!integrationDbUp)('staff revocation of a visitor session (#123)', () => {
   let harness: Harness;
   let app: Express;
 

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { probeLiveHarness, type LiveTestHarness } from './setup.js';
+import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -108,7 +108,7 @@ function waitFor<T>(socket: Socket, event: string, timeoutMs = 3000): Promise<T>
   });
 }
 
-describe('visitor namespace + visitor routes (integration)', () => {
+describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integration)', () => {
   let harness: LiveTestHarness | null = null;
 
   beforeAll(async () => {

--- a/api/tests/integration/visitor-socket.test.ts
+++ b/api/tests/integration/visitor-socket.test.ts
@@ -4,7 +4,12 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Tenant, User } from '../../src/models/index.js';
 
-import { integrationDbUp, probeLiveHarness, type LiveTestHarness } from './setup.js';
+import {
+  integrationDbUp,
+  probeLiveHarness,
+  waitForRoomSize,
+  type LiveTestHarness,
+} from './setup.js';
 
 const STAFF_PASSWORD = 'Staff!Password1';
 
@@ -166,7 +171,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('chat:typing fans out to the chat room and the staff namespace', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io } = harness;
     await seedTenantAndStaff('typing', 'staff@typing.example');
     const accessToken = await loginAs(baseUrl, 'staff@typing.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, csrfToken } = await initVisitor(baseUrl, 'typing');
@@ -197,7 +202,11 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
     // chat:message) is not also mirrored to the tenant room, so without this
     // the staff socket never sees it.
     staffSocket.emit('chat:accept', { chatId });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // The accept handler awaits a MySQL assignment before its socket.join, so
+    // wait on the membership itself — the state the fan-out depends on —
+    // rather than on wall-clock time.
+    await waitForRoomSize(io.of('/staff'), `chat:${chatId}`, 1);
+    await waitForRoomSize(io.of('/visitor'), `chat:${chatId}`, 1);
 
     const otherVisitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
       path: '/api/socket.io',
@@ -207,7 +216,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
     });
     await waitFor(otherVisitorSocket, 'connect');
     otherVisitorSocket.emit('chat:join', { chatId });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitForRoomSize(io.of('/visitor'), `chat:${chatId}`, 2);
 
     const staffSeesTyping = waitFor<{ chatId: string; actor: string; isTyping: boolean }>(
       staffSocket,
@@ -231,7 +240,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('visitor chat:end ends the chat as customer and notifies staff', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
+    const { baseUrl, io } = harness;
     await seedTenantAndStaff('vend', 'staff@vend.example');
     const accessToken = await loginAs(baseUrl, 'staff@vend.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, csrfToken } = await initVisitor(baseUrl, 'vend');
@@ -259,7 +268,10 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
     await Promise.all([waitFor(staffSocket, 'connect'), waitFor(visitorSocket, 'connect')]);
     visitorSocket.emit('chat:join', { chatId });
     staffSocket.emit('chat:accept', { chatId });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // chat:ended is emitted to the staff-namespace `chat:{id}` room, so the
+    // membership itself is the precondition to wait for.
+    await waitForRoomSize(io.of('/staff'), `chat:${chatId}`, 1);
+    await waitForRoomSize(io.of('/visitor'), `chat:${chatId}`, 1);
 
     const staffSeesEnd = waitFor<{ chatId: string; endedBy: string }>(staffSocket, 'chat:ended');
     visitorSocket.emit('chat:end', { chatId });
@@ -273,8 +285,8 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('visitor:page_changed fans out to the tenant staff room', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('pagechange', 'staff@pagechange.example');
+    const { baseUrl, io } = harness;
+    const { tenantId } = await seedTenantAndStaff('pagechange', 'staff@pagechange.example');
     const accessToken = await loginAs(baseUrl, 'staff@pagechange.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'pagechange');
 
@@ -285,7 +297,9 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
       forceNew: true,
     });
     await waitFor(staffSocket, 'connect');
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // The fan-out targets the staff-namespace tenant room, which the staff
+    // connection handler joins asynchronously after the handshake completes.
+    await waitForRoomSize(io.of('/staff'), `tenant:${tenantId}`, 1);
 
     const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
       path: '/api/socket.io',
@@ -310,8 +324,8 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
 
   test('visitor disconnect removes presence and notifies staff visitor:left', async () => {
     if (harness === null) return;
-    const { baseUrl } = harness;
-    await seedTenantAndStaff('leaving', 'staff@leaving.example');
+    const { baseUrl, io } = harness;
+    const { tenantId } = await seedTenantAndStaff('leaving', 'staff@leaving.example');
     const accessToken = await loginAs(baseUrl, 'staff@leaving.example', STAFF_PASSWORD);
     const { cookie: visitorCookie, sessionId } = await initVisitor(baseUrl, 'leaving');
 
@@ -322,8 +336,14 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
       forceNew: true,
     });
     await waitFor(staffSocket, 'connect');
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Staff must be in the tenant room before the visitor connects, or the
+    // visitor:joined / visitor:left broadcasts have no one to reach.
+    await waitForRoomSize(io.of('/staff'), `tenant:${tenantId}`, 1);
 
+    // Register the visitor:joined listener before the visitor connects — the
+    // broadcast fires during the visitor's connection handler, and receiving
+    // it proves the handler ran and tenant-room delivery works end to end.
+    const staffSeesJoined = waitFor(staffSocket, 'visitor:joined');
     const visitorSocket: Socket = ioClient(`${baseUrl}/visitor`, {
       path: '/api/socket.io',
       auth: { cookie: visitorCookie },
@@ -331,7 +351,7 @@ describe.skipIf(!integrationDbUp)('visitor namespace + visitor routes (integrati
       forceNew: true,
     });
     await waitFor(visitorSocket, 'connect');
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await staffSeesJoined;
 
     const staffSeesLeft = waitFor<{ tenantId: string; visitorSessionId: string }>(
       staffSocket,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livechat-root",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livechat-root",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "UNLICENSED",
       "workspaces": [
         "shared",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livechat-root",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "license": "UNLICENSED",
   "type": "module",


### PR DESCRIPTION
Promotes develop to main for **v0.4.1** — a patch release hardening the API test infrastructure. No product behavior changes, no breaking changes, no schema or API changes.

## What's shipping

- #171 — **Integration tests fail loudly when MySQL/Redis are down** (closes #170). Previously the whole suite reported ✓ passed in 0–1 ms with zero integration coverage. Now the stack being unreachable fails the file with operator guidance; `INTEGRATION_DB_OPTIONAL=1` is the only way to run without it and reports tests as *skipped*. `REQUIRE_DB` removed; `availability-gate.test.ts` pins both arms.
- #172 — **visitor-socket waits keyed to room membership** instead of fixed 150 ms sleeps — fixes the `chat:typing` fan-out flake observed on CI.
- #173 — **remaining fixed sleeps retired** in chat-flow and staff-availability via `waitUntil`/`waitForRoomSize`/`waitForRoomSizeAtMost`; also fixes the connect-time availability-restore broadcast race the sleeps had masked.
- #174 — version bump + CHANGELOG entry.

Compare: https://github.com/AFixt/livechat/compare/v0.4.0...develop